### PR TITLE
Fix datetime/date JSON serialization in MCP tool responses

### DIFF
--- a/custom_components/mcp_server_http_transport/json_utils.py
+++ b/custom_components/mcp_server_http_transport/json_utils.py
@@ -1,0 +1,16 @@
+"""Shared JSON helpers for Home Assistant MCP serialization."""
+
+import json
+from datetime import date, datetime
+from typing import Any
+
+
+class _HAJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles datetime/date objects in HA state attributes."""
+
+    def default(self, o: Any) -> Any:
+        if isinstance(o, datetime):
+            return o.isoformat()
+        if isinstance(o, date):
+            return o.isoformat()
+        return super().default(o)

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.7.1"
+  "version": "1.7.2"
 }

--- a/custom_components/mcp_server_http_transport/prompts/automation_workflows.py
+++ b/custom_components/mcp_server_http_transport/prompts/automation_workflows.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
+from ..json_utils import _HAJSONEncoder
 from . import register_prompt
 
 _LOGGER = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ async def automation_debugger(hass: HomeAssistant, arguments: dict[str, Any]) ->
     # Fetch automation config
     try:
         config = await read_list_entry(hass, "automations.yaml", automation_id)
-        config_text = json.dumps(config, indent=2)
+        config_text = json.dumps(config, indent=2, cls=_HAJSONEncoder)
     except Exception:
         _LOGGER.exception("Error reading automation config for '%s'", automation_id)
         config_text = f"Automation with id '{automation_id}' not found in automations.yaml"
@@ -121,6 +122,7 @@ async def automation_debugger(hass: HomeAssistant, arguments: dict[str, Any]) ->
                 "mode": state.attributes.get("mode", "single"),
             },
             indent=2,
+            cls=_HAJSONEncoder,
         )
     else:
         state_text = f"Automation entity not found for id '{automation_id}'"
@@ -150,7 +152,11 @@ async def automation_debugger(hass: HomeAssistant, arguments: dict[str, Any]) ->
             events = await get_instance(hass).async_add_executor_job(
                 processor.get_events, start_time, end_time
             )
-            logbook_text = json.dumps(events[:20], indent=2) if events else "No recent events"
+            logbook_text = (
+                json.dumps(events[:20], indent=2, cls=_HAJSONEncoder)
+                if events
+                else "No recent events"
+            )
     except Exception:
         _LOGGER.debug("Could not fetch logbook entries for automation debug")
 
@@ -195,7 +201,7 @@ async def automation_audit(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     automations = None
     try:
         automations = await read_list_entries(hass, "automations.yaml")
-        automations_text = json.dumps(automations, indent=2)
+        automations_text = json.dumps(automations, indent=2, cls=_HAJSONEncoder)
     except Exception:
         _LOGGER.exception("Error reading automations for audit")
         automations_text = "Unable to read automations.yaml"
@@ -211,7 +217,7 @@ async def automation_audit(hass: HomeAssistant, arguments: dict[str, Any]) -> di
                     "last_triggered": str(state.attributes.get("last_triggered", "never")),
                 }
             )
-    states_text = json.dumps(auto_states, indent=2)
+    states_text = json.dumps(auto_states, indent=2, cls=_HAJSONEncoder)
 
     return {
         "description": "Audit all automations",

--- a/custom_components/mcp_server_http_transport/prompts/diagnostics.py
+++ b/custom_components/mcp_server_http_transport/prompts/diagnostics.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
+from ..json_utils import _HAJSONEncoder
 from . import register_prompt
 
 
@@ -36,6 +37,7 @@ def troubleshoot_device(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
                 "last_updated": state.last_updated.isoformat(),
             },
             indent=2,
+            cls=_HAJSONEncoder,
         )
 
     return {
@@ -90,6 +92,7 @@ def setup_guide(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any
                 "last_updated": state.last_updated.isoformat(),
             },
             indent=2,
+            cls=_HAJSONEncoder,
         )
 
     return {

--- a/custom_components/mcp_server_http_transport/prompts/optimization.py
+++ b/custom_components/mcp_server_http_transport/prompts/optimization.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
+from ..json_utils import _HAJSONEncoder
 from . import register_prompt
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ async def schedule_optimizer(hass: HomeAssistant, arguments: dict[str, Any]) -> 
 
     try:
         automations = await read_list_entries(hass, "automations.yaml")
-        automations_text = json.dumps(automations, indent=2)
+        automations_text = json.dumps(automations, indent=2, cls=_HAJSONEncoder)
     except Exception:
         _LOGGER.exception("Error reading automations for schedule optimizer")
         automations_text = "Unable to read automations.yaml"
@@ -45,7 +46,7 @@ async def schedule_optimizer(hass: HomeAssistant, arguments: dict[str, Any]) -> 
             entity_context = (
                 f"\n**Focus entity:** {entity_id}\n"
                 f"Current state: {state.state}\n"
-                f"Attributes: {json.dumps(dict(state.attributes), indent=2)}\n"
+                f"Attributes: {json.dumps(dict(state.attributes), indent=2, cls=_HAJSONEncoder)}\n"
             )
         else:
             entity_context = f"\n**Focus entity:** {entity_id} (not found)\n"
@@ -100,7 +101,7 @@ async def naming_conventions(hass: HomeAssistant, arguments: dict[str, Any]) -> 
             }
         )
 
-    entities_text = json.dumps(by_domain, indent=2)
+    entities_text = json.dumps(by_domain, indent=2, cls=_HAJSONEncoder)
     total = sum(len(v) for v in by_domain.values())
 
     return {

--- a/custom_components/mcp_server_http_transport/resources.py
+++ b/custom_components/mcp_server_http_transport/resources.py
@@ -10,6 +10,8 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import floor_registry as fr
 from homeassistant.helpers import label_registry as lr
 
+from .json_utils import _HAJSONEncoder
+
 RESOURCES = [
     {
         "uri": "hass://config",
@@ -147,7 +149,13 @@ def _read_config(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         "country": config.country,
         "language": config.language,
     }
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(data, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(data, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_areas(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
@@ -161,7 +169,13 @@ def _read_areas(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         }
         for area in registry.async_list_areas()
     ]
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(areas, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(areas, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 async def _read_dashboard(hass: HomeAssistant, uri: str, url_path: str) -> list[dict[str, Any]]:
@@ -169,7 +183,13 @@ async def _read_dashboard(hass: HomeAssistant, uri: str, url_path: str) -> list[
     from .dashboard_manager import get_dashboard_config
 
     config = await get_dashboard_config(hass, url_path)
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(config, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(config, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_devices(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
@@ -186,14 +206,26 @@ def _read_devices(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         }
         for device in registry.devices.values()
     ]
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(devices, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(devices, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_services(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
     """Read all services as a resource."""
     services = hass.services.async_services()
     result = {domain: list(svcs.keys()) for domain, svcs in services.items()}
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(result, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(result, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_floors(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
@@ -209,7 +241,13 @@ def _read_floors(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         }
         for floor in registry.async_list_floors()
     ]
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(floors, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(floors, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_entity(hass: HomeAssistant, uri: str, entity_id: str) -> list[dict[str, Any]]:
@@ -226,7 +264,13 @@ def _read_entity(hass: HomeAssistant, uri: str, entity_id: str) -> list[dict[str
         "last_changed": state.last_changed.isoformat(),
         "last_updated": state.last_updated.isoformat(),
     }
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(data, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(data, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_entities(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
@@ -241,7 +285,13 @@ def _read_entities(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
                 "friendly_name": state.attributes.get("friendly_name", state.entity_id),
             }
         )
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(by_domain, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(by_domain, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_entities_domain(hass: HomeAssistant, uri: str, domain: str) -> list[dict[str, Any]]:
@@ -257,7 +307,13 @@ def _read_entities_domain(hass: HomeAssistant, uri: str, domain: str) -> list[di
                 "friendly_name": state.attributes.get("friendly_name", state.entity_id),
             }
         )
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(entities, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_labels(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
@@ -273,7 +329,13 @@ def _read_labels(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         }
         for label in registry.async_list_labels()
     ]
-    return [{"uri": uri, "mimeType": "application/json", "text": json.dumps(labels, indent=2)}]
+    return [
+        {
+            "uri": uri,
+            "mimeType": "application/json",
+            "text": json.dumps(labels, indent=2, cls=_HAJSONEncoder),
+        }
+    ]
 
 
 def _read_integrations(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
@@ -292,6 +354,6 @@ def _read_integrations(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(integrations, indent=2),
+            "text": json.dumps(integrations, indent=2, cls=_HAJSONEncoder),
         }
     ]

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -1,8 +1,21 @@
 """MCP tool definitions and handlers for Home Assistant."""
 
+import json
+from datetime import date, datetime
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+
+
+class _HAJSONEncoder(json.JSONEncoder):
+    """JSON encoder that handles datetime/date objects in HA state attributes."""
+
+    def default(self, o: Any) -> Any:
+        if isinstance(o, datetime):
+            return o.isoformat()
+        if isinstance(o, date):
+            return o.isoformat()
+        return super().default(o)
 
 # Tool registry: name -> {"schema": {...}, "handler": callable}
 TOOLS: dict[str, dict[str, Any]] = {}

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -1,21 +1,10 @@
 """MCP tool definitions and handlers for Home Assistant."""
 
-import json
-from datetime import date, datetime
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-
-class _HAJSONEncoder(json.JSONEncoder):
-    """JSON encoder that handles datetime/date objects in HA state attributes."""
-
-    def default(self, o: Any) -> Any:
-        if isinstance(o, datetime):
-            return o.isoformat()
-        if isinstance(o, date):
-            return o.isoformat()
-        return super().default(o)
+from ..json_utils import _HAJSONEncoder  # noqa: F401
 
 # Tool registry: name -> {"schema": {...}, "handler": callable}
 TOOLS: dict[str, dict[str, Any]] = {}

--- a/custom_components/mcp_server_http_transport/tools/config.py
+++ b/custom_components/mcp_server_http_transport/tools/config.py
@@ -122,7 +122,9 @@ async def list_automations(hass: HomeAssistant, arguments: dict[str, Any]) -> di
 
     try:
         entries = await read_list_entries(hass, "automations.yaml")
-        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing automations: {str(e)}"}]}
 
@@ -147,7 +149,9 @@ async def get_automation_config(hass: HomeAssistant, arguments: dict[str, Any]) 
 
     try:
         entry = await read_list_entry(hass, "automations.yaml", arguments["automation_id"])
-        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting automation config: {str(e)}"}]}
 
@@ -252,7 +256,9 @@ async def list_scenes(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
 
     try:
         entries = await read_list_entries(hass, "scenes.yaml")
-        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing scenes: {str(e)}"}]}
 
@@ -277,7 +283,9 @@ async def get_scene_config(hass: HomeAssistant, arguments: dict[str, Any]) -> di
 
     try:
         entry = await read_list_entry(hass, "scenes.yaml", arguments["scene_id"])
-        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting scene config: {str(e)}"}]}
 
@@ -388,7 +396,9 @@ async def list_scripts(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
 
     try:
         entries = await read_dict_entries(hass, "scripts.yaml")
-        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing scripts: {str(e)}"}]}
 
@@ -413,6 +423,8 @@ async def get_script_config(hass: HomeAssistant, arguments: dict[str, Any]) -> d
 
     try:
         entry = await read_dict_entry(hass, "scripts.yaml", arguments["key"])
-        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting script config: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/config.py
+++ b/custom_components/mcp_server_http_transport/tools/config.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from . import register_tool
+from . import _HAJSONEncoder, register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,7 +122,7 @@ async def list_automations(hass: HomeAssistant, arguments: dict[str, Any]) -> di
 
     try:
         entries = await read_list_entries(hass, "automations.yaml")
-        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing automations: {str(e)}"}]}
 
@@ -147,7 +147,7 @@ async def get_automation_config(hass: HomeAssistant, arguments: dict[str, Any]) 
 
     try:
         entry = await read_list_entry(hass, "automations.yaml", arguments["automation_id"])
-        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting automation config: {str(e)}"}]}
 
@@ -252,7 +252,7 @@ async def list_scenes(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
 
     try:
         entries = await read_list_entries(hass, "scenes.yaml")
-        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing scenes: {str(e)}"}]}
 
@@ -277,7 +277,7 @@ async def get_scene_config(hass: HomeAssistant, arguments: dict[str, Any]) -> di
 
     try:
         entry = await read_list_entry(hass, "scenes.yaml", arguments["scene_id"])
-        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting scene config: {str(e)}"}]}
 
@@ -388,7 +388,7 @@ async def list_scripts(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
 
     try:
         entries = await read_dict_entries(hass, "scripts.yaml")
-        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing scripts: {str(e)}"}]}
 
@@ -413,6 +413,6 @@ async def get_script_config(hass: HomeAssistant, arguments: dict[str, Any]) -> d
 
     try:
         entry = await read_dict_entry(hass, "scripts.yaml", arguments["key"])
-        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting script config: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/dashboards.py
+++ b/custom_components/mcp_server_http_transport/tools/dashboards.py
@@ -25,7 +25,11 @@ async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -
 
     try:
         dashboards = await list_dashboards(hass)
-        return {"content": [{"type": "text", "text": json.dumps(dashboards, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [
+                {"type": "text", "text": json.dumps(dashboards, indent=2, cls=_HAJSONEncoder)}
+            ]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing dashboards: {str(e)}"}]}
 
@@ -58,7 +62,9 @@ async def get_dashboard_config_tool(
 
     try:
         config = await get_dashboard_config(hass, arguments["url_path"])
-        return {"content": [{"type": "text", "text": json.dumps(config, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(config, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting dashboard config: {str(e)}"}]}
 

--- a/custom_components/mcp_server_http_transport/tools/dashboards.py
+++ b/custom_components/mcp_server_http_transport/tools/dashboards.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from . import register_tool
+from . import _HAJSONEncoder, register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -
 
     try:
         dashboards = await list_dashboards(hass)
-        return {"content": [{"type": "text", "text": json.dumps(dashboards, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(dashboards, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing dashboards: {str(e)}"}]}
 
@@ -58,7 +58,7 @@ async def get_dashboard_config_tool(
 
     try:
         config = await get_dashboard_config(hass, arguments["url_path"])
-        return {"content": [{"type": "text", "text": json.dumps(config, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(config, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting dashboard config: {str(e)}"}]}
 
@@ -199,7 +199,7 @@ async def create_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) 
                     "type": "text",
                     "text": (
                         f"Successfully created dashboard '{arguments['url_path']}': "
-                        f"{json.dumps(item, indent=2)}"
+                        f"{json.dumps(item, indent=2, cls=_HAJSONEncoder)}"
                     ),
                 }
             ]
@@ -256,7 +256,7 @@ async def update_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) 
                     "type": "text",
                     "text": (
                         f"Successfully updated dashboard '{url_path}': "
-                        f"{json.dumps(item, indent=2)}"
+                        f"{json.dumps(item, indent=2, cls=_HAJSONEncoder)}"
                     ),
                 }
             ]

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -10,7 +10,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import label_registry as lr
 
-from . import register_tool
+from . import _HAJSONEncoder, register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,7 +72,7 @@ async def get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str,
         "last_updated": state.last_updated.isoformat(),
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -200,7 +200,7 @@ async def list_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
             }
         entities.append(entity)
 
-    return {"content": [{"type": "text", "text": json.dumps(entities, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -223,7 +223,7 @@ async def list_areas(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         for area in registry.async_list_areas()
     ]
 
-    return {"content": [{"type": "text", "text": json.dumps(areas, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(areas, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -259,7 +259,7 @@ async def list_devices(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             }
         )
 
-    return {"content": [{"type": "text", "text": json.dumps(devices, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(devices, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -288,7 +288,7 @@ async def list_services(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
     for domain, domain_services in services.items():
         result[domain] = list(domain_services.keys())
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -394,7 +394,7 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         if len(entities) >= limit:
             break
 
-    return {"content": [{"type": "text", "text": json.dumps(entities, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -422,7 +422,7 @@ async def list_labels(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
         for label in registry.async_list_labels()
     ]
 
-    return {"content": [{"type": "text", "text": json.dumps(labels, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(labels, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -472,4 +472,4 @@ async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
             }
         )
 
-    return {"content": [{"type": "text", "text": json.dumps(results, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(results, indent=2, cls=_HAJSONEncoder)}]}

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -200,7 +200,9 @@ async def list_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
             }
         entities.append(entity)
 
-    return {"content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]}
+    return {
+        "content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]
+    }
 
 
 @register_tool(
@@ -259,7 +261,9 @@ async def list_devices(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             }
         )
 
-    return {"content": [{"type": "text", "text": json.dumps(devices, indent=2, cls=_HAJSONEncoder)}]}
+    return {
+        "content": [{"type": "text", "text": json.dumps(devices, indent=2, cls=_HAJSONEncoder)}]
+    }
 
 
 @register_tool(
@@ -394,7 +398,9 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         if len(entities) >= limit:
             break
 
-    return {"content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]}
+    return {
+        "content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]
+    }
 
 
 @register_tool(
@@ -472,4 +478,6 @@ async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
             }
         )
 
-    return {"content": [{"type": "text", "text": json.dumps(results, indent=2, cls=_HAJSONEncoder)}]}
+    return {
+        "content": [{"type": "text", "text": json.dumps(results, indent=2, cls=_HAJSONEncoder)}]
+    }

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from . import register_tool
+from . import _HAJSONEncoder, register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
                     entry[key] = stat[key]
             result.append(entry)
 
-        return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         _LOGGER.error("Error getting statistics: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting statistics: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -93,7 +93,9 @@ async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
                     entry[key] = stat[key]
             result.append(entry)
 
-        return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         _LOGGER.error("Error getting statistics: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting statistics: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/system.py
+++ b/custom_components/mcp_server_http_transport/tools/system.py
@@ -9,7 +9,7 @@ from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from . import register_tool
+from . import _HAJSONEncoder, register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ async def get_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         "language": config.language,
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -124,7 +124,7 @@ async def get_history(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
                     "attributes": dict(state.attributes),
                 }
             )
-        return {"content": [{"type": "text", "text": json.dumps(history, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(history, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         _LOGGER.error("Error getting history: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting history: {str(e)}"}]}
@@ -243,7 +243,7 @@ async def get_logbook(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
             processor.get_events, start_time, end_time
         )
 
-        return {"content": [{"type": "text", "text": json.dumps(events, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(events, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         _LOGGER.error("Error getting logbook: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting logbook: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/system.py
+++ b/custom_components/mcp_server_http_transport/tools/system.py
@@ -124,7 +124,9 @@ async def get_history(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
                     "attributes": dict(state.attributes),
                 }
             )
-        return {"content": [{"type": "text", "text": json.dumps(history, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(history, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         _LOGGER.error("Error getting history: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting history: {str(e)}"}]}
@@ -243,7 +245,9 @@ async def get_logbook(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
             processor.get_events, start_time, end_time
         )
 
-        return {"content": [{"type": "text", "text": json.dumps(events, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(events, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         _LOGGER.error("Error getting logbook: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting logbook: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/system_admin.py
+++ b/custom_components/mcp_server_http_transport/tools/system_admin.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 
-from . import register_tool
+from . import _HAJSONEncoder, register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ async def get_system_status(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         "integration_count": integration_count,
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -173,7 +173,7 @@ async def get_domain_stats(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         "examples": examples,
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -198,7 +198,7 @@ async def check_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             "valid": len(errors) == 0,
             "errors": errors,
         }
-        return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+        return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
     except Exception as e:
         _LOGGER.error("Error checking config: %s", e)
         return {"content": [{"type": "text", "text": f"Error checking config: {str(e)}"}]}
@@ -225,4 +225,4 @@ async def list_integrations(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         for entry in entries
     ]
 
-    return {"content": [{"type": "text", "text": json.dumps(integrations, indent=2)}]}
+    return {"content": [{"type": "text", "text": json.dumps(integrations, indent=2, cls=_HAJSONEncoder)}]}

--- a/custom_components/mcp_server_http_transport/tools/system_admin.py
+++ b/custom_components/mcp_server_http_transport/tools/system_admin.py
@@ -198,7 +198,9 @@ async def check_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             "valid": len(errors) == 0,
             "errors": errors,
         }
-        return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+        return {
+            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
+        }
     except Exception as e:
         _LOGGER.error("Error checking config: %s", e)
         return {"content": [{"type": "text", "text": f"Error checking config: {str(e)}"}]}
@@ -225,4 +227,8 @@ async def list_integrations(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         for entry in entries
     ]
 
-    return {"content": [{"type": "text", "text": json.dumps(integrations, indent=2, cls=_HAJSONEncoder)}]}
+    return {
+        "content": [
+            {"type": "text", "text": json.dumps(integrations, indent=2, cls=_HAJSONEncoder)}
+        ]
+    }


### PR DESCRIPTION
# Summary
This fixes `Internal error: Object of type datetime is not JSON serializable` when MCP tools serialize Home Assistant state attributes containing `datetime`/`date` values.

```
 [info] Connection state: Error 500 status sending message to http://homeassistant.home.lan:8123/api/mcp: {"jsonrpc": "2.0", "error": {"code": -32603, "message": "Internal error: Object of type datetime is not JSON serializable"}, "id": 4}
```

# Changes
- Add a shared JSON encoder in `tools/__init__.py` for `datetime`/`date` -> ISO8601 strings
- Use that encoder in `json.dumps` calls across:
  - `tools/entities.py`
  - `tools/system.py`
  - `tools/system_admin.py`
  - `tools/statistics.py`
  - `tools/config.py`
  - `tools/dashboards.py`

# Why
Some Home Assistant state attributes include native `datetime`/`date` objects. Default JSON encoding fails and can return HTTP 500 for affected tool calls.

# Related
Related to #28 context (HA 2026.4 MCP breakages), but this addresses a separate serialization path.

# Validation
- Reproduced failure with `batch_get_state` returning HTTP 500 when attributes contain datetime values
- Verified successful responses after this encoder change