### PR TITLE
feat: add native HA authentication (Long-Lived Access Tokens)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,14 +56,9 @@ jobs:
         virtualenvs-in-project: true
 
     - name: Install dependencies
-      run: poetry install --no-interaction
-      env:
-        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
-
-    - name: Pin HA test helper version
-      run: poetry run pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }}
-      env:
-        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+      run: |
+        poetry run pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }}
+        poetry install --no-interaction
 
     - name: Check formatting with Black
       run: poetry run black --check custom_components/ tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.14"
+          - python-version: "3.13"
             ha-version: "2026.4.2"
             ha-test-helper: "0.13.323"
           - python-version: "3.13"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,47 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    name: test (py${{ matrix.python-version }}, HA ${{ matrix.ha-version }})
+    name: test
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Install dependencies
+      run: poetry install --no-interaction
+
+    - name: Check formatting with Black
+      run: poetry run black --check custom_components/ tests/
+
+    - name: Lint with Ruff
+      run: poetry run ruff check custom_components/ tests/
+
+    - name: Run unit tests
+      run: poetry run pytest tests/ -v --ignore=tests/test_integration.py
+
+    - name: Run tests with coverage
+      run: poetry run pytest tests/ --ignore=tests/test_integration.py --cov=custom_components.mcp_server_http_transport --cov-report=xml --cov-report=term-missing
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        fail_ci_if_error: false
+
+  integration-test:
+    runs-on: ubuntu-latest
+    name: integration (py${{ matrix.python-version }}, HA ${{ matrix.ha-version }})
     strategy:
       fail-fast: false
       matrix:
@@ -36,6 +76,7 @@ jobs:
           - python-version: "3.13"
             ha-version: "2025.10.1"
             ha-test-helper: "0.13.286"
+            extra-deps: "pycares<5"
           - python-version: "3.13"
             ha-version: "2025.4.4"
             ha-test-helper: "0.13.236"
@@ -51,26 +92,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m venv .venv
-        .venv/bin/pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }} mcp black ruff
-
-    - name: Check formatting with Black
-      run: .venv/bin/black --check custom_components/ tests/
-
-    - name: Lint with Ruff
-      run: .venv/bin/ruff check custom_components/ tests/
-
-    - name: Run unit tests
-      run: .venv/bin/pytest tests/ -v --ignore=tests/test_integration.py
+        .venv/bin/pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }} mcp ${{ matrix.extra-deps || '' }}
 
     - name: Run integration tests
       run: .venv/bin/pytest tests/test_integration.py -v
-
-    - name: Run tests with coverage
-      run: .venv/bin/pytest tests/ --cov=custom_components.mcp_server_http_transport --cov-report=xml --cov-report=term-missing
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        fail_ci_if_error: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,10 @@ jobs:
     - name: Install dependencies
       run: |
         python -m venv .venv
-        .venv/bin/pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }} mcp ${{ matrix.extra-deps || '' }}
+        .venv/bin/pip install "pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }}" mcp
+        if [ -n "$EXTRA_DEPS" ]; then .venv/bin/pip install $EXTRA_DEPS; fi
+      env:
+        EXTRA_DEPS: ${{ matrix.extra-deps }}
 
     - name: Run integration tests
       run: .venv/bin/pytest tests/test_integration.py -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,32 +48,25 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        version: latest
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-
     - name: Install dependencies
       run: |
-        poetry run pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }}
-        poetry install --no-interaction
+        python -m venv .venv
+        .venv/bin/pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }} mcp black ruff
 
     - name: Check formatting with Black
-      run: poetry run black --check custom_components/ tests/
+      run: .venv/bin/black --check custom_components/ tests/
 
     - name: Lint with Ruff
-      run: poetry run ruff check custom_components/ tests/
+      run: .venv/bin/ruff check custom_components/ tests/
 
     - name: Run unit tests
-      run: poetry run pytest tests/ -v --ignore=tests/test_integration.py
+      run: .venv/bin/pytest tests/ -v --ignore=tests/test_integration.py
 
     - name: Run integration tests
-      run: poetry run pytest tests/test_integration.py -v
+      run: .venv/bin/pytest tests/test_integration.py -v
 
     - name: Run tests with coverage
-      run: poetry run pytest tests/ --cov=custom_components.mcp_server_http_transport --cov-report=xml --cov-report=term-missing
+      run: .venv/bin/pytest tests/ --cov=custom_components.mcp_server_http_transport --cov-report=xml --cov-report=term-missing
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,16 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    name: test (py${{ matrix.python-version }}, HA ${{ matrix.ha-version }})
     strategy:
       matrix:
-        python-version:
-          - "3.13"
+        include:
+          - python-version: "3.14"
+            ha-version: "2026.4.2"
+          - python-version: "3.13"
+            ha-version: "2025.10.4"
+          - python-version: "3.13"
+            ha-version: "2025.4.4"
 
     steps:
     - uses: actions/checkout@v5
@@ -47,6 +53,9 @@ jobs:
 
     - name: Install dependencies
       run: poetry install --no-interaction
+
+    - name: Pin Home Assistant version
+      run: poetry run pip install homeassistant==${{ matrix.ha-version }}
 
     - name: Check formatting with Black
       run: poetry run black --check custom_components/ tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.13"
+          - python-version: "3.14"
             ha-version: "2026.4.2"
             ha-test-helper: "0.13.323"
           - python-version: "3.13"
@@ -57,9 +57,13 @@ jobs:
 
     - name: Install dependencies
       run: poetry install --no-interaction
+      env:
+        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
     - name: Pin HA test helper version
       run: poetry run pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }}
+      env:
+        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
     - name: Check formatting with Black
       run: poetry run black --check custom_components/ tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,14 +27,18 @@ jobs:
     runs-on: ubuntu-latest
     name: test (py${{ matrix.python-version }}, HA ${{ matrix.ha-version }})
     strategy:
+      fail-fast: false
       matrix:
         include:
           - python-version: "3.14"
             ha-version: "2026.4.2"
+            ha-test-helper: "0.13.323"
           - python-version: "3.13"
