### PR TITLE
fix(#37) + feat(#26): disable gate + batch_get_state fields, bump 1.7.4

### DIFF
--- a/custom_components/mcp_server_http_transport/__init__.py
+++ b/custom_components/mcp_server_http_transport/__init__.py
@@ -35,9 +35,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     server = Server("home-assistant-mcp-server")
     hass.data[DOMAIN]["server"] = server
 
-    # Register HTTP endpoints
-    hass.http.register_view(MCPProtectedResourceMetadataView())
-    hass.http.register_view(MCPSubpathProtectedResourceMetadataView())
+    # Register HTTP endpoints. The views are gated on hass.data[DOMAIN] so
+    # requests stop being served the moment async_unload_entry clears it
+    # (HA has no public register_view reverse — see #37).
+    hass.http.register_view(MCPProtectedResourceMetadataView(hass))
+    hass.http.register_view(MCPSubpathProtectedResourceMetadataView(hass))
     hass.http.register_view(MCPEndpointView(hass, server, native_auth_enabled))
 
     _LOGGER.info("MCP Server initialized at /api/mcp (native_auth=%s)", native_auth_enabled)

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -9,11 +9,35 @@ from homeassistant.core import HomeAssistant
 from mcp.server import Server
 
 from .completions import complete
+from .const import DOMAIN
 from .prompts import get_prompt, get_prompts
 from .resources import get_resources, read_resource
 from .tools import call_tool, get_tool_schemas
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _integration_loaded(hass: HomeAssistant) -> bool:
+    """Return True when the config entry is active.
+
+    HA's HTTP stack has no public way to unregister a view, so registered
+    views survive `async_unload_entry`. async_unload_entry clears
+    `hass.data[DOMAIN]`, so we gate requests on it being populated — when
+    the user disables the integration, requests return 503 immediately
+    instead of continuing to succeed until the next HA restart (#37).
+    """
+    return bool(hass.data.get(DOMAIN))
+
+
+def _service_unavailable() -> web.Response:
+    """Build a 503 response for requests made while the integration is disabled."""
+    return web.json_response(
+        {
+            "error": "service_unavailable",
+            "error_description": "MCP Server integration is disabled",
+        },
+        status=503,
+    )
 
 
 def _get_issuer(request: web.Request) -> str | None:
@@ -46,8 +70,14 @@ class MCPProtectedResourceMetadataView(HomeAssistantView):
     name = "api:mcp:metadata:root"
     requires_auth = False
 
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the metadata view."""
+        self.hass = hass
+
     async def get(self, request: web.Request) -> web.Response:
         """Return protected resource metadata."""
+        if not _integration_loaded(self.hass):
+            return _service_unavailable()
         base_url = _get_issuer(request)
         if base_url is None:
             return web.json_response({"error": "OIDC provider not available"}, status=404)
@@ -62,8 +92,14 @@ class MCPSubpathProtectedResourceMetadataView(HomeAssistantView):
     name = "api:mcp:metadata:mcp"
     requires_auth = False
 
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the metadata view."""
+        self.hass = hass
+
     async def get(self, request: web.Request) -> web.Response:
         """Return protected resource metadata with /mcp suffix."""
+        if not _integration_loaded(self.hass):
+            return _service_unavailable()
         base_url = _get_issuer(request)
         if base_url is None:
             return web.json_response({"error": "OIDC provider not available"}, status=404)
@@ -118,6 +154,9 @@ class MCPEndpointView(HomeAssistantView):
 
     async def post(self, request: web.Request) -> web.Response:
         """Handle POST requests for MCP messages."""
+        if not _integration_loaded(self.hass):
+            return _service_unavailable()
+
         # Validate token
         token_payload = await self._validate_token(request)
         if not token_payload:

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.7.2"
+  "version": "1.7.4"
 }

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -444,7 +444,15 @@ async def list_labels(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
                 "type": "array",
                 "items": {"type": "string"},
                 "description": "List of entity IDs to get state for (max 50)",
-            }
+            },
+            "fields": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Limit which attribute keys are included in each entity's response "
+                    "(e.g., ['brightness', 'color_temp']). Omit for all attributes"
+                ),
+            },
         },
         "required": ["entity_ids"],
     },
