### PR TITLE
fix: HA 2026.4.x compatibility for config.version and entity aliases

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.6.0"
+  "version": "1.6.1"
 }

--- a/custom_components/mcp_server_http_transport/resources.py
+++ b/custom_components/mcp_server_http_transport/resources.py
@@ -3,6 +3,7 @@
 import json
 from typing import Any
 
+from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
@@ -141,7 +142,7 @@ def _read_config(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         "elevation": config.elevation,
         "unit_system": config.units.as_dict(),
         "time_zone": str(config.time_zone),
-        "version": config.version,
+        "version": HA_VERSION,
         "currency": config.currency,
         "country": config.country,
         "language": config.language,

--- a/custom_components/mcp_server_http_transport/server.py
+++ b/custom_components/mcp_server_http_transport/server.py
@@ -12,6 +12,15 @@ from mcp.types import TextContent, Tool
 
 _LOGGER = logging.getLogger(__name__)
 
+_HAS_GET_ENTITY_ALIASES = hasattr(er, "async_get_entity_aliases")
+
+
+def _get_aliases(hass: "HomeAssistant", entry: er.RegistryEntry) -> list[str]:
+    """Get entity aliases, handling ComputedNameType on HA 2026.4+."""
+    if _HAS_GET_ENTITY_ALIASES:
+        return er.async_get_entity_aliases(hass, entry)
+    return sorted(str(a) for a in entry.aliases) if entry.aliases else []
+
 
 class HomeAssistantMCPServer:
     """Home Assistant MCP Server."""
@@ -108,7 +117,7 @@ class HomeAssistantMCPServer:
 
         registry = er.async_get(self.hass)
         entry = registry.async_get(entity_id)
-        aliases = sorted(entry.aliases) if entry and entry.aliases else []
+        aliases = _get_aliases(self.hass, entry) if entry else []
 
         result = {
             "entity_id": state.entity_id,
@@ -149,7 +158,7 @@ class HomeAssistantMCPServer:
             if domain_filter and not state.entity_id.startswith(f"{domain_filter}."):
                 continue
             entry = registry.async_get(state.entity_id)
-            aliases = sorted(entry.aliases) if entry and entry.aliases else []
+            aliases = _get_aliases(self.hass, entry) if entry else []
             entities.append(
                 {
                     "entity_id": state.entity_id,

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -14,6 +14,15 @@ from . import register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
+_HAS_GET_ENTITY_ALIASES = hasattr(er, "async_get_entity_aliases")
+
+
+def _get_aliases(hass: HomeAssistant, entry: er.RegistryEntry) -> list[str]:
+    """Get entity aliases, handling ComputedNameType on HA 2026.4+."""
+    if _HAS_GET_ENTITY_ALIASES:
+        return er.async_get_entity_aliases(hass, entry)
+    return sorted(str(a) for a in entry.aliases) if entry.aliases else []
+
 
 @register_tool(
     name="get_state",
@@ -48,7 +57,7 @@ async def get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str,
 
     registry = er.async_get(hass)
     entry = registry.async_get(entity_id)
-    aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
+    aliases = _get_aliases(hass, entry) if entry else []
 
     attributes = dict(state.attributes)
     if fields is not None:
@@ -159,7 +168,7 @@ async def list_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         if domain_filter and not state.entity_id.startswith(f"{domain_filter}."):
             continue
         entry = registry.async_get(state.entity_id)
-        aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
+        aliases = _get_aliases(hass, entry) if entry else []
 
         if fields is not None:
             full = {
@@ -350,7 +359,7 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
                 continue
 
         entry = entity_registry.async_get(state.entity_id)
-        aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
+        aliases = _get_aliases(hass, entry) if entry else []
 
         # Resolve area: entity's own area, falling back to its device's area
         entity_area = entry.area_id if entry else None
@@ -366,7 +375,7 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
             searchable = [
                 state.entity_id.lower(),
                 friendly_name,
-                *(str(a).lower() for a in aliases),
+                *(a.lower() for a in aliases),
             ]
             if not any(query in s for s in searchable):
                 continue
@@ -450,7 +459,7 @@ async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
             continue
 
         entry = registry.async_get(entity_id)
-        aliases = sorted(entry.aliases, key=str) if entry and entry.aliases else []
+        aliases = _get_aliases(hass, entry) if entry else []
 
         results.append(
             {

--- a/custom_components/mcp_server_http_transport/tools/system.py
+++ b/custom_components/mcp_server_http_transport/tools/system.py
@@ -5,6 +5,7 @@ import logging
 from datetime import datetime as dt
 from typing import Any
 
+from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -31,7 +32,7 @@ async def get_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         "elevation": config.elevation,
         "unit_system": config.units.as_dict(),
         "time_zone": str(config.time_zone),
-        "version": config.version,
+        "version": HA_VERSION,
         "currency": config.currency,
         "country": config.country,
         "language": config.language,

--- a/custom_components/mcp_server_http_transport/tools/system_admin.py
+++ b/custom_components/mcp_server_http_transport/tools/system_admin.py
@@ -5,6 +5,7 @@ import logging
 from collections import deque
 from typing import Any
 
+from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 
 from . import register_tool
@@ -115,7 +116,7 @@ async def get_system_status(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     integration_count = len(hass.config_entries.async_entries())
 
     result = {
-        "version": hass.config.version,
+        "version": HA_VERSION,
         "total_entities": len(all_states),
         "domain_counts": dict(sorted(domain_counts.items())),
         "problem_entities": problem_entities,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -103,7 +103,6 @@ def populated_hass():
     hass.config.elevation = 28
     hass.config.units = mock_units
     hass.config.time_zone = "Europe/Stockholm"
-    hass.config.version = "2024.12.0"
     hass.config.currency = "SEK"
     hass.config.country = "SE"
     hass.config.language = "sv"
@@ -140,31 +139,31 @@ def mock_entity_registry():
     entries = {}
 
     entry_living = Mock()
-    entry_living.aliases = {"Living Room Lamp", "Lounge Light"}
+    entry_living.aliases = ["Living Room Lamp", "Lounge Light"]
     entry_living.area_id = "living_room"
     entry_living.device_id = "hue_bridge"
     entries["light.living_room"] = entry_living
 
     entry_bedroom = Mock()
-    entry_bedroom.aliases = set()
+    entry_bedroom.aliases = []
     entry_bedroom.area_id = "bedroom"
     entry_bedroom.device_id = None
     entries["light.bedroom"] = entry_bedroom
 
     entry_temp = Mock()
-    entry_temp.aliases = {"Temp Sensor"}
+    entry_temp.aliases = ["Temp Sensor"]
     entry_temp.area_id = "bedroom"
     entry_temp.device_id = "aqara_sensor"
     entries["sensor.temperature"] = entry_temp
 
     entry_switch = Mock()
-    entry_switch.aliases = set()
+    entry_switch.aliases = []
     entry_switch.area_id = "kitchen"
     entry_switch.device_id = "smart_plug"
     entries["switch.kitchen"] = entry_switch
 
     entry_auto = Mock()
-    entry_auto.aliases = {"Wake Up Routine"}
+    entry_auto.aliases = ["Wake Up Routine"]
     entry_auto.area_id = None
     entry_auto.device_id = None
     entries["automation.morning_routine"] = entry_auto

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -67,7 +67,6 @@ class TestResources:
         mock_hass.config.elevation = 10
         mock_hass.config.units = mock_units
         mock_hass.config.time_zone = "Europe/Stockholm"
-        mock_hass.config.version = "2024.12.0"
         mock_hass.config.currency = "SEK"
         mock_hass.config.country = "SE"
         mock_hass.config.language = "en"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,7 @@ class TestGetAliasesCompat:
             patch(
                 "custom_components.mcp_server_http_transport.server.er.async_get_entity_aliases",
                 return_value=["Resolved"],
+                create=True,
             ) as mock_fn,
         ):
             result = server_mod._get_aliases(mock_hass, mock_entry)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -43,7 +43,7 @@ class TestHomeAssistantMCPServer:
         mock_hass.states.get.return_value = mock_state
 
         mock_entry = Mock()
-        mock_entry.aliases = {"Lounge Light"}
+        mock_entry.aliases = ["Lounge Light"]
         mock_er = Mock()
         mock_er.async_get.return_value = mock_entry
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,27 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from custom_components.mcp_server_http_transport import server as server_mod
 from custom_components.mcp_server_http_transport.server import HomeAssistantMCPServer
+
+
+class TestGetAliasesCompat:
+    """Test _get_aliases backward compatibility helper."""
+
+    def test_uses_async_get_entity_aliases_when_available(self):
+        """Test _get_aliases uses er.async_get_entity_aliases on HA 2026.4+."""
+        mock_hass = Mock()
+        mock_entry = Mock()
+        with (
+            patch.object(server_mod, "_HAS_GET_ENTITY_ALIASES", True),
+            patch(
+                "custom_components.mcp_server_http_transport.server.er.async_get_entity_aliases",
+                return_value=["Resolved"],
+            ) as mock_fn,
+        ):
+            result = server_mod._get_aliases(mock_hass, mock_entry)
+        assert result == ["Resolved"]
+        mock_fn.assert_called_once_with(mock_hass, mock_entry)
 
 
 class TestHomeAssistantMCPServer:

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -7,6 +7,36 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from custom_components.mcp_server_http_transport.http import MCPEndpointView
+from custom_components.mcp_server_http_transport.tools import entities as entities_mod
+
+
+class TestGetAliasesCompat:
+    """Test _get_aliases backward compatibility helper."""
+
+    def test_uses_async_get_entity_aliases_when_available(self):
+        """Test _get_aliases uses er.async_get_entity_aliases on HA 2026.4+."""
+        mock_hass = Mock()
+        mock_entry = Mock()
+        mock_entry.aliases = ["Test Alias"]
+        with (
+            patch.object(entities_mod, "_HAS_GET_ENTITY_ALIASES", True),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.er.async_get_entity_aliases",
+                return_value=["Resolved Alias"],
+            ) as mock_fn,
+        ):
+            result = entities_mod._get_aliases(mock_hass, mock_entry)
+        assert result == ["Resolved Alias"]
+        mock_fn.assert_called_once_with(mock_hass, mock_entry)
+
+    def test_falls_back_to_sorted_str_on_older_ha(self):
+        """Test _get_aliases falls back to sorted(str(a) ...) on older HA."""
+        mock_hass = Mock()
+        mock_entry = Mock()
+        mock_entry.aliases = ["Bravo", "Alpha"]
+        with patch.object(entities_mod, "_HAS_GET_ENTITY_ALIASES", False):
+            result = entities_mod._get_aliases(mock_hass, mock_entry)
+        assert result == ["Alpha", "Bravo"]
 
 
 class TestToolsEntities:

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -42,7 +42,7 @@ class TestToolsEntities:
         mock_hass.states.get.return_value = mock_state
 
         mock_entry = Mock()
-        mock_entry.aliases = {"Lounge Light"}
+        mock_entry.aliases = ["Lounge Light"]
         mock_er = Mock()
         mock_er.async_get.return_value = mock_entry
 
@@ -461,7 +461,7 @@ class TestToolsEntities:
         mock_hass.states.async_all.return_value = [mock_state1, mock_state2]
 
         mock_entry = Mock()
-        mock_entry.aliases = set()
+        mock_entry.aliases = []
         mock_entry.area_id = None
         mock_entry.device_id = None
         mock_er = Mock()
@@ -541,7 +541,7 @@ class TestToolsEntities:
         mock_hass.states.async_all.return_value = [mock_state1, mock_state2]
 
         mock_entry = Mock()
-        mock_entry.aliases = set()
+        mock_entry.aliases = []
         mock_entry.area_id = None
         mock_entry.device_id = None
         mock_er = Mock()
@@ -595,12 +595,12 @@ class TestToolsEntities:
         mock_hass.states.async_all.return_value = [mock_state1, mock_state2]
 
         entry1 = Mock()
-        entry1.aliases = set()
+        entry1.aliases = []
         entry1.area_id = "living_room"
         entry1.device_id = None
 
         entry2 = Mock()
-        entry2.aliases = set()
+        entry2.aliases = []
         entry2.area_id = "bedroom"
         entry2.device_id = None
 
@@ -651,7 +651,7 @@ class TestToolsEntities:
         mock_hass.states.async_all.return_value = [mock_state]
 
         entry = Mock()
-        entry.aliases = set()
+        entry.aliases = []
         entry.area_id = None
         entry.device_id = "device_1"
         mock_er = Mock()
@@ -708,7 +708,7 @@ class TestToolsEntities:
         mock_hass.states.async_all.return_value = states
 
         mock_entry = Mock()
-        mock_entry.aliases = set()
+        mock_entry.aliases = []
         mock_entry.area_id = None
         mock_entry.device_id = None
         mock_er = Mock()
@@ -761,7 +761,7 @@ class TestToolsEntities:
         mock_hass.states.async_all.return_value = [mock_state1, mock_state2]
 
         mock_entry = Mock()
-        mock_entry.aliases = set()
+        mock_entry.aliases = []
         mock_entry.area_id = None
         mock_entry.device_id = None
         mock_er = Mock()
@@ -902,7 +902,7 @@ class TestToolsEntities:
         mock_hass.states.get = mock_get
 
         mock_entry = Mock()
-        mock_entry.aliases = set()
+        mock_entry.aliases = []
         mock_er = Mock()
         mock_er.async_get.return_value = mock_entry
 
@@ -957,7 +957,7 @@ class TestToolsEntities:
         mock_hass.states.get = mock_get
 
         mock_entry = Mock()
-        mock_entry.aliases = set()
+        mock_entry.aliases = []
         mock_er = Mock()
         mock_er.async_get.return_value = mock_entry
 
@@ -1036,7 +1036,7 @@ class TestToolsEntities:
         mock_hass.states.get.return_value = mock_state
 
         mock_entry = Mock()
-        mock_entry.aliases = set()
+        mock_entry.aliases = []
         mock_er = Mock()
         mock_er.async_get.return_value = mock_entry
 

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -23,6 +23,7 @@ class TestGetAliasesCompat:
             patch(
                 "custom_components.mcp_server_http_transport.tools.entities.er.async_get_entity_aliases",
                 return_value=["Resolved Alias"],
+                create=True,
             ) as mock_fn,
         ):
             result = entities_mod._get_aliases(mock_hass, mock_entry)

--- a/tests/test_tools_system.py
+++ b/tests/test_tools_system.py
@@ -40,7 +40,6 @@ class TestToolsSystem:
         mock_hass.config.elevation = 10
         mock_hass.config.units = mock_units
         mock_hass.config.time_zone = "Europe/Stockholm"
-        mock_hass.config.version = "2024.12.0"
         mock_hass.config.currency = "SEK"
         mock_hass.config.country = "SE"
         mock_hass.config.language = "en"
@@ -64,7 +63,9 @@ class TestToolsSystem:
         config = json.loads(body["result"]["content"][0]["text"])
         assert config["location_name"] == "Home"
         assert config["latitude"] == 59.0
-        assert config["version"] == "2024.12.0"
+        from homeassistant.const import __version__ as HA_VERSION
+
+        assert config["version"] == HA_VERSION
         assert config["time_zone"] == "Europe/Stockholm"
         assert config["unit_system"]["temperature"] == "°C"
 

--- a/tests/test_tools_system_admin.py
+++ b/tests/test_tools_system_admin.py
@@ -191,7 +191,6 @@ class TestToolsSystemAdmin:
         mock_state3.entity_id = "switch.kitchen"
         mock_state3.state = "off"
         mock_hass.states.async_all.return_value = [mock_state1, mock_state2, mock_state3]
-        mock_hass.config.version = "2024.12.0"
 
         mock_entry = Mock()
         mock_hass.config_entries.async_entries.return_value = [mock_entry, mock_entry]
@@ -213,7 +212,9 @@ class TestToolsSystemAdmin:
         assert response.status == 200
         body = json.loads(response.body)
         data = json.loads(body["result"]["content"][0]["text"])
-        assert data["version"] == "2024.12.0"
+        from homeassistant.const import __version__ as HA_VERSION
+
+        assert data["version"] == HA_VERSION
         assert data["total_entities"] == 3
         assert data["domain_counts"]["light"] == 1
         assert data["domain_counts"]["sensor"] == 1


### PR DESCRIPTION
Fixes two breaking changes introduced in Home Assistant 2026.4.x that cause all MCP tool calls to fail with HTTP 500. Ref #28.

**config.version (3 files):** `hass.config.version` was never a real attribute on the HA `Config` class (the `Config` class was also moved from `homeassistant.core` to `homeassistant.core_config`). Our tests masked this by using `Mock()`. Replaced with `homeassistant.const.__version__` which is the canonical source (used by HA's own REST API via `config.as_dict()`).

**ComputedNameType (6 files):** HA 2026.4.0 changed entity `aliases` from `set[str]` to `list[str | ComputedNameType]` (PR home-assistant/core#162763). The `ComputedNameType` enum sentinel breaks `sorted()`, `.lower()`, and `json.dumps()`. Replaced `sorted(entry.aliases)` with `er.async_get_entity_aliases(hass, entry)` which resolves `COMPUTED_NAME` entries to actual name strings and returns a clean `list[str]`. Falls back to `sorted(str(a) for ...)` on older HA versions. Floor and area aliases remain `set[str]` and are unaffected.

Both fixes were applied directly to a running HA 2026.4.2 container and verified working via the MCP tools before creating this PR.