### PR TITLE
fix: add translations/en.json for config flow labels

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.7.0"
+  "version": "1.7.1"
 }

--- a/custom_components/mcp_server_http_transport/translations/en.json
+++ b/custom_components/mcp_server_http_transport/translations/en.json
@@ -1,0 +1,37 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "MCP Server (HTTP Transport)",
+        "description": "Set up the MCP Server integration for Home Assistant.",
+        "data": {
+          "native_auth_enabled": "Enable native Home Assistant authentication"
+        },
+        "data_description": {
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+        }
+      }
+    },
+    "error": {
+      "oidc_provider_required": "The OIDC Provider integration is required when native authentication is disabled. Install it from {oidc_provider_url} or enable native authentication."
+    },
+    "abort": {
+      "oidc_provider_required": "The OIDC Provider integration is required but not installed. Please install hass-oidc-provider from {oidc_provider_url} first."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "native_auth_enabled": "Enable native Home Assistant authentication"
+        },
+        "data_description": {
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+        }
+      }
+    },
+    "error": {
+      "oidc_provider_required": "The OIDC Provider integration is required when native authentication is disabled. Install it or keep native authentication enabled."
+    }
+  }
+}


### PR DESCRIPTION
Custom components need `translations/en.json` for HA to display friendly labels in the config and options flows. Without it, raw config keys like `native_auth_enabled` are shown instead of "Enable native Home Assistant authentication".