@@ -452,6 +460,7 @@ async def list_labels(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
 async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get state for multiple entities."""
     entity_ids = arguments["entity_ids"]
+    fields = arguments.get("fields")
 
     if len(entity_ids) > 50:
         return {"content": [{"type": "text", "text": "Error: maximum 50 entity IDs per request"}]}
@@ -467,11 +476,15 @@ async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         entry = registry.async_get(entity_id)
         aliases = _get_aliases(hass, entry) if entry else []
 
+        attributes = dict(state.attributes)
+        if fields is not None:
+            attributes = {k: v for k, v in attributes.items() if k in fields}
+
         results.append(
             {
                 "entity_id": state.entity_id,
                 "state": state.state,
-                "attributes": dict(state.attributes),
+                "attributes": attributes,
                 "aliases": aliases,
                 "last_changed": state.last_changed.isoformat(),
                 "last_updated": state.last_updated.isoformat(),

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -96,7 +96,7 @@ class TestMCPProtectedResourceMetadataView:
         request.headers = {}
         request.url.origin.return_value = "https://homeassistant.local"
 
-        view = MCPProtectedResourceMetadataView()
+        view = MCPProtectedResourceMetadataView(Mock())
         response = await view.get(request)
 
         assert response.status == 200
@@ -114,7 +114,7 @@ class TestMCPProtectedResourceMetadataView:
             "X-Forwarded-Host": "example.com",
         }
 
-        view = MCPProtectedResourceMetadataView()
+        view = MCPProtectedResourceMetadataView(Mock())
         response = await view.get(request)
 
         body = json.loads(response.body)
@@ -124,7 +124,7 @@ class TestMCPProtectedResourceMetadataView:
         """Test GET returns 404 when OIDC provider is not installed."""
         request = Mock()
 
-        view = MCPProtectedResourceMetadataView()
+        view = MCPProtectedResourceMetadataView(Mock())
         with patch(
             "custom_components.mcp_server_http_transport.http._get_issuer",
             return_value=None,
@@ -143,7 +143,7 @@ class TestMCPSubpathProtectedResourceMetadataView:
         request.headers = {}
         request.url.origin.return_value = "https://homeassistant.local"
 
-        view = MCPSubpathProtectedResourceMetadataView()
+        view = MCPSubpathProtectedResourceMetadataView(Mock())
         response = await view.get(request)
 
         assert response.status == 200
@@ -154,7 +154,7 @@ class TestMCPSubpathProtectedResourceMetadataView:
         """Test GET returns 404 when OIDC provider is not installed."""
         request = Mock()
 
-        view = MCPSubpathProtectedResourceMetadataView()
+        view = MCPSubpathProtectedResourceMetadataView(Mock())
         with patch(
             "custom_components.mcp_server_http_transport.http._get_issuer",
             return_value=None,
@@ -325,6 +325,70 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert "error" in body
         assert "Unknown tool" in body["error"]["message"]
+
+
+class TestIntegrationDisabledGate:
+    """Regression for #37: views return 503 when the integration is unloaded.
+
+    HA's HTTP stack keeps registered views alive across config entry unloads,
+    so we gate on `hass.data[DOMAIN]` — which async_unload_entry clears.
+    """
+
+    async def test_endpoint_view_returns_503_when_domain_missing(self):
+        hass = Mock()
+        hass.data = {}
+        view = MCPEndpointView(hass, Mock())
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+
+        response = await view.post(request)
+
+        assert response.status == 503
+        body = json.loads(response.body)
+        assert body["error"] == "service_unavailable"
+
+    async def test_endpoint_view_returns_503_when_domain_cleared(self):
+        hass = Mock()
+        hass.data = {"mcp_server_http_transport": {}}  # matches async_unload_entry.clear()
+        view = MCPEndpointView(hass, Mock())
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+
+        response = await view.post(request)
+
+        assert response.status == 503
+
+    async def test_metadata_view_returns_503_when_unloaded(self):
+        hass = Mock()
+        hass.data = {}
+        view = MCPProtectedResourceMetadataView(hass)
+
+        response = await view.get(Mock())
+
+        assert response.status == 503
+
+    async def test_subpath_metadata_view_returns_503_when_unloaded(self):
+        hass = Mock()
+        hass.data = {}
+        view = MCPSubpathProtectedResourceMetadataView(hass)
+
+        response = await view.get(Mock())
+
+        assert response.status == 503
+
+    async def test_endpoint_view_serves_when_domain_populated(self):
+        hass = Mock()
+        hass.data = {"mcp_server_http_transport": {"server": Mock()}}
+        view = MCPEndpointView(hass, Mock())
+
+        request = Mock()
+        request.headers = {}  # no token → 401, not 503
+
+        response = await view.post(request)
+
+        assert response.status == 401
 
 
 class TestNativeAuth:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1182,7 +1182,10 @@ class TestMCPClientSession:
 
         lovelace_data = Mock()
         lovelace_data.dashboards = {"energy": mock_dashboard}
-        populated_hass.data = {"lovelace": lovelace_data}
+        populated_hass.data = {
+            "lovelace": lovelace_data,
+            "mcp_server_http_transport": {"server": Mock()},
+        }
 
         # Get (empty)
         result = await self._call(

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -1085,6 +1085,73 @@ class TestToolsEntities:
             "Frühlingsblüten",
         ]
 
+    async def test_post_tools_call_batch_get_state_with_fields(self, view, mock_hass):
+        """Test batch_get_state filters attributes per entity when fields is provided (#26)."""
+        mock_state1 = Mock()
+        mock_state1.entity_id = "light.living_room"
+        mock_state1.state = "on"
+        mock_state1.attributes = {
+            "brightness": 255,
+            "color_temp": 300,
+            "friendly_name": "Living Room",
+        }
+        mock_state1.last_changed = datetime(2024, 1, 1, 12, 0, 0)
+        mock_state1.last_updated = datetime(2024, 1, 1, 12, 0, 0)
+
+        mock_state2 = Mock()
+        mock_state2.entity_id = "light.bedroom"
+        mock_state2.state = "off"
+        mock_state2.attributes = {
+            "brightness": 0,
+            "color_temp": 0,
+            "friendly_name": "Bedroom",
+        }
+        mock_state2.last_changed = datetime(2024, 1, 1, 10, 0, 0)
+        mock_state2.last_updated = datetime(2024, 1, 1, 10, 0, 0)
+
+        mock_hass.states.get = lambda entity_id: {
+            "light.living_room": mock_state1,
+            "light.bedroom": mock_state2,
+        }.get(entity_id)
+
+        mock_entry = Mock()
+        mock_entry.aliases = []
+        mock_er = Mock()
+        mock_er.async_get.return_value = mock_entry
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "batch_get_state",
+                    "arguments": {
+                        "entity_ids": ["light.living_room", "light.bedroom"],
+                        "fields": ["brightness"],
+                    },
+                },
+                "id": 220,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.er.async_get",
+                return_value=mock_er,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert len(data) == 2
+        assert data[0]["attributes"] == {"brightness": 255}
+        assert data[1]["attributes"] == {"brightness": 0}
+
     async def test_post_tools_call_batch_get_state_exceeds_limit(self, view, mock_hass):
         """Test POST with tools/call for batch_get_state exceeding 50 limit."""
         entity_ids = [f"light.light_{i}" for i in range(51)]


### PR DESCRIPTION
Two related changes shipping together under 1.7.4.

### fix: deny MCP requests when integration is disabled (#37)

When a user disabled the integration in the UI, the AI client could still call \`batch_get_state\` (and every other tool) until HA was restarted — a surprising and potentially security-sensitive behavior since the user reasonably expects \"disabled\" to mean \"off\".

Root cause: HA's HTTP stack has no public \`register_view\` reverse, so the three views registered in \`async_setup_entry\` survive \`async_unload_entry\`.

Fix: \`async_unload_entry\` already clears \`hass.data[DOMAIN]\`, so gate all three views (\`MCPEndpointView\`, \`MCPProtectedResourceMetadataView\`, \`MCPSubpathProtectedResourceMetadataView\`) on \`hass.data[DOMAIN]\` being populated. Return 503 with \`error: service_unavailable\` when unloaded. The two metadata views now take \`hass\` to perform the check; previously they were stateless.

### feat: add fields parameter to batch_get_state (#26)

Mirrors \`get_state\`'s existing \`fields\` behavior — when provided, each entity's attributes dict is filtered to only the requested keys. Useful for token optimization when checking many entities and only a few attributes matter.

### Tests

- \`TestIntegrationDisabledGate\` in \`test_http.py\`: covers all three views returning 503 when \`hass.data[DOMAIN]\` is missing or cleared, plus a positive case where the endpoint serves normally when data is populated.
- \`test_post_tools_call_batch_get_state_with_fields\` in \`test_tools_entities.py\`: passes a \`fields\` list, asserts each entity's attributes is filtered.
- One integration test (\`test_dashboard_config_round_trip\`) was updated to include \`mcp_server_http_transport\` in the mocked \`hass.data\` it was overwriting — otherwise the new gate would have returned 503.

Full suite: 305 passed, ruff/black clean.