### PR TITLE
fix: handle ComputedNameType aliases in list_entities and search_entities

### DIFF
--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -48,7 +48,7 @@ async def get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str,
 
     registry = er.async_get(hass)
     entry = registry.async_get(entity_id)
-    aliases = sorted(entry.aliases) if entry and entry.aliases else []
+    aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
 
     attributes = dict(state.attributes)
     if fields is not None:
@@ -159,7 +159,7 @@ async def list_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         if domain_filter and not state.entity_id.startswith(f"{domain_filter}."):
             continue
         entry = registry.async_get(state.entity_id)
-        aliases = sorted(entry.aliases) if entry and entry.aliases else []
+        aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
 
         if fields is not None:
             full = {
@@ -350,7 +350,7 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
                 continue
 
         entry = entity_registry.async_get(state.entity_id)
-        aliases = sorted(entry.aliases) if entry and entry.aliases else []
+        aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
 
         # Resolve area: entity's own area, falling back to its device's area
         entity_area = entry.area_id if entry else None
@@ -366,7 +366,7 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
             searchable = [
                 state.entity_id.lower(),
                 friendly_name,
-                *(a.lower() for a in aliases),
+                *(str(a).lower() for a in aliases),
             ]
             if not any(query in s for s in searchable):
                 continue
@@ -450,7 +450,7 @@ async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
             continue
 
         entry = registry.async_get(entity_id)
-        aliases = sorted(entry.aliases) if entry and entry.aliases else []
+        aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
 
         results.append(
             {


### PR DESCRIPTION
## Problem

Starting with recent versions of Home Assistant, entity aliases are returned
as `ComputedNameType` objects instead of plain strings. This causes two tools
to crash with unhandled exceptions:

- `list_entities` — `TypeError: '<' not supported between instances of 'str' and 'ComputedNameType'`
- `search_entities` — `AttributeError: 'ComputedNameType' object has no attribute 'lower'`

Both tools become completely unusable, returning a 500 error on every call.

## Fix

Wrap alias values with `str()` before any string operations:

- `sorted(entry.aliases)` → `sorted(entry.aliases, key=str)`
- `a.lower()` → `str(a).lower()`

`ComputedNameType` implements `__str__`, so this is safe and
backwards-compatible with older HA versions where aliases are plain strings.

## Tested on

- Home Assistant 2025.x with `ComputedNameType` aliases present