### PR TITLE
fix: Handle set/frozenset in _HAJSONEncoder

### DIFF
--- a/custom_components/mcp_server_http_transport/json_utils.py
+++ b/custom_components/mcp_server_http_transport/json_utils.py
@@ -13,4 +13,6 @@ class _HAJSONEncoder(json.JSONEncoder):
             return o.isoformat()
         if isinstance(o, date):
             return o.isoformat()
+        if isinstance(o, (set, frozenset)):
+            return sorted(o) if all(isinstance(x, str) for x in o) else list(o)
         return super().default(o)


### PR DESCRIPTION
## Summary

Extends the shared `_HAJSONEncoder` introduced in #36 to also handle `set` and `frozenset` objects, which fixes a reproducible HTTP 500 on `batch_get_state` (and anywhere else the encoder is used) when entity attributes contain Python sets.

## Reproduction

Any Hue Bridge Pro-managed group entity (`is_hue_group: true`) exposes a `hue_scenes` attribute as a Python `set`. Calling `batch_get_state` on such an entity fails after #36:

    File "/config/custom_components/mcp_server_http_transport/json_utils.py", line 15, in default
      return super().default(o)
    TypeError: Object of type set is not JSON serializable
    when serializing dict item 'hue_scenes'
    when serializing dict item 'attributes'

Verified on:

- hass-mcp-server v1.7.2
- Home Assistant 2026.4.x (HAOS)
- Python 3.14
- Hue Bridge Pro via the `hue` integration (13 group entities affected in my setup)

## Fix

Three lines in `json_utils.py`:

    if isinstance(o, (set, frozenset)):
        return sorted(o) if all(isinstance(x, str) for x in o) else list(o)

String-only sets are sorted for stable, diff-friendly output (useful for caching and snapshot testing). Mixed/non-string sets fall back to `list()` which preserves behavior without guaranteeing order.

No changes needed at call sites — all of them already use `cls=_HAJSONEncoder` after #36.

## Verification

After applying the patch locally, `batch_get_state` on Hue Bridge Pro groups returns clean JSON with `hue_scenes` serialized as a sorted array:

    "hue_scenes": [
      "Energie tanken",
      "Entspannen",
      "Frühlingsblüten",
      ...
    ]

No regression on non-set entities observed.