-            ha-version: "2025.10.4"
+            ha-version: "2025.10.1"
+            ha-test-helper: "0.13.286"
           - python-version: "3.13"
             ha-version: "2025.4.4"
+            ha-test-helper: "0.13.236"
 
     steps:
     - uses: actions/checkout@v5
@@ -54,8 +58,8 @@ jobs:
     - name: Install dependencies
       run: poetry install --no-interaction
 
-    - name: Pin Home Assistant version
-      run: poetry run pip install homeassistant==${{ matrix.ha-version }}
+    - name: Pin HA test helper version
+      run: poetry run pip install pytest-homeassistant-custom-component==${{ matrix.ha-test-helper }}
 
     - name: Check formatting with Black
       run: poetry run black --check custom_components/ tests/

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 A Home Assistant Custom Component that provides an MCP (Model Context Protocol) server using **HTTP transport**, allowing AI assistants like Claude to interact with your Home Assistant instance.
 
-**Why HTTP transport with OAuth?** This project was built primarily to support MCP Streamable HTTP transport, enabling web-based clients like Claude that require OIDC and OAuth 2.0 Dynamic Client Registration (RFC 7591). Since Home Assistant already has an [official MCP integration](https://www.home-assistant.io/integrations/mcp_server/) that supports SSE transport, there wasn't a need to duplicate that. For local or custom client setups, Long-Lived Access Token authentication is available as an alternative.
+**Why HTTP transport with OAuth?** This project was built primarily to support MCP Streamable HTTP transport, enabling web-based clients like Claude that require OIDC and OAuth 2.0 Dynamic Client Registration (RFC 7591). Since Home Assistant already has an [official MCP integration](https://www.home-assistant.io/integrations/mcp_server/) that supports SSE transport, there wasn't a need to duplicate that. For local or custom client setups, Long-Lived Access Token authentication can be enabled as an alternative.
 
 ## Features
 
 - 🌐 **HTTP transport** (not SSE) - works remotely, not just locally
 - 🔐 **OAuth 2.0 authentication** with Dynamic Client Registration (via [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server))
-- 🔑 **Long-Lived Access Token** authentication for local and custom client setups
+- 🔑 **Long-Lived Access Token** authentication (opt-in) for local and custom client setups
 - 🏠 Full Home Assistant API access (entities, services, areas, devices, history, statistics)
 - 🔧 Easy HACS installation
 - 📝 CRUD management of automations, scenes, and scripts
@@ -19,7 +19,12 @@ A Home Assistant Custom Component that provides an MCP (Model Context Protocol) 
 
 ## Prerequisites
 
-If using OAuth 2.0 authentication (required for browser-based clients like Claude), [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server) must be installed and configured. Long-Lived Access Token authentication has no additional prerequisites.
+The integration supports two authentication methods:
+
+- **OAuth 2.0** (default): Required for browser-based clients like Claude. Requires [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server) to be installed and configured.
+- **Long-Lived Access Tokens** (opt-in): For local agents and custom MCP clients that can't run an OAuth browser flow. No extra dependencies. Must be enabled in the integration settings.
+
+You can use both methods at the same time. When both are active, the server tries OAuth first and falls back to the Long-Lived Access Token.
 
 ## Installation
 
@@ -39,12 +44,18 @@ If using OAuth 2.0 authentication (required for browser-based clients like Claud
 
 ## Configuration
 
-1. Go to Settings → Devices & Services
+1. Go to Settings > Devices & Services
 1. Click "Add Integration"
 1. Search for "MCP Server"
-1. Follow the configuration steps
+1. Choose your authentication method:
+   - Leave "Enable native Home Assistant authentication" **unchecked** for OAuth-only (requires [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server))
+   - **Check** it to allow Long-Lived Access Tokens (can be used alongside OAuth or on its own)
 
-## Usage with Claude in Browser
+You can change this setting later via Settings > Devices & Services > MCP Server > Configure.
+
+## Usage with Claude in Browser (OAuth)
+
+This requires the [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server) integration to be installed.
 
 The MCP server uses OAuth 2.0 Dynamic Client Registration (DCR), which allows Claude to automatically register itself without manual client setup.
 
@@ -71,13 +82,11 @@ That's it! Claude will now be able to interact with your Home Assistant instance
 
 ## Usage with Long-Lived Access Tokens
 
-For local or custom client setups, you can use a Home Assistant Long-Lived Access Token instead of OAuth.
+For local agents or MCP clients that can't run an OAuth browser flow, you can authenticate with a Home Assistant Long-Lived Access Token. This must be enabled first.
 
-1. Enable native authentication in the integration settings (Settings > Devices & Services > MCP Server > Configure > Enable native Home Assistant authentication)
-2. In Home Assistant, go to your user profile and create a Long-Lived Access Token
-3. Configure your MCP client to connect to `http://your-home-assistant:8123/api/mcp` with the token as a Bearer token in the `Authorization` header
-
-When both OAuth and native authentication are enabled, the server tries OAuth first and falls back to the Long-Lived Access Token automatically.
+1. Enable native authentication: Settings > Devices & Services > MCP Server > Configure > check "Enable native Home Assistant authentication"
+2. Create a token: go to your Home Assistant user profile > Long-Lived Access Tokens > Create Token
+3. Configure your MCP client to send the token as a Bearer header to `http://your-home-assistant:8123/api/mcp`
 
 ## MCP Capabilities
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,13 @@
 
 A Home Assistant Custom Component that provides an MCP (Model Context Protocol) server using **HTTP transport**, allowing AI assistants like Claude to interact with your Home Assistant instance.
 
-**Note:** Unlike other Home Assistant MCP servers that use SSE (Server-Sent Events), this implementation uses HTTP transport with OAuth 2.0 authentication, making it suitable for remote access and integration with services like Claude in browser.
+**Why HTTP transport with OAuth?** This project was built primarily to support MCP Streamable HTTP transport, enabling web-based clients like Claude that require OIDC and OAuth 2.0 Dynamic Client Registration (RFC 7591). Since Home Assistant already has an [official MCP integration](https://www.home-assistant.io/integrations/mcp_server/) that supports SSE transport, there wasn't a need to duplicate that. For local or custom client setups, Long-Lived Access Token authentication is available as an alternative.
 
 ## Features
 
 - 🌐 **HTTP transport** (not SSE) - works remotely, not just locally
 - 🔐 **OAuth 2.0 authentication** with Dynamic Client Registration (via [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server))
+- 🔑 **Long-Lived Access Token** authentication for local and custom client setups
 - 🏠 Full Home Assistant API access (entities, services, areas, devices, history, statistics)
 - 🔧 Easy HACS installation
 - 📝 CRUD management of automations, scenes, and scripts
@@ -18,7 +19,7 @@ A Home Assistant Custom Component that provides an MCP (Model Context Protocol) 
 
 ## Prerequisites
 
-This plugin requires [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server) to be installed and configured for OIDC authentication.
+If using OAuth 2.0 authentication (required for browser-based clients like Claude), [hass-oidc-server](https://github.com/ganhammar/hass-oidc-server) must be installed and configured. Long-Lived Access Token authentication has no additional prerequisites.
 
 ## Installation
 
@@ -67,6 +68,16 @@ The MCP server uses OAuth 2.0 Dynamic Client Registration (DCR), which allows Cl
    - Click "Authorize" to grant access
 
 That's it! Claude will now be able to interact with your Home Assistant instance through the MCP server.
+
+## Usage with Long-Lived Access Tokens
+
+For local or custom client setups, you can use a Home Assistant Long-Lived Access Token instead of OAuth.
+
+1. Enable native authentication in the integration settings (Settings > Devices & Services > MCP Server > Configure > Enable native Home Assistant authentication)
+2. In Home Assistant, go to your user profile and create a Long-Lived Access Token
+3. Configure your MCP client to connect to `http://your-home-assistant:8123/api/mcp` with the token as a Bearer token in the `Authorization` header
+
+When both OAuth and native authentication are enabled, the server tries OAuth first and falls back to the Long-Lived Access Token automatically.
 
 ## MCP Capabilities
 

--- a/custom_components/mcp_server_http_transport/__init__.py
+++ b/custom_components/mcp_server_http_transport/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from mcp.server import Server
 
-from .const import DOMAIN
+from .const import CONF_NATIVE_AUTH, DOMAIN
 from .http import (
     MCPEndpointView,
     MCPProtectedResourceMetadataView,
@@ -29,6 +29,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up MCP Server from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
+    native_auth_enabled = entry.data.get(CONF_NATIVE_AUTH, False)
+
     # Create MCP server
     server = Server("home-assistant-mcp-server")
     hass.data[DOMAIN]["server"] = server
@@ -36,10 +38,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register HTTP endpoints
     hass.http.register_view(MCPProtectedResourceMetadataView())
     hass.http.register_view(MCPSubpathProtectedResourceMetadataView())
-    hass.http.register_view(MCPEndpointView(hass, server))
+    hass.http.register_view(MCPEndpointView(hass, server, native_auth_enabled))
 
-    _LOGGER.info("MCP Server initialized at /api/mcp")
+    _LOGGER.info("MCP Server initialized at /api/mcp (native_auth=%s)", native_auth_enabled)
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload integration when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/mcp_server_http_transport/config_flow.py
+++ b/custom_components/mcp_server_http_transport/config_flow.py
@@ -7,9 +7,15 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 
-from .const import DOMAIN
+from .const import CONF_NATIVE_AUTH, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NATIVE_AUTH, default=False): bool,
+    }
+)
 
 
 class MCPServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -21,21 +27,24 @@ class MCPServerConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
         """Handle the initial step."""
-        # Check if OIDC Provider is installed
-        if "oidc_provider" not in self.hass.config_entries.async_domains():
-            return self.async_abort(
-                reason="oidc_provider_required",
-                description_placeholders={
-                    "oidc_provider_url": "https://github.com/ganhammar/hass-oidc-provider"
-                },
-            )
+        errors: dict[str, str] = {}
 
         if user_input is not None:
-            return self.async_create_entry(title="MCP Server", data=user_input)
+            native_auth = user_input.get(CONF_NATIVE_AUTH, False)
+
+            # OIDC provider is only required when native auth is disabled
+            if not native_auth and "oidc_provider" not in self.hass.config_entries.async_domains():
+                errors["base"] = "oidc_provider_required"
+            else:
+                return self.async_create_entry(title="MCP Server", data=user_input)
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema({}),
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+            description_placeholders={
+                "oidc_provider_url": "https://github.com/ganhammar/hass-oidc-provider"
+            },
         )
 
     @staticmethod
@@ -55,9 +64,20 @@ class MCPServerOptionsFlowHandler(config_entries.OptionsFlow):
     ) -> config_entries.FlowResult:
         """Manage the options."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            # Merge options into config entry data so the integration reads from one place
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data={**self.config_entry.data, **user_input},
+            )
+            return self.async_create_entry(title="", data={})
+
+        current_native_auth = self.config_entry.data.get(CONF_NATIVE_AUTH, False)
 
         return self.async_show_form(
             step_id="init",
-            data_schema=vol.Schema({}),
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_NATIVE_AUTH, default=current_native_auth): bool,
+                }
+            ),
         )

--- a/custom_components/mcp_server_http_transport/config_flow.py
+++ b/custom_components/mcp_server_http_transport/config_flow.py
@@ -63,13 +63,19 @@ class MCPServerOptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> config_entries.FlowResult:
         """Manage the options."""
+        errors: dict[str, str] = {}
+
         if user_input is not None:
-            # Merge options into config entry data so the integration reads from one place
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data={**self.config_entry.data, **user_input},
-            )
-            return self.async_create_entry(title="", data={})
+            native_auth = user_input.get(CONF_NATIVE_AUTH, False)
+
+            if not native_auth and "oidc_provider" not in self.hass.config_entries.async_domains():
+                errors["base"] = "oidc_provider_required"
+            else:
+                self.hass.config_entries.async_update_entry(
+                    self.config_entry,
+                    data={**self.config_entry.data, **user_input},
+                )
+                return self.async_create_entry(title="", data={})
 
         current_native_auth = self.config_entry.data.get(CONF_NATIVE_AUTH, False)
 
@@ -80,4 +86,5 @@ class MCPServerOptionsFlowHandler(config_entries.OptionsFlow):
                     vol.Optional(CONF_NATIVE_AUTH, default=current_native_auth): bool,
                 }
             ),
+            errors=errors,
         )

--- a/custom_components/mcp_server_http_transport/const.py
+++ b/custom_components/mcp_server_http_transport/const.py
@@ -5,3 +5,6 @@ DOMAIN = "mcp_server_http_transport"
 # MCP Server configuration
 DEFAULT_PORT = 8080
 DEFAULT_HOST = "0.0.0.0"
+
+# Authentication configuration
+CONF_NATIVE_AUTH = "native_auth_enabled"

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -103,7 +103,7 @@ class MCPEndpointView(HomeAssistantView):
 
             expected_issuer = get_issuer_from_request(request)
             result = validate_access_token(self.hass, token, expected_issuer)
-            if result:
+            if result is not None:
                 return result
         except ImportError as e:
             _LOGGER.debug("OIDC provider not available: %s", e)
@@ -140,6 +140,7 @@ class MCPEndpointView(HomeAssistantView):
                 headers={"WWW-Authenticate": www_authenticate},
             )
 
+        body = None
         try:
             # Parse JSON-RPC message
             body = await request.json()

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -8,14 +8,24 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
 from mcp.server import Server
 
-from custom_components.oidc_provider.token_validator import get_issuer_from_request
-
 from .completions import complete
 from .prompts import get_prompt, get_prompts
 from .resources import get_resources, read_resource
 from .tools import call_tool, get_tool_schemas
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _get_issuer(request: web.Request) -> str | None:
+    """Get the OIDC issuer URL from the request, or None if unavailable."""
+    try:
+        from custom_components.oidc_provider.token_validator import (
+            get_issuer_from_request,
+        )
+
+        return get_issuer_from_request(request)
+    except ImportError:
+        return None
 
 
 def _get_protected_resource_metadata(base_url: str) -> dict[str, Any]:
@@ -38,7 +48,9 @@ class MCPProtectedResourceMetadataView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Return protected resource metadata."""
-        base_url = get_issuer_from_request(request)
+        base_url = _get_issuer(request)
+        if base_url is None:
+            return web.json_response({"error": "OIDC provider not available"}, status=404)
         metadata = _get_protected_resource_metadata(base_url)
         return web.json_response(metadata)
 
@@ -52,7 +64,9 @@ class MCPSubpathProtectedResourceMetadataView(HomeAssistantView):
 
     async def get(self, request: web.Request) -> web.Response:
         """Return protected resource metadata with /mcp suffix."""
-        base_url = get_issuer_from_request(request)
+        base_url = _get_issuer(request)
+        if base_url is None:
+            return web.json_response({"error": "OIDC provider not available"}, status=404)
         metadata = _get_protected_resource_metadata(base_url)
         return web.json_response(metadata)
 
@@ -64,47 +78,64 @@ class MCPEndpointView(HomeAssistantView):
     name = "api:mcp"
     requires_auth = False
 
-    def __init__(self, hass: HomeAssistant, server: Server) -> None:
+    def __init__(
+        self, hass: HomeAssistant, server: Server, native_auth_enabled: bool = False
+    ) -> None:
         """Initialize the MCP endpoint."""
         self.hass = hass
         self.server = server
+        self.native_auth_enabled = native_auth_enabled
 
-    def _validate_token(self, request: web.Request) -> dict[str, Any] | None:
-        """Validate the OAuth bearer token."""
+    async def _validate_token(self, request: web.Request) -> dict[str, Any] | None:
+        """Validate the bearer token via OIDC (if available) then native HA auth."""
         auth_header = request.headers.get("Authorization", "")
         if not auth_header.startswith("Bearer "):
             return None
 
         token = auth_header[7:]  # Remove "Bearer " prefix
 
-        # Import dynamically to avoid circular dependency
+        # 1. Try OIDC first
         try:
             from custom_components.oidc_provider.token_validator import (
                 get_issuer_from_request,
                 validate_access_token,
             )
 
-            # Get the expected issuer from the request
             expected_issuer = get_issuer_from_request(request)
-
-            return validate_access_token(self.hass, token, expected_issuer)
+            result = validate_access_token(self.hass, token, expected_issuer)
+            if result:
+                return result
         except ImportError as e:
-            _LOGGER.error("OIDC provider integration not found: %s", e)
-            return None
+            _LOGGER.debug("OIDC provider not available: %s", e)
+
+        # 2. Fall back to native HA auth (Long-Lived Access Tokens)
+        if self.native_auth_enabled:
+            refresh_token = self.hass.auth.async_validate_access_token(token)
+            if refresh_token is not None:
+                return {"sub": refresh_token.user.id}
+
+        return None
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle POST requests for MCP messages."""
-        # Validate OAuth token
-        token_payload = self._validate_token(request)
+        # Validate token
+        token_payload = await self._validate_token(request)
         if not token_payload:
-            base_url = get_issuer_from_request(request)
-            # Point to protected resource metadata (RFC 9728)
-            resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource/api/mcp"
-            www_authenticate = (
-                f'Bearer realm="MCP Server", resource_metadata="{resource_metadata_url}"'
-            )
+            # Build WWW-Authenticate header
+            base_url = _get_issuer(request)
+            if base_url is not None:
+                resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource/api/mcp"
+                www_authenticate = (
+                    f'Bearer realm="MCP Server",' f' resource_metadata="{resource_metadata_url}"'
+                )
+            else:
+                www_authenticate = 'Bearer realm="Home Assistant MCP Server"'
+
             return web.json_response(
-                {"error": "invalid_token", "error_description": "Invalid or missing token"},
+                {
+                    "error": "invalid_token",
+                    "error_description": "Invalid or missing token",
+                },
                 status=401,
                 headers={"WWW-Authenticate": www_authenticate},
             )
@@ -129,7 +160,10 @@ class MCPEndpointView(HomeAssistantView):
             return web.json_response(
                 {
                     "jsonrpc": "2.0",
-                    "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
+                    "error": {
+                        "code": -32603,
+                        "message": f"Internal error: {str(e)}",
+                    },
                     "id": body.get("id") if isinstance(body, dict) else None,
                 },
                 status=500,
@@ -235,7 +269,10 @@ class MCPEndpointView(HomeAssistantView):
         if msg_id is not None:
             return {
                 "jsonrpc": "2.0",
-                "error": {"code": -32601, "message": f"Method not found: {method}"},
+                "error": {
+                    "code": -32601,
+                    "message": f"Method not found: {method}",
+                },
                 "id": msg_id,
             }
 

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.6.1"
+  "version": "1.7.0"
 }

--- a/custom_components/mcp_server_http_transport/strings.json
+++ b/custom_components/mcp_server_http_transport/strings.json
@@ -29,6 +29,9 @@
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
         }
       }
+    },
+    "error": {
+      "oidc_provider_required": "The OIDC Provider integration is required when native authentication is disabled. Install it or keep native authentication enabled."
     }
   }
 }

--- a/custom_components/mcp_server_http_transport/strings.json
+++ b/custom_components/mcp_server_http_transport/strings.json
@@ -3,11 +3,32 @@
     "step": {
       "user": {
         "title": "MCP Server (HTTP Transport)",
-        "description": "Set up the MCP Server integration for Home Assistant."
+        "description": "Set up the MCP Server integration for Home Assistant.",
+        "data": {
+          "native_auth_enabled": "Enable native Home Assistant authentication"
+        },
+        "data_description": {
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+        }
       }
+    },
+    "error": {
+      "oidc_provider_required": "The OIDC Provider integration is required when native authentication is disabled. Install it from {oidc_provider_url} or enable native authentication."
     },
     "abort": {
       "oidc_provider_required": "The OIDC Provider integration is required but not installed. Please install hass-oidc-provider from {oidc_provider_url} first."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "native_auth_enabled": "Enable native Home Assistant authentication"
+        },
+        "data_description": {
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+        }
+      }
     }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,4 +49,7 @@ def mock_config_entry():
     entry = Mock()
     entry.data = {}
     entry.options = {}
+    entry.async_on_unload = Mock()
+    entry.add_update_listener = Mock()
+    entry.entry_id = "test_entry_id"
     return entry

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -116,7 +116,29 @@ class TestAsyncSetupEntry:
         result = await async_setup_entry(mock_hass, mock_config_entry)
 
         assert result is True
-        mock_endpoint_view_class.assert_called_once_with(mock_hass, mock_server)
+        mock_endpoint_view_class.assert_called_once_with(mock_hass, mock_server, False)
+
+    @patch("custom_components.mcp_server_http_transport.Server")
+    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
+    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
+    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
+    async def test_async_setup_entry_passes_native_auth_enabled(
+        self,
+        mock_subpath_view,
+        mock_metadata_view,
+        mock_endpoint_view_class,
+        mock_server_class,
+        mock_hass,
+        mock_config_entry,
+    ):
+        """Test async_setup_entry passes native_auth_enabled to endpoint view."""
+        mock_config_entry.data = {"native_auth_enabled": True}
+        mock_server = Mock()
+        mock_server_class.return_value = mock_server
+
+        await async_setup_entry(mock_hass, mock_config_entry)
+
+        mock_endpoint_view_class.assert_called_once_with(mock_hass, mock_server, True)
 
 
 class TestAsyncUnloadEntry:

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -1,6 +1,6 @@
 """Test __init__.py for MCP Server integration."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from custom_components.mcp_server_http_transport import (
     DOMAIN,
@@ -139,6 +139,21 @@ class TestAsyncSetupEntry:
         await async_setup_entry(mock_hass, mock_config_entry)
 
         mock_endpoint_view_class.assert_called_once_with(mock_hass, mock_server, True)
+
+
+class TestUpdateListener:
+    """Test config entry update listener."""
+
+    async def test_update_listener_reloads_entry(self, mock_hass, mock_config_entry):
+        """Test _async_update_listener triggers a reload."""
+        from custom_components.mcp_server_http_transport import _async_update_listener
+
+        mock_hass.config_entries = Mock()
+        mock_hass.config_entries.async_reload = AsyncMock()
+
+        await _async_update_listener(mock_hass, mock_config_entry)
+
+        mock_hass.config_entries.async_reload.assert_called_once_with(mock_config_entry.entry_id)
 
 
 class TestAsyncUnloadEntry:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -103,7 +103,7 @@ class TestMCPServerConfigFlow:
 class TestMCPServerOptionsFlow:
     """Test the MCP Server options flow."""
 
-    def _create_flow(self, data=None):
+    def _create_flow(self, data=None, installed_domains=None):
         """Create an options flow with mocked internals."""
         mock_config_entry = Mock()
         mock_config_entry.data = data or {}
@@ -113,6 +113,9 @@ class TestMCPServerOptionsFlow:
         flow.hass = Mock()
         flow.hass.config_entries = Mock()
         flow.hass.config_entries.async_get_known_entry.return_value = mock_config_entry
+        flow.hass.config_entries.async_domains.return_value = (
+            installed_domains if installed_domains is not None else ["oidc_provider"]
+        )
         flow._config_entry = mock_config_entry
         flow.handler = mock_config_entry.entry_id
         return flow
@@ -143,6 +146,16 @@ class TestMCPServerOptionsFlow:
         flow.hass.config_entries.async_update_entry.assert_called_once()
         call_kwargs = flow.hass.config_entries.async_update_entry.call_args
         assert call_kwargs[1]["data"][CONF_NATIVE_AUTH] is True
+
+    async def test_init_step_error_disabling_native_without_oidc(self):
+        """Test options flow shows error when disabling native auth without OIDC."""
+        flow = self._create_flow(data={CONF_NATIVE_AUTH: True}, installed_domains=[])
+
+        result = await flow.async_step_init(user_input={CONF_NATIVE_AUTH: False})
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"]["base"] == "oidc_provider_required"
+        flow.hass.config_entries.async_update_entry.assert_not_called()
 
     async def test_init_step_defaults_to_false(self):
         """Test init step defaults native_auth_enabled to False."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,12 +8,13 @@ from custom_components.mcp_server_http_transport.config_flow import (
     MCPServerConfigFlow,
     MCPServerOptionsFlowHandler,
 )
+from custom_components.mcp_server_http_transport.const import CONF_NATIVE_AUTH
 
 
 class TestMCPServerConfigFlow:
     """Test the MCP Server config flow."""
 
-    async def test_user_flow_creates_entry(self):
+    async def test_user_flow_creates_entry_with_oidc(self):
         """Test user flow creates config entry when OIDC provider exists."""
         mock_hass = Mock()
         mock_hass.config_entries = Mock()
@@ -22,11 +23,39 @@ class TestMCPServerConfigFlow:
         flow = MCPServerConfigFlow()
         flow.hass = mock_hass
 
-        result = await flow.async_step_user(user_input={})
+        result = await flow.async_step_user(user_input={CONF_NATIVE_AUTH: False})
 
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert result["title"] == "MCP Server"
-        assert result["data"] == {}
+        assert result["data"][CONF_NATIVE_AUTH] is False
+
+    async def test_user_flow_creates_entry_with_native_auth(self):
+        """Test user flow creates entry with native auth, no OIDC required."""
+        mock_hass = Mock()
+        mock_hass.config_entries = Mock()
+        mock_hass.config_entries.async_domains = Mock(return_value=[])
+
+        flow = MCPServerConfigFlow()
+        flow.hass = mock_hass
+
+        result = await flow.async_step_user(user_input={CONF_NATIVE_AUTH: True})
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["data"][CONF_NATIVE_AUTH] is True
+
+    async def test_user_flow_error_when_no_oidc_and_native_disabled(self):
+        """Test user flow shows error when OIDC missing and native auth disabled."""
+        mock_hass = Mock()
+        mock_hass.config_entries = Mock()
+        mock_hass.config_entries.async_domains = Mock(return_value=[])
+
+        flow = MCPServerConfigFlow()
+        flow.hass = mock_hass
+
+        result = await flow.async_step_user(user_input={CONF_NATIVE_AUTH: False})
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["errors"]["base"] == "oidc_provider_required"
 
     async def test_user_flow_shows_form_when_no_input(self):
         """Test user flow shows form when no input provided."""
@@ -43,19 +72,19 @@ class TestMCPServerConfigFlow:
         assert result["step_id"] == "user"
         assert result["data_schema"] is not None
 
-    async def test_user_flow_aborts_when_oidc_provider_missing(self):
-        """Test user flow aborts when OIDC provider is not installed."""
+    async def test_user_flow_form_has_native_auth_field(self):
+        """Test user flow form includes native_auth_enabled field."""
         mock_hass = Mock()
         mock_hass.config_entries = Mock()
-        mock_hass.config_entries.async_domains = Mock(return_value=[])
+        mock_hass.config_entries.async_domains = Mock(return_value=["oidc_provider"])
 
         flow = MCPServerConfigFlow()
         flow.hass = mock_hass
 
-        result = await flow.async_step_user(user_input={})
+        result = await flow.async_step_user(user_input=None)
 
-        assert result["type"] == data_entry_flow.FlowResultType.ABORT
-        assert result["reason"] == "oidc_provider_required"
+        schema_keys = [str(k) for k in result["data_schema"].schema]
+        assert CONF_NATIVE_AUTH in schema_keys
 
     async def test_version_is_set(self):
         """Test config flow version is set."""
@@ -70,67 +99,55 @@ class TestMCPServerConfigFlow:
 
             assert isinstance(options_flow, MCPServerOptionsFlowHandler)
 
-    async def test_user_flow_form_has_empty_schema(self):
-        """Test user flow form has empty data schema."""
-        mock_hass = Mock()
-        mock_hass.config_entries = Mock()
-        mock_hass.config_entries.async_domains = Mock(return_value=["oidc_provider"])
-
-        flow = MCPServerConfigFlow()
-        flow.hass = mock_hass
-
-        result = await flow.async_step_user(user_input=None)
-
-        # Verify the schema is empty (no user input required)
-        assert result["data_schema"].schema == {}
-
 
 class TestMCPServerOptionsFlow:
     """Test the MCP Server options flow."""
 
-    async def test_init_step_shows_form(self):
-        """Test init step shows form."""
+    def _create_flow(self, data=None):
+        """Create an options flow with mocked internals."""
         mock_config_entry = Mock()
+        mock_config_entry.data = data or {}
+        mock_config_entry.entry_id = "test_entry"
 
         flow = MCPServerOptionsFlowHandler.__new__(MCPServerOptionsFlowHandler)
+        flow.hass = Mock()
+        flow.hass.config_entries = Mock()
+        flow.hass.config_entries.async_get_known_entry.return_value = mock_config_entry
         flow._config_entry = mock_config_entry
+        flow.handler = mock_config_entry.entry_id
+        return flow
 
+    async def test_init_step_shows_form(self):
+        """Test init step shows form."""
+        flow = self._create_flow()
         result = await flow.async_step_init(user_input=None)
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
 
-    async def test_init_step_with_user_input_creates_entry(self):
-        """Test init step with user input creates entry."""
-        mock_config_entry = Mock()
-
-        flow = MCPServerOptionsFlowHandler.__new__(MCPServerOptionsFlowHandler)
-        flow._config_entry = mock_config_entry
-
-        result = await flow.async_step_init(user_input={})
-
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert result["title"] == ""
-        assert result["data"] == {}
-
-    async def test_init_step_form_has_empty_schema(self):
-        """Test init step form has empty data schema."""
-        mock_config_entry = Mock()
-
-        flow = MCPServerOptionsFlowHandler.__new__(MCPServerOptionsFlowHandler)
-        flow._config_entry = mock_config_entry
-
+    async def test_init_step_shows_current_value(self):
+        """Test init step shows current native_auth_enabled value."""
+        flow = self._create_flow(data={CONF_NATIVE_AUTH: True})
         result = await flow.async_step_init(user_input=None)
 
-        # Verify the schema is empty (no user input required)
-        assert result["data_schema"].schema == {}
+        schema_keys = {str(k): k for k in result["data_schema"].schema}
+        assert schema_keys[CONF_NATIVE_AUTH].default() is True
 
-    def test_options_flow_stores_config_entry(self):
-        """Test options flow stores config entry."""
-        mock_config_entry = Mock()
+    async def test_init_step_updates_entry_data(self):
+        """Test init step merges user input into config entry data."""
+        flow = self._create_flow(data={CONF_NATIVE_AUTH: False})
 
-        # Use internal attribute to avoid deprecated setter
-        flow = MCPServerOptionsFlowHandler.__new__(MCPServerOptionsFlowHandler)
-        flow._config_entry = mock_config_entry
+        result = await flow.async_step_init(user_input={CONF_NATIVE_AUTH: True})
 
-        assert flow.config_entry == mock_config_entry
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        flow.hass.config_entries.async_update_entry.assert_called_once()
+        call_kwargs = flow.hass.config_entries.async_update_entry.call_args
+        assert call_kwargs[1]["data"][CONF_NATIVE_AUTH] is True
+
+    async def test_init_step_defaults_to_false(self):
+        """Test init step defaults native_auth_enabled to False."""
+        flow = self._create_flow(data={})
+        result = await flow.async_step_init(user_input=None)
+
+        schema_keys = {str(k): k for k in result["data_schema"].schema}
+        assert schema_keys[CONF_NATIVE_AUTH].default() is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -10,6 +10,7 @@ from custom_components.mcp_server_http_transport.http import (
     MCPEndpointView,
     MCPProtectedResourceMetadataView,
     MCPSubpathProtectedResourceMetadataView,
+    _get_issuer,
     _get_protected_resource_metadata,
 )
 
@@ -53,6 +54,24 @@ def test_get_base_url_with_partial_forwarded_headers():
 
     assert result == "http://localhost:8123"
     request.url.origin.assert_called_once()
+
+
+def test_get_issuer_returns_none_when_oidc_unavailable():
+    """Test _get_issuer returns None when oidc_provider import fails."""
+    import sys
+
+    request = Mock()
+    # Temporarily remove the mocked oidc module so the import raises ImportError
+    saved = sys.modules.pop("custom_components.oidc_provider.token_validator", None)
+    saved_parent = sys.modules.pop("custom_components.oidc_provider", None)
+    try:
+        result = _get_issuer(request)
+        assert result is None
+    finally:
+        if saved is not None:
+            sys.modules["custom_components.oidc_provider.token_validator"] = saved
+        if saved_parent is not None:
+            sys.modules["custom_components.oidc_provider"] = saved_parent
 
 
 def test_get_protected_resource_metadata():
@@ -101,6 +120,19 @@ class TestMCPProtectedResourceMetadataView:
         body = json.loads(response.body)
         assert body["resource"] == "https://example.com/api/mcp"
 
+    async def test_get_returns_404_when_oidc_unavailable(self):
+        """Test GET returns 404 when OIDC provider is not installed."""
+        request = Mock()
+
+        view = MCPProtectedResourceMetadataView()
+        with patch(
+            "custom_components.mcp_server_http_transport.http._get_issuer",
+            return_value=None,
+        ):
+            response = await view.get(request)
+
+        assert response.status == 404
+
 
 class TestMCPSubpathProtectedResourceMetadataView:
     """Test the MCP protected resource metadata view with /mcp suffix."""
@@ -117,6 +149,19 @@ class TestMCPSubpathProtectedResourceMetadataView:
         assert response.status == 200
         body = json.loads(response.body)
         assert body["resource"] == "https://homeassistant.local/api/mcp"
+
+    async def test_get_returns_404_when_oidc_unavailable(self):
+        """Test GET returns 404 when OIDC provider is not installed."""
+        request = Mock()
+
+        view = MCPSubpathProtectedResourceMetadataView()
+        with patch(
+            "custom_components.mcp_server_http_transport.http._get_issuer",
+            return_value=None,
+        ):
+            response = await view.get(request)
+
+        assert response.status == 404
 
 
 class TestMCPEndpointView:
@@ -342,22 +387,21 @@ class TestNativeAuth:
 
     async def test_oidc_tried_before_llat(self, view, mock_hass):
         """Test that OIDC validation is attempted before LLAT."""
+        import sys
+
         request = Mock()
         request.headers = {"Authorization": "Bearer oidc_token"}
 
-        oidc_result = {"sub": "oidc_user", "scope": "openid"}
-
-        with patch(
-            "custom_components.mcp_server_http_transport.http.validate_access_token",
-            return_value=oidc_result,
-            create=True,
-        ):
-            # OIDC succeeds, LLAT should not be called
+        mock_validator = sys.modules["custom_components.oidc_provider.token_validator"]
+        original = mock_validator.validate_access_token.return_value
+        mock_validator.validate_access_token.return_value = {"sub": "oidc_user"}
+        try:
             result = await view._validate_token(request)
+        finally:
+            mock_validator.validate_access_token.return_value = original
 
-        # OIDC succeeded, so result should be the OIDC payload
-        if result is not None and result.get("sub") == "oidc_user":
-            mock_hass.auth.async_validate_access_token.assert_not_called()
+        assert result == {"sub": "oidc_user"}
+        mock_hass.auth.async_validate_access_token.assert_not_called()
 
     async def test_llat_fallback_after_oidc_fails(self, view, mock_hass):
         """Test LLAT is tried as fallback when OIDC validation returns None."""
@@ -372,6 +416,29 @@ class TestNativeAuth:
         result = await view._validate_token(request)
 
         assert result == {"sub": "ha_user"}
+
+    async def test_validate_token_import_error_falls_through(self, view, mock_hass):
+        """Test _validate_token handles ImportError from OIDC and falls through to LLAT."""
+        import sys
+
+        mock_refresh_token = Mock()
+        mock_refresh_token.user.id = "fallback_user"
+        mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer some_token"}
+
+        saved = sys.modules.pop("custom_components.oidc_provider.token_validator", None)
+        saved_parent = sys.modules.pop("custom_components.oidc_provider", None)
+        try:
+            result = await view._validate_token(request)
+        finally:
+            if saved is not None:
+                sys.modules["custom_components.oidc_provider.token_validator"] = saved
+            if saved_parent is not None:
+                sys.modules["custom_components.oidc_provider"] = saved_parent
+
+        assert result == {"sub": "fallback_user"}
 
     async def test_401_without_oidc_metadata_when_oidc_unavailable(self, view, mock_hass):
         """Test 401 response uses plain Bearer when OIDC is not available."""

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         request = Mock()
         request.headers = {"Authorization": "invalid_format"}
 
-        result = view._validate_token(request)
+        result = await view._validate_token(request)
 
         assert result is None
 
@@ -280,3 +280,129 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert "error" in body
         assert "Unknown tool" in body["error"]["message"]
+
+
+class TestNativeAuth:
+    """Test native HA authentication (Long-Lived Access Tokens)."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        """Create a mock Home Assistant instance with auth."""
+        hass = Mock()
+        hass.states = Mock()
+        hass.services = Mock()
+        hass.auth = Mock()
+        hass.auth.async_validate_access_token = Mock(return_value=None)
+        return hass
+
+    @pytest.fixture
+    def view(self, mock_hass):
+        """Create an MCPEndpointView with native auth enabled."""
+        return MCPEndpointView(mock_hass, Mock(), native_auth_enabled=True)
+
+    @pytest.fixture
+    def view_disabled(self, mock_hass):
+        """Create an MCPEndpointView with native auth disabled."""
+        return MCPEndpointView(mock_hass, Mock(), native_auth_enabled=False)
+
+    async def test_llat_validates_when_enabled(self, view, mock_hass):
+        """Test that a valid LLAT is accepted when native auth is enabled."""
+        mock_refresh_token = Mock()
+        mock_refresh_token.user.id = "user_abc"
+        mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_llat"}
+
+        result = await view._validate_token(request)
+
+        assert result == {"sub": "user_abc"}
+        mock_hass.auth.async_validate_access_token.assert_called_once_with("valid_llat")
+
+    async def test_llat_rejected_when_disabled(self, view_disabled, mock_hass):
+        """Test that LLAT is not tried when native auth is disabled."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer some_token"}
+
+        result = await view_disabled._validate_token(request)
+
+        assert result is None
+        mock_hass.auth.async_validate_access_token.assert_not_called()
+
+    async def test_invalid_llat_returns_none(self, view, mock_hass):
+        """Test that an invalid LLAT returns None."""
+        mock_hass.auth.async_validate_access_token.return_value = None
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer bad_token"}
+
+        result = await view._validate_token(request)
+
+        assert result is None
+
+    async def test_oidc_tried_before_llat(self, view, mock_hass):
+        """Test that OIDC validation is attempted before LLAT."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer oidc_token"}
+
+        oidc_result = {"sub": "oidc_user", "scope": "openid"}
+
+        with patch(
+            "custom_components.mcp_server_http_transport.http.validate_access_token",
+            return_value=oidc_result,
+            create=True,
+        ):
+            # OIDC succeeds, LLAT should not be called
+            result = await view._validate_token(request)
+
+        # OIDC succeeded, so result should be the OIDC payload
+        if result is not None and result.get("sub") == "oidc_user":
+            mock_hass.auth.async_validate_access_token.assert_not_called()
+
+    async def test_llat_fallback_after_oidc_fails(self, view, mock_hass):
+        """Test LLAT is tried as fallback when OIDC validation returns None."""
+        mock_refresh_token = Mock()
+        mock_refresh_token.user.id = "ha_user"
+        mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer llat_token"}
+
+        # OIDC will fail (ImportError from conftest mock returning None)
+        result = await view._validate_token(request)
+
+        assert result == {"sub": "ha_user"}
+
+    async def test_401_without_oidc_metadata_when_oidc_unavailable(self, view, mock_hass):
+        """Test 401 response uses plain Bearer when OIDC is not available."""
+        mock_hass.auth.async_validate_access_token.return_value = None
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer bad_token"}
+        request.url.origin.return_value = "http://localhost:8123"
+
+        with patch(
+            "custom_components.mcp_server_http_transport.http._get_issuer",
+            return_value=None,
+        ):
+            response = await view.post(request)
+
+        assert response.status == 401
+        assert 'realm="Home Assistant MCP Server"' in response.headers["WWW-Authenticate"]
+        assert "resource_metadata" not in response.headers["WWW-Authenticate"]
+
+    async def test_native_auth_full_request(self, view, mock_hass):
+        """Test a full request with native auth from token to response."""
+        mock_refresh_token = Mock()
+        mock_refresh_token.user.id = "user_xyz"
+        mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer my_llat"}
+        request.json = AsyncMock(return_value={"jsonrpc": "2.0", "method": "initialize", "id": 1})
+
+        response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert body["result"]["protocolVersion"] == "2024-11-05"


### PR DESCRIPTION
Add support for native Home Assistant authentication as a fallback alongside OIDC. When enabled via the integration config toggle (default off), the MCP endpoint tries OIDC first, then validates against HA's built-in auth system using Long-Lived Access Tokens.

**What changed:**
- New `native_auth_enabled` toggle in both setup and options flow (default off, backward compatible)
- `_validate_token()` tries OIDC first, falls back to `hass.auth.async_validate_access_token()` when enabled
- Removed hard top-level OIDC import from `http.py`, all OIDC imports are now lazy
- OIDC provider is only required when native auth is disabled
- Metadata endpoints (RFC 9728) gracefully return 404 when OIDC is unavailable
- CI now tests against HA 2026.4.2, 2025.10.4, and 2025.4.4

Tested on a live HA 2026.4.2 instance with both OIDC (via Claude MCP tools) and LLAT (via curl) working simultaneously. Invalid tokens correctly return 401.

Ref #27, #28