### PR TITLE
test: regression tests for _HAJSONEncoder

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.7.2"
+  "version": "1.7.3"
 }

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.7.3"
+  "version": "1.7.2"
 }

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,56 @@
+"""Tests for the shared _HAJSONEncoder."""
+
+import json
+from datetime import date, datetime
+
+import pytest
+
+from custom_components.mcp_server_http_transport.json_utils import _HAJSONEncoder
+
+
+class TestHAJSONEncoder:
+    """Test _HAJSONEncoder handles HA state attribute types."""
+
+    def test_encodes_datetime_as_isoformat(self):
+        value = datetime(2024, 6, 15, 8, 30, 45)
+        assert json.dumps(value, cls=_HAJSONEncoder) == '"2024-06-15T08:30:45"'
+
+    def test_encodes_date_as_isoformat(self):
+        value = date(2024, 6, 15)
+        assert json.dumps(value, cls=_HAJSONEncoder) == '"2024-06-15"'
+
+    def test_encodes_string_set_as_sorted_array(self):
+        # Regression: Hue Bridge Pro groups expose `hue_scenes` as a set of
+        # strings. Sorting gives stable, diff-friendly output.
+        value = {"Entspannen", "Energie tanken", "Frühlingsblüten"}
+        assert json.loads(json.dumps(value, cls=_HAJSONEncoder)) == [
+            "Energie tanken",
+            "Entspannen",
+            "Frühlingsblüten",
+        ]
+
+    def test_encodes_string_frozenset_as_sorted_array(self):
+        value = frozenset({"b", "a", "c"})
+        assert json.loads(json.dumps(value, cls=_HAJSONEncoder)) == ["a", "b", "c"]
+
+    def test_encodes_empty_set_as_empty_array(self):
+        assert json.dumps(set(), cls=_HAJSONEncoder) == "[]"
+
+    def test_encodes_mixed_type_set_as_unsorted_array(self):
+        # Mixed types can't be sorted across types in Python 3, so we fall
+        # back to list() without guaranteeing order.
+        value = {1, "two"}
+        decoded = json.loads(json.dumps(value, cls=_HAJSONEncoder))
+        assert sorted(decoded, key=str) == [1, "two"]
+
+    def test_encodes_nested_set_inside_dict(self):
+        value = {"hue_scenes": {"a", "b"}, "brightness": 255}
+        decoded = json.loads(json.dumps(value, cls=_HAJSONEncoder))
+        assert decoded == {"hue_scenes": ["a", "b"], "brightness": 255}
+
+    def test_raises_type_error_for_unhandled_types(self):
+        class CustomType:
+            pass
+
+        with pytest.raises(TypeError):
+            json.dumps(CustomType(), cls=_HAJSONEncoder)

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -1026,6 +1026,65 @@ class TestToolsEntities:
         assert data[1]["entity_id"] == "light.nonexistent"
         assert data[1]["error"] == "not found"
 
+    async def test_post_tools_call_batch_get_state_with_set_attribute(self, view, mock_hass):
+        """Regression for PR #38: batch_get_state must serialize set attributes.
+
+        Hue Bridge Pro groups expose `hue_scenes` as a Python set. Before the
+        encoder handled sets, this path raised TypeError and returned HTTP 500.
+        """
+        mock_state = Mock()
+        mock_state.entity_id = "light.hue_group"
+        mock_state.state = "on"
+        mock_state.attributes = {
+            "is_hue_group": True,
+            "hue_scenes": {"Entspannen", "Energie tanken", "Frühlingsblüten"},
+        }
+        mock_state.last_changed = datetime(2024, 1, 1, 12, 0, 0)
+        mock_state.last_updated = datetime(2024, 1, 1, 12, 0, 0)
+
+        mock_hass.states.get = lambda entity_id: (
+            mock_state if entity_id == "light.hue_group" else None
+        )
+
+        mock_entry = Mock()
+        mock_entry.aliases = []
+        mock_er = Mock()
+        mock_er.async_get.return_value = mock_entry
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "batch_get_state",
+                    "arguments": {"entity_ids": ["light.hue_group"]},
+                },
+                "id": 219,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.er.async_get",
+                return_value=mock_er,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert len(data) == 1
+        assert data[0]["entity_id"] == "light.hue_group"
+        assert data[0]["attributes"]["hue_scenes"] == [
+            "Energie tanken",
+            "Entspannen",
+            "Frühlingsblüten",
+        ]
+
     async def test_post_tools_call_batch_get_state_exceeds_limit(self, view, mock_hass):
         """Test POST with tools/call for batch_get_state exceeding 50 limit."""
         entity_ids = [f"light.light_{i}" for i in range(51)]


### PR DESCRIPTION
Adds regression coverage for the JSON encoder that landed in #36 and was extended for sets in #38. Reviewing #38 highlighted that we had no unit or integration tests pinning the encoder's behavior, so any future refactor could silently reintroduce the HTTP 500 on exotic HA attribute types.

Two layers:

- **Unit** — `tests/test_json_utils.py` exercises `_HAJSONEncoder` directly: `datetime`, `date`, sorted string-set, sorted string-frozenset, empty set, mixed-type set fallback, nested set inside a dict, and confirms unhandled types still raise `TypeError` (no silent fallbacks).
- **Integration** — `test_post_tools_call_batch_get_state_with_set_attribute` in `tests/test_tools_entities.py` mirrors the exact #38 scenario: a mock state with `hue_scenes` as a set, routed through `batch_get_state`, asserting HTTP 200 and the set surfacing as a sorted array. Protects against regressions via any path (encoder change, call-site change, bypassing `cls=_HAJSONEncoder`).

Version bump will ship in the follow-up PR that fixes #37 and #26.

Full suite: 308 passed, ruff/black clean.