### PR TITLE
feat: add CRUD tools for Home Assistant helper entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,17 +92,25 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 
 ### Tools
 
+**Entities & State**
+
 | Tool | Description |
 |------|-------------|
 | `get_state` | Get the current state of any entity (optional `fields` to limit attributes) |
-| `call_service` | Call any Home Assistant service |
+| `batch_get_state` | Get state for multiple entities in one call (max 50) |
 | `list_entities` | List all entities, with optional `domain`, `detailed`, and `fields` parameters |
-| `get_config` | Get Home Assistant configuration (version, location, units, timezone) |
-| `list_areas` | List all areas |
-| `list_devices` | List devices, optionally filtered by area |
-| `list_services` | List available services, optionally filtered by domain |
-| `render_template` | Evaluate a Jinja2 template |
+| `search_entities` | Search entities by friendly name, device class, domain, or area |
+| `call_service` | Call any Home Assistant service |
+| `fire_event` | Fire a custom event on the Home Assistant event bus |
 | `get_history` | Get state history of an entity over a time range |
+| `get_logbook` | Fetch logbook entries for an entity or time range |
+| `get_statistics` | Fetch long-term statistics (energy, climate) with configurable period |
+| `render_template` | Evaluate a Jinja2 template |
+
+**Automations, Scenes & Scripts**
+
+| Tool | Description |
+|------|-------------|
 | `list_automations` | List all automations with full configuration |
 | `get_automation_config` | Get full configuration of a single automation |
 | `create_automation` | Create a new automation |
@@ -118,6 +126,21 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `create_script` | Create a new script |
 | `update_script` | Update an existing script |
 | `delete_script` | Delete a script |
+
+**Helpers**
+
+| Tool | Description |
+|------|-------------|
+| `list_helpers` | List all helper entities, optionally filtered by domain |
+| `get_helper_config` | Get the raw stored configuration of a UI-managed helper |
+| `create_helper` | Create a new helper (input_boolean, input_number, input_text, input_select, input_datetime, input_button, counter, timer, schedule) |
+| `update_helper` | Update an existing UI-managed helper by entity ID |
+| `delete_helper` | Delete a UI-managed helper by entity ID |
+
+**Dashboards**
+
+| Tool | Description |
+|------|-------------|
 | `list_dashboards` | List all Lovelace dashboards with metadata |
 | `get_dashboard_config` | Get full dashboard configuration (views/cards) |
 | `save_dashboard_config` | Save (replace) full dashboard configuration |
@@ -125,23 +148,22 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `create_dashboard` | Create a new Lovelace dashboard (experimental) |
 | `update_dashboard` | Update dashboard metadata (experimental) |
 | `delete_dashboard` | Delete a dashboard and its config (experimental) |
-| `search_entities` | Search entities by friendly name, device class, domain, or area |
-| `fire_event` | Fire a custom event on the Home Assistant event bus |
-| `get_logbook` | Fetch logbook entries for an entity or time range |
-| `get_error_log` | Fetch the Home Assistant error log (last N lines) |
-| `restart_ha` | Restart Home Assistant (requires explicit confirmation) |
+
+**System & Infrastructure**
+
+| Tool | Description |
+|------|-------------|
+| `get_config` | Get Home Assistant configuration (version, location, units, timezone) |
 | `get_system_status` | System overview: version, domain counts, entity totals, problem entities |
 | `get_domain_stats` | Aggregate stats for a single domain (count, state breakdown, examples) |
 | `check_config` | Validate Home Assistant configuration without restarting |
-| `get_statistics` | Fetch long-term statistics (energy, climate) with configurable period |
+| `restart_ha` | Restart Home Assistant (requires explicit confirmation) |
+| `get_error_log` | Fetch the Home Assistant error log (last N lines) |
+| `list_areas` | List all areas |
+| `list_devices` | List devices, optionally filtered by area |
+| `list_services` | List available services, optionally filtered by domain |
 | `list_integrations` | List installed integrations and their status |
 | `list_labels` | List all labels for cross-domain grouping |
-| `batch_get_state` | Get state for multiple entities in one call (max 50) |
-| `list_helpers` | List all helper entities, optionally filtered by domain |
-| `get_helper_config` | Get the raw stored configuration of a UI-managed helper |
-| `create_helper` | Create a new helper (input_boolean, input_number, input_text, input_select, input_datetime, input_button, counter, timer, schedule) |
-| `update_helper` | Update an existing UI-managed helper by entity ID |
-| `delete_helper` | Delete a UI-managed helper by entity ID |
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Home Assistant Custom Component that provides an MCP (Model Context Protocol) 
 - 🔑 **Long-Lived Access Token** authentication (opt-in) for local and custom client setups
 - 🏠 Full Home Assistant API access (entities, services, areas, devices, history, statistics)
 - 🔧 Easy HACS installation
-- 📝 CRUD management of automations, scenes, scripts, and helper entities
+- 📝 CRUD management of automations, scenes, scripts, and helper entities (input_boolean, counter, timer, schedule, and more)
 - 📋 Lovelace dashboard management (list, get/save/delete config, create/update/delete dashboards)
 - 🩺 System administration tools (error log, config validation, restart, system status)
 - 📊 Resources, prompts, and completions for richer AI interactions

--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | Tool | Description |
 |------|-------------|
 | `list_helpers` | List all helper entities, optionally filtered by domain |
-| `get_helper_config` | Get the raw stored configuration of a UI-managed helper |
-| `create_helper` | Create a new helper (input_boolean, input_number, input_text, input_select, input_datetime, input_button, counter, timer, schedule) |
-| `update_helper` | Update an existing UI-managed helper by entity ID |
-| `delete_helper` | Delete a UI-managed helper by entity ID |
+| `get_helper_config` | Get the raw stored configuration of a UI-managed helper (experimental) |
+| `create_helper` | Create a new helper (input_boolean, input_number, input_text, input_select, input_datetime, input_button, counter, timer, schedule) (experimental) |
+| `update_helper` | Update an existing UI-managed helper by entity ID (experimental) |
+| `delete_helper` | Delete a UI-managed helper by entity ID (experimental) |
 
 **Dashboards**
 
@@ -311,9 +311,13 @@ delete_helper(entity_id="counter.motion_events")
 </details>
 
 <details>
-<summary>What does "experimental" mean for dashboard tools?</summary>
+<summary>What does "experimental" mean for some tools?</summary>
 
-The `create_dashboard`, `update_dashboard`, and `delete_dashboard` tools use internal Home Assistant APIs (`DashboardsCollection`) that are not publicly exposed. They replicate side effects (panel registration, dashboards dict updates) that HA normally handles internally. These may break with HA updates that change internal behavior. The config-level tools (`list_dashboards`, `get/save/delete_dashboard_config`) use stable public APIs.
+Some tools use internal Home Assistant APIs that are not publicly exposed and may break with future HA updates.
+
+**Dashboard tools:** `create_dashboard`, `update_dashboard`, and `delete_dashboard` use `DashboardsCollection` and replicate side effects (panel registration, dashboards dict updates) that HA normally handles internally. The config-level tools (`list_dashboards`, `get/save/delete_dashboard_config`) use stable public APIs and are not experimental.
+
+**Helper tools:** `get_helper_config`, `create_helper`, `update_helper`, and `delete_helper` use `StorageCollection` internals to manage UI-created helpers. They only affect helpers stored in `.storage/` — helpers defined in YAML are read-only from the perspective of these tools. `list_helpers` uses public APIs and is not experimental.
 </details>
 
 ## License

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Home Assistant Custom Component that provides an MCP (Model Context Protocol) 
 - 🔑 **Long-Lived Access Token** authentication (opt-in) for local and custom client setups
 - 🏠 Full Home Assistant API access (entities, services, areas, devices, history, statistics)
 - 🔧 Easy HACS installation
-- 📝 CRUD management of automations, scenes, and scripts
+- 📝 CRUD management of automations, scenes, scripts, and helper entities
 - 📋 Lovelace dashboard management (list, get/save/delete config, create/update/delete dashboards)
 - 🩺 System administration tools (error log, config validation, restart, system status)
 - 📊 Resources, prompts, and completions for richer AI interactions
@@ -137,6 +137,11 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `list_integrations` | List installed integrations and their status |
 | `list_labels` | List all labels for cross-domain grouping |
 | `batch_get_state` | Get state for multiple entities in one call (max 50) |
+| `list_helpers` | List all helper entities, optionally filtered by domain |
+| `get_helper_config` | Get the raw stored configuration of a UI-managed helper |
+| `create_helper` | Create a new helper (input_boolean, input_number, input_text, input_select, input_datetime, input_button, counter, timer, schedule) |
+| `update_helper` | Update an existing UI-managed helper by entity ID |
+| `delete_helper` | Delete a UI-managed helper by entity ID |
 
 ### Resources
 
@@ -174,7 +179,7 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 
 ### Completions
 
-Autocompletion is supported for `entity_id`, `entity_ids`, `domain`, `service`, `area_id`, `url_path`, `automation_id`, `scene_id`, script `key`, `trigger_type`, `period`, and `config_type` arguments.
+Autocompletion is supported for `entity_id`, `entity_ids`, `domain`, `service`, `area_id`, `url_path`, `automation_id`, `scene_id`, script `key`, `trigger_type`, `period`, `config_type`, and helper `domain` arguments.
 
 ## FAQ
 
@@ -251,6 +256,36 @@ save_dashboard_config(url_path="default", config={"views": [{"title": "Home", "c
 ```
 
 To create or delete dashboards themselves, use the experimental `create_dashboard` and `delete_dashboard` tools. These use internal HA APIs and may break with future HA updates.
+</details>
+
+<details>
+<summary>How do I manage helper entities (input_boolean, counter, timer, etc.)?</summary>
+
+Use `list_helpers` to see all helpers, optionally filtered by type:
+
+```
+list_helpers()                          // all helper types
+list_helpers(domain="input_boolean")    // only toggles
+```
+
+To create a helper, specify the domain and a config with at least a `name`:
+
+```json
+create_helper(domain="input_boolean", config={"name": "Vacation Mode", "icon": "mdi:palm-tree"})
+create_helper(domain="input_number", config={"name": "Target Temperature", "min": 15, "max": 30, "step": 0.5, "unit_of_measurement": "°C"})
+create_helper(domain="input_select", config={"name": "House Mode", "options": ["Home", "Away", "Sleep"]})
+create_helper(domain="counter", config={"name": "Motion Events", "initial": 0, "step": 1})
+create_helper(domain="timer", config={"name": "Cooking Timer", "duration": "00:30:00"})
+```
+
+To update or delete, use the entity ID:
+
+```json
+update_helper(entity_id="input_boolean.vacation_mode", config={"name": "Vacation Mode", "icon": "mdi:airplane"})
+delete_helper(entity_id="counter.motion_events")
+```
+
+> **Note:** These tools only manage UI-created helpers stored in Home Assistant's `.storage/` files. Helpers defined in YAML configuration are read-only from the perspective of these tools.
 </details>
 
 <details>

--- a/custom_components/mcp_server_http_transport/completions.py
+++ b/custom_components/mcp_server_http_transport/completions.py
@@ -22,6 +22,8 @@ async def complete(
         return _complete_entity_id(hass, arg_value)
 
     if arg_name == "domain":
+        if ref.get("name") == "create_helper":
+            return _complete_helper_domain(arg_value)
         return _complete_domain(hass, arg_value)
 
     if arg_name == "service":
@@ -43,9 +45,6 @@ async def complete(
         return _complete_config_type(arg_value)
 
     ref_name = ref.get("name", "")
-
-    if arg_name == "domain" and ref_name == "create_helper":
-        return _complete_helper_domain(arg_value)
 
     if arg_name == "automation_id" and ref_name in (
         "get_automation_config",

--- a/custom_components/mcp_server_http_transport/completions.py
+++ b/custom_components/mcp_server_http_transport/completions.py
@@ -44,6 +44,9 @@ async def complete(
 
     ref_name = ref.get("name", "")
 
+    if arg_name == "domain" and ref_name == "create_helper":
+        return _complete_helper_domain(arg_value)
+
     if arg_name == "automation_id" and ref_name in (
         "get_automation_config",
         "create_automation",
@@ -207,4 +210,23 @@ _CONFIG_TYPES = ["automation", "scene", "script"]
 def _complete_config_type(prefix: str) -> dict[str, Any]:
     """Complete configuration types."""
     matches = [c for c in _CONFIG_TYPES if c.startswith(prefix)]
+    return {"values": matches, "hasMore": False}
+
+
+_HELPER_DOMAINS = [
+    "counter",
+    "input_boolean",
+    "input_button",
+    "input_datetime",
+    "input_number",
+    "input_select",
+    "input_text",
+    "schedule",
+    "timer",
+]
+
+
+def _complete_helper_domain(prefix: str) -> dict[str, Any]:
+    """Complete helper domain names."""
+    matches = [d for d in _HELPER_DOMAINS if d.startswith(prefix)]
     return {"values": matches, "hasMore": False}

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -41,4 +41,12 @@ async def call_tool(hass: HomeAssistant, name: str, arguments: dict[str, Any]) -
 
 
 # Import submodules so tools auto-register via @register_tool
-from . import config, dashboards, entities, helpers, statistics, system, system_admin  # noqa: F401, E402
+from . import (  # noqa: E402
+    config,  # noqa: F401
+    dashboards,  # noqa: F401
+    entities,  # noqa: F401
+    helpers,  # noqa: F401
+    statistics,  # noqa: F401
+    system,  # noqa: F401
+    system_admin,  # noqa: F401
+)

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -41,4 +41,4 @@ async def call_tool(hass: HomeAssistant, name: str, arguments: dict[str, Any]) -
 
 
 # Import submodules so tools auto-register via @register_tool
-from . import config, dashboards, entities, statistics, system, system_admin  # noqa: F401, E402
+from . import config, dashboards, entities, helpers, statistics, system, system_admin  # noqa: F401, E402

--- a/custom_components/mcp_server_http_transport/tools/helpers.py
+++ b/custom_components/mcp_server_http_transport/tools/helpers.py
@@ -27,14 +27,32 @@ HELPER_DOMAINS = frozenset(
 
 
 def _get_collection(hass: HomeAssistant, domain: str):
-    """Return the storage collection for a helper domain, or raise."""
-    collection = hass.data.get(domain)
-    if collection is None or not hasattr(collection, "async_create_item"):
+    """Return the storage collection for a helper domain, or raise.
+
+    HA does not expose helper storage collections directly via hass.data[domain].
+    Instead, they are held inside StorageCollectionWebsocket instances whose
+    handlers are registered in hass.data["websocket_api"].  The list handler
+    is stored unwrapped, so we can reach the collection via its __self__.
+    """
+    ws_handlers = hass.data.get("websocket_api")
+    if ws_handlers is None:
+        raise ValueError("WebSocket API is not loaded")
+
+    entry = ws_handlers.get(f"{domain}/list")
+    if entry is None:
         raise ValueError(
-            f"Helper domain '{domain}' is not available. "
-            "Ensure the domain is loaded and is a UI-managed helper."
+            f"Helper domain '{domain}' is not available or not UI-managed. "
+            "Ensure the integration is loaded in Home Assistant."
         )
-    return collection
+
+    list_handler = entry[0]
+    ws_obj = getattr(list_handler, "__self__", None)
+    if ws_obj is None or not hasattr(ws_obj, "storage_collection"):
+        raise ValueError(
+            f"Cannot access storage collection for '{domain}' " "(unexpected handler structure)"
+        )
+
+    return ws_obj.storage_collection
 
 
 async def _entity_id_to_item_id(hass: HomeAssistant, entity_id: str) -> tuple[str, str]:

--- a/custom_components/mcp_server_http_transport/tools/helpers.py
+++ b/custom_components/mcp_server_http_transport/tools/helpers.py
@@ -1,0 +1,263 @@
+"""Helper entity CRUD tools (input_boolean, input_text, counter, timer, etc.)."""
+
+import json
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import _HAJSONEncoder, register_tool
+
+_LOGGER = logging.getLogger(__name__)
+
+HELPER_DOMAINS = frozenset(
+    {
+        "counter",
+        "input_boolean",
+        "input_button",
+        "input_datetime",
+        "input_number",
+        "input_select",
+        "input_text",
+        "schedule",
+        "timer",
+    }
+)
+
+
+def _get_collection(hass: HomeAssistant, domain: str):
+    """Return the storage collection for a helper domain, or raise."""
+    collection = hass.data.get(domain)
+    if collection is None or not hasattr(collection, "async_create_item"):
+        raise ValueError(
+            f"Helper domain '{domain}' is not available. "
+            "Ensure the domain is loaded and is a UI-managed helper."
+        )
+    return collection
+
+
+async def _entity_id_to_item_id(hass: HomeAssistant, entity_id: str) -> tuple[str, str]:
+    """Resolve entity_id to (domain, item_id) via the entity registry."""
+    domain = entity_id.split(".")[0]
+    if domain not in HELPER_DOMAINS:
+        raise ValueError(f"'{entity_id}' is not a helper entity (domain: {domain})")
+    registry = er.async_get(hass)
+    entry = registry.async_get(entity_id)
+    if entry is None:
+        raise ValueError(f"Entity '{entity_id}' not found in entity registry")
+    return domain, entry.unique_id
+
+
+@register_tool(
+    name="list_helpers",
+    description=(
+        "List all helper entities in Home Assistant "
+        "(input_boolean, input_number, input_text, input_select, "
+        "input_datetime, input_button, counter, timer, schedule). "
+        "Returns their current state and configuration"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "string",
+                "description": (
+                    "Filter by helper domain, e.g. 'input_boolean' or 'counter'. "
+                    "Omit to list all helper types"
+                ),
+            }
+        },
+    },
+)
+async def list_helpers(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """List helpers, optionally filtered by domain."""
+    domain_filter = arguments.get("domain")
+
+    if domain_filter and domain_filter not in HELPER_DOMAINS:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Unknown helper domain '{domain_filter}'. "
+                        f"Supported: {', '.join(sorted(HELPER_DOMAINS))}"
+                    ),
+                }
+            ]
+        }
+
+    domains = {domain_filter} if domain_filter else HELPER_DOMAINS
+    registry = er.async_get(hass)
+    helpers = []
+
+    for domain in sorted(domains):
+        for state in hass.states.async_all():
+            if not state.entity_id.startswith(f"{domain}."):
+                continue
+            entry = registry.async_get(state.entity_id)
+            helpers.append(
+                {
+                    "entity_id": state.entity_id,
+                    "domain": domain,
+                    "state": state.state,
+                    "friendly_name": state.attributes.get("friendly_name", state.entity_id),
+                    "attributes": dict(state.attributes),
+                    "unique_id": entry.unique_id if entry else None,
+                }
+            )
+
+    return {
+        "content": [{"type": "text", "text": json.dumps(helpers, indent=2, cls=_HAJSONEncoder)}]
+    }
+
+
+@register_tool(
+    name="get_helper_config",
+    description=(
+        "Get the full stored configuration of a UI-managed helper by its entity ID. "
+        "Returns the raw storage config, not just the current state"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "entity_id": {
+                "type": "string",
+                "description": "The helper entity ID (e.g., input_boolean.my_flag)",
+            }
+        },
+        "required": ["entity_id"],
+    },
+)
+async def get_helper_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Get a helper's stored config."""
+    try:
+        domain, item_id = await _entity_id_to_item_id(hass, arguments["entity_id"])
+        collection = _get_collection(hass, domain)
+        item = collection.data.get(item_id)
+        if item is None:
+            raise ValueError(
+                f"Helper '{arguments['entity_id']}' not found in storage "
+                "(it may be YAML-configured)"
+            )
+        return {
+            "content": [{"type": "text", "text": json.dumps(item, indent=2, cls=_HAJSONEncoder)}]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error getting helper config: {str(e)}"}]}
+
+
+@register_tool(
+    name="create_helper",
+    description=(
+        "Create a new helper entity in Home Assistant. "
+        "Supported domains: input_boolean, input_number, input_text, input_select, "
+        "input_datetime, input_button, counter, timer, schedule"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "string",
+                "description": ("Helper type to create, e.g. 'input_boolean', 'counter', 'timer'"),
+            },
+            "config": {
+                "type": "object",
+                "description": (
+                    "Helper configuration. All types require 'name'. "
+                    "input_number also requires 'min' and 'max'. "
+                    "input_select requires 'options' (list of strings). "
+                    "Optional for most types: icon, initial, restore"
+                ),
+            },
+        },
+        "required": ["domain", "config"],
+    },
+)
+async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Create a new helper."""
+    domain = arguments["domain"]
+    config = arguments["config"]
+
+    if domain not in HELPER_DOMAINS:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Unknown helper domain '{domain}'. "
+                        f"Supported: {', '.join(sorted(HELPER_DOMAINS))}"
+                    ),
+                }
+            ]
+        }
+
+    try:
+        collection = _get_collection(hass, domain)
+        item = await collection.async_create_item(config)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"Successfully created {domain} helper with id: {item['id']}",
+                }
+            ]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error creating helper: {str(e)}"}]}
+
+
+@register_tool(
+    name="update_helper",
+    description="Update an existing UI-managed helper entity by its entity ID",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "entity_id": {
+                "type": "string",
+                "description": "The helper entity ID (e.g., input_boolean.my_flag)",
+            },
+            "config": {
+                "type": "object",
+                "description": (
+                    "Updated helper configuration. Include all fields, not just changed ones"
+                ),
+            },
+        },
+        "required": ["entity_id", "config"],
+    },
+)
+async def update_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Update an existing helper."""
+    try:
+        domain, item_id = await _entity_id_to_item_id(hass, arguments["entity_id"])
+        collection = _get_collection(hass, domain)
+        await collection.async_update_item(item_id, arguments["config"])
+        return {"content": [{"type": "text", "text": "Successfully updated helper"}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error updating helper: {str(e)}"}]}
+
+
+@register_tool(
+    name="delete_helper",
+    description="Delete a UI-managed helper entity from Home Assistant by its entity ID",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "entity_id": {
+                "type": "string",
+                "description": "The helper entity ID (e.g., input_boolean.my_flag)",
+            }
+        },
+        "required": ["entity_id"],
+    },
+)
+async def delete_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Delete a helper."""
+    try:
+        domain, item_id = await _entity_id_to_item_id(hass, arguments["entity_id"])
+        collection = _get_collection(hass, domain)
+        await collection.async_delete_item(item_id)
+        return {"content": [{"type": "text", "text": "Successfully deleted helper"}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error deleting helper: {str(e)}"}]}

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -342,3 +342,37 @@ class TestCompletions:
         completion = body["result"]["completion"]
         assert "abc-123" in completion["values"]
         assert "def-456" not in completion["values"]
+
+    async def test_post_completion_domain_create_helper(self, view, mock_hass):
+        """Test domain completion for create_helper returns helper domains, not entity domains."""
+        mock_state1 = Mock()
+        mock_state1.entity_id = "light.living_room"
+        mock_state2 = Mock()
+        mock_state2.entity_id = "switch.kitchen"
+        mock_hass.states.async_all.return_value = [mock_state1, mock_state2]
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "completion/complete",
+                "params": {
+                    "ref": {"type": "ref/tool", "name": "create_helper"},
+                    "argument": {"name": "domain", "value": ""},
+                },
+                "id": 242,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        completion = body["result"]["completion"]
+        assert "input_boolean" in completion["values"]
+        assert "counter" in completion["values"]
+        assert "timer" in completion["values"]
+        assert "light" not in completion["values"]
+        assert "switch" not in completion["values"]

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 43
+        assert len(body["result"]["tools"]) == 48
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 43
+        assert len(tool_names) == 48
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_tools_helpers.py
+++ b/tests/test_tools_helpers.py
@@ -35,6 +35,24 @@ def _make_collection(items: dict | None = None) -> Mock:
     return collection
 
 
+def _make_hass_with_collection(domain: str, collection: Mock) -> Mock:
+    """Create a mock hass with a websocket-registry entry for a helper domain.
+
+    Mirrors how HA stores StorageCollectionWebsocket handlers:
+    hass.data["websocket_api"]["{domain}/list"] = (list_handler, schema)
+    where list_handler.__self__.storage_collection is the collection.
+    """
+    ws_obj = Mock()
+    ws_obj.storage_collection = collection
+
+    list_handler = Mock()
+    list_handler.__self__ = ws_obj
+
+    hass = Mock()
+    hass.data = {"websocket_api": {f"{domain}/list": (list_handler, None)}}
+    return hass
+
+
 class TestListHelpers:
     """Tests for the list_helpers tool."""
 
@@ -127,19 +145,13 @@ class TestListHelpers:
 class TestGetHelperConfig:
     """Tests for the get_helper_config tool."""
 
-    @pytest.fixture
-    def mock_hass(self):
-        hass = Mock()
-        hass.data = {}
-        return hass
-
-    async def test_get_helper_config_success(self, mock_hass):
+    async def test_get_helper_config_success(self):
         """get_helper_config returns the stored config for a known helper."""
         from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
 
         stored_item = {"id": "uid-123", "name": "My Flag", "icon": "mdi:flag"}
         collection = _make_collection({"uid-123": stored_item})
-        mock_hass.data["input_boolean"] = collection
+        mock_hass = _make_hass_with_collection("input_boolean", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry(
@@ -156,18 +168,24 @@ class TestGetHelperConfig:
         assert body["id"] == "uid-123"
         assert body["name"] == "My Flag"
 
-    async def test_get_helper_config_non_helper_domain(self, mock_hass):
+    async def test_get_helper_config_non_helper_domain(self):
         """get_helper_config returns an error for non-helper entities."""
         from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        mock_hass = Mock()
+        mock_hass.data = {}
 
         result = await get_helper_config(mock_hass, {"entity_id": "light.living_room"})
 
         assert "Error getting helper config" in result["content"][0]["text"]
         assert "not a helper entity" in result["content"][0]["text"]
 
-    async def test_get_helper_config_entity_not_in_registry(self, mock_hass):
+    async def test_get_helper_config_entity_not_in_registry(self):
         """get_helper_config returns an error when entity is missing from registry."""
         from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        collection = _make_collection()
+        mock_hass = _make_hass_with_collection("input_boolean", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = None
@@ -181,12 +199,12 @@ class TestGetHelperConfig:
         assert "Error getting helper config" in result["content"][0]["text"]
         assert "not found in entity registry" in result["content"][0]["text"]
 
-    async def test_get_helper_config_not_in_storage(self, mock_hass):
+    async def test_get_helper_config_not_in_storage(self):
         """get_helper_config returns an error when item is not in storage (YAML-configured)."""
         from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
 
         collection = _make_collection({})  # empty storage
-        mock_hass.data["input_boolean"] = collection
+        mock_hass = _make_hass_with_collection("input_boolean", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry(
@@ -202,11 +220,57 @@ class TestGetHelperConfig:
         assert "Error getting helper config" in result["content"][0]["text"]
         assert "not found in storage" in result["content"][0]["text"]
 
-    async def test_get_helper_config_domain_not_loaded(self, mock_hass):
+    async def test_get_helper_config_no_websocket_api(self):
+        """get_helper_config returns an error when websocket_api is absent from hass.data."""
+        from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        mock_hass = Mock()
+        mock_hass.data = {}  # no websocket_api at all
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "input_boolean.flag", "uid-1"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await get_helper_config(mock_hass, {"entity_id": "input_boolean.flag"})
+
+        assert "Error getting helper config" in result["content"][0]["text"]
+        assert "WebSocket API is not loaded" in result["content"][0]["text"]
+
+    async def test_get_helper_config_unexpected_handler_structure(self):
+        """get_helper_config returns an error when the handler has no storage_collection."""
+        from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        # Handler without __self__ (e.g. a plain function, not a bound method)
+        plain_handler = Mock(spec=[])  # no __self__ attribute
+        mock_hass = Mock()
+        mock_hass.data = {"websocket_api": {"input_boolean/list": (plain_handler, None)}}
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "input_boolean.flag", "uid-1"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await get_helper_config(mock_hass, {"entity_id": "input_boolean.flag"})
+
+        assert "Error getting helper config" in result["content"][0]["text"]
+        assert "unexpected handler structure" in result["content"][0]["text"]
+
+    async def test_get_helper_config_domain_not_loaded(self):
         """get_helper_config returns an error when the domain is not loaded in hass."""
         from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
 
-        # domain not in hass.data
+        mock_hass = Mock()
+        mock_hass.data = {"websocket_api": {}}  # no entry for schedule
+
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry(
             "schedule.my_schedule", "sched-1"
@@ -225,19 +289,13 @@ class TestGetHelperConfig:
 class TestCreateHelper:
     """Tests for the create_helper tool."""
 
-    @pytest.fixture
-    def mock_hass(self):
-        hass = Mock()
-        hass.data = {}
-        return hass
-
-    async def test_create_helper_success(self, mock_hass):
+    async def test_create_helper_success(self):
         """create_helper successfully creates a new helper."""
         from custom_components.mcp_server_http_transport.tools.helpers import create_helper
 
         collection = _make_collection()
         collection.async_create_item.return_value = {"id": "new-id-456", "name": "My Counter"}
-        mock_hass.data["counter"] = collection
+        mock_hass = _make_hass_with_collection("counter", collection)
 
         result = await create_helper(
             mock_hass, {"domain": "counter", "config": {"name": "My Counter"}}
@@ -248,32 +306,38 @@ class TestCreateHelper:
         assert "Successfully created counter helper" in text
         assert "new-id-456" in text
 
-    async def test_create_helper_unknown_domain(self, mock_hass):
+    async def test_create_helper_unknown_domain(self):
         """create_helper rejects unsupported domains."""
         from custom_components.mcp_server_http_transport.tools.helpers import create_helper
 
-        result = await create_helper(mock_hass, {"domain": "light", "config": {"name": "My Light"}})
+        mock_hass = Mock()
+        mock_hass.data = {}
+
+        result = await create_helper(mock_hass, {"domain": "light", "config": {"name": "x"}})
 
         text = result["content"][0]["text"]
         assert "Unknown helper domain" in text
         assert "light" in text
 
-    async def test_create_helper_domain_not_loaded(self, mock_hass):
+    async def test_create_helper_domain_not_loaded(self):
         """create_helper returns an error when the domain is not loaded."""
         from custom_components.mcp_server_http_transport.tools.helpers import create_helper
+
+        mock_hass = Mock()
+        mock_hass.data = {"websocket_api": {}}  # no entry for timer
 
         result = await create_helper(mock_hass, {"domain": "timer", "config": {"name": "My Timer"}})
 
         assert "Error creating helper" in result["content"][0]["text"]
         assert "not available" in result["content"][0]["text"]
 
-    async def test_create_helper_collection_error(self, mock_hass):
+    async def test_create_helper_collection_error(self):
         """create_helper wraps collection errors in a user-friendly message."""
         from custom_components.mcp_server_http_transport.tools.helpers import create_helper
 
         collection = _make_collection()
         collection.async_create_item.side_effect = ValueError("Invalid config")
-        mock_hass.data["input_select"] = collection
+        mock_hass = _make_hass_with_collection("input_select", collection)
 
         result = await create_helper(
             mock_hass,
@@ -297,13 +361,13 @@ class TestCreateHelper:
             "timer",
         ],
     )
-    async def test_create_helper_all_supported_domains(self, mock_hass, domain):
+    async def test_create_helper_all_supported_domains(self, domain):
         """create_helper accepts all supported helper domains."""
         from custom_components.mcp_server_http_transport.tools.helpers import create_helper
 
         collection = _make_collection()
         collection.async_create_item.return_value = {"id": "new-id", "name": "Test"}
-        mock_hass.data[domain] = collection
+        mock_hass = _make_hass_with_collection(domain, collection)
 
         result = await create_helper(mock_hass, {"domain": domain, "config": {"name": "Test"}})
 
@@ -314,18 +378,12 @@ class TestCreateHelper:
 class TestUpdateHelper:
     """Tests for the update_helper tool."""
 
-    @pytest.fixture
-    def mock_hass(self):
-        hass = Mock()
-        hass.data = {}
-        return hass
-
-    async def test_update_helper_success(self, mock_hass):
+    async def test_update_helper_success(self):
         """update_helper calls async_update_item with correct args."""
         from custom_components.mcp_server_http_transport.tools.helpers import update_helper
 
         collection = _make_collection()
-        mock_hass.data["input_text"] = collection
+        mock_hass = _make_hass_with_collection("input_text", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry("input_text.my_text", "txt-uid")
@@ -342,9 +400,12 @@ class TestUpdateHelper:
         collection.async_update_item.assert_called_once_with("txt-uid", {"name": "Renamed"})
         assert "Successfully updated helper" in result["content"][0]["text"]
 
-    async def test_update_helper_non_helper_entity(self, mock_hass):
+    async def test_update_helper_non_helper_entity(self):
         """update_helper rejects non-helper entity IDs."""
         from custom_components.mcp_server_http_transport.tools.helpers import update_helper
+
+        mock_hass = Mock()
+        mock_hass.data = {}
 
         result = await update_helper(
             mock_hass, {"entity_id": "switch.my_switch", "config": {"name": "x"}}
@@ -353,9 +414,12 @@ class TestUpdateHelper:
         assert "Error updating helper" in result["content"][0]["text"]
         assert "not a helper entity" in result["content"][0]["text"]
 
-    async def test_update_helper_entity_not_in_registry(self, mock_hass):
+    async def test_update_helper_entity_not_in_registry(self):
         """update_helper returns an error when entity is not in the registry."""
         from custom_components.mcp_server_http_transport.tools.helpers import update_helper
+
+        collection = _make_collection()
+        mock_hass = _make_hass_with_collection("input_boolean", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = None
@@ -372,13 +436,13 @@ class TestUpdateHelper:
         assert "Error updating helper" in result["content"][0]["text"]
         assert "not found in entity registry" in result["content"][0]["text"]
 
-    async def test_update_helper_collection_error(self, mock_hass):
+    async def test_update_helper_collection_error(self):
         """update_helper wraps collection errors."""
         from custom_components.mcp_server_http_transport.tools.helpers import update_helper
 
         collection = _make_collection()
         collection.async_update_item.side_effect = ValueError("Item not found")
-        mock_hass.data["counter"] = collection
+        mock_hass = _make_hass_with_collection("counter", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry("counter.my_counter", "cnt-uid")
@@ -399,18 +463,12 @@ class TestUpdateHelper:
 class TestDeleteHelper:
     """Tests for the delete_helper tool."""
 
-    @pytest.fixture
-    def mock_hass(self):
-        hass = Mock()
-        hass.data = {}
-        return hass
-
-    async def test_delete_helper_success(self, mock_hass):
+    async def test_delete_helper_success(self):
         """delete_helper calls async_delete_item with the correct item_id."""
         from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
 
         collection = _make_collection()
-        mock_hass.data["input_number"] = collection
+        mock_hass = _make_hass_with_collection("input_number", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry(
@@ -426,18 +484,24 @@ class TestDeleteHelper:
         collection.async_delete_item.assert_called_once_with("num-uid")
         assert "Successfully deleted helper" in result["content"][0]["text"]
 
-    async def test_delete_helper_non_helper_entity(self, mock_hass):
+    async def test_delete_helper_non_helper_entity(self):
         """delete_helper rejects non-helper entity IDs."""
         from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
+
+        mock_hass = Mock()
+        mock_hass.data = {}
 
         result = await delete_helper(mock_hass, {"entity_id": "sensor.temperature"})
 
         assert "Error deleting helper" in result["content"][0]["text"]
         assert "not a helper entity" in result["content"][0]["text"]
 
-    async def test_delete_helper_entity_not_in_registry(self, mock_hass):
+    async def test_delete_helper_entity_not_in_registry(self):
         """delete_helper returns an error when entity is not in the registry."""
         from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
+
+        collection = _make_collection()
+        mock_hass = _make_hass_with_collection("timer", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = None
@@ -451,13 +515,13 @@ class TestDeleteHelper:
         assert "Error deleting helper" in result["content"][0]["text"]
         assert "not found in entity registry" in result["content"][0]["text"]
 
-    async def test_delete_helper_collection_error(self, mock_hass):
+    async def test_delete_helper_collection_error(self):
         """delete_helper wraps collection errors."""
         from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
 
         collection = _make_collection()
         collection.async_delete_item.side_effect = ValueError("Not found")
-        mock_hass.data["input_datetime"] = collection
+        mock_hass = _make_hass_with_collection("input_datetime", collection)
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry(
@@ -511,7 +575,12 @@ class TestHelperToolsViaHTTP:
         """create_helper is reachable and returns success via the HTTP endpoint."""
         collection = _make_collection()
         collection.async_create_item.return_value = {"id": "http-id", "name": "HTTP Helper"}
-        mock_hass.data["input_boolean"] = collection
+
+        ws_obj = Mock()
+        ws_obj.storage_collection = collection
+        list_handler = Mock()
+        list_handler.__self__ = ws_obj
+        mock_hass.data["websocket_api"] = {"input_boolean/list": (list_handler, None)}
 
         request = self._make_request(
             "tools/call",
@@ -532,7 +601,12 @@ class TestHelperToolsViaHTTP:
     async def test_delete_helper_via_http(self, view, mock_hass):
         """delete_helper is reachable via the HTTP endpoint."""
         collection = _make_collection()
-        mock_hass.data["counter"] = collection
+
+        ws_obj = Mock()
+        ws_obj.storage_collection = collection
+        list_handler = Mock()
+        list_handler.__self__ = ws_obj
+        mock_hass.data["websocket_api"] = {"counter/list": (list_handler, None)}
 
         mock_registry = Mock()
         mock_registry.async_get.return_value = _make_registry_entry("counter.my_counter", "cnt-uid")

--- a/tests/test_tools_helpers.py
+++ b/tests/test_tools_helpers.py
@@ -1,0 +1,600 @@
+"""Tests for helper entity CRUD tools."""
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from custom_components.mcp_server_http_transport.http import MCPEndpointView
+
+
+def _make_state(entity_id: str, state: str = "on", attributes: dict | None = None) -> Mock:
+    """Create a mock state object."""
+    s = Mock()
+    s.entity_id = entity_id
+    s.state = state
+    s.attributes = attributes or {"friendly_name": entity_id.split(".")[-1]}
+    return s
+
+
+def _make_registry_entry(entity_id: str, unique_id: str) -> Mock:
+    """Create a mock entity registry entry."""
+    entry = Mock()
+    entry.entity_id = entity_id
+    entry.unique_id = unique_id
+    return entry
+
+
+def _make_collection(items: dict | None = None) -> Mock:
+    """Create a mock storage collection."""
+    collection = Mock()
+    collection.data = items or {}
+    collection.async_create_item = AsyncMock()
+    collection.async_update_item = AsyncMock()
+    collection.async_delete_item = AsyncMock()
+    return collection
+
+
+class TestListHelpers:
+    """Tests for the list_helpers tool."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = Mock()
+        hass.data = {}
+        return hass
+
+    async def test_list_all_helpers(self, mock_hass):
+        """list_helpers with no filter returns helpers from all domains."""
+        from custom_components.mcp_server_http_transport.tools.helpers import list_helpers
+
+        mock_hass.states.async_all.return_value = [
+            _make_state("input_boolean.my_flag"),
+            _make_state("counter.my_counter", "5"),
+            _make_state("light.living_room"),  # non-helper, should be excluded
+        ]
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "input_boolean.my_flag", "abc123"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await list_helpers(mock_hass, {})
+
+        body = json.loads(result["content"][0]["text"])
+        entity_ids = [h["entity_id"] for h in body]
+        assert "input_boolean.my_flag" in entity_ids
+        assert "counter.my_counter" in entity_ids
+        assert "light.living_room" not in entity_ids
+
+    async def test_list_helpers_filtered_by_domain(self, mock_hass):
+        """list_helpers with domain filter returns only that domain."""
+        from custom_components.mcp_server_http_transport.tools.helpers import list_helpers
+
+        mock_hass.states.async_all.return_value = [
+            _make_state("input_boolean.flag_a"),
+            _make_state("input_boolean.flag_b"),
+            _make_state("counter.my_counter", "3"),
+        ]
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = None
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await list_helpers(mock_hass, {"domain": "input_boolean"})
+
+        body = json.loads(result["content"][0]["text"])
+        assert len(body) == 2
+        assert all(h["domain"] == "input_boolean" for h in body)
+
+    async def test_list_helpers_unknown_domain(self, mock_hass):
+        """list_helpers with an unsupported domain returns an error message."""
+        from custom_components.mcp_server_http_transport.tools.helpers import list_helpers
+
+        result = await list_helpers(mock_hass, {"domain": "light"})
+
+        text = result["content"][0]["text"]
+        assert "Unknown helper domain" in text
+        assert "light" in text
+
+    async def test_list_helpers_includes_unique_id(self, mock_hass):
+        """list_helpers includes the unique_id from the entity registry."""
+        from custom_components.mcp_server_http_transport.tools.helpers import list_helpers
+
+        mock_hass.states.async_all.return_value = [
+            _make_state("timer.my_timer"),
+        ]
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry("timer.my_timer", "uid-999")
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await list_helpers(mock_hass, {"domain": "timer"})
+
+        body = json.loads(result["content"][0]["text"])
+        assert body[0]["unique_id"] == "uid-999"
+
+
+class TestGetHelperConfig:
+    """Tests for the get_helper_config tool."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = Mock()
+        hass.data = {}
+        return hass
+
+    async def test_get_helper_config_success(self, mock_hass):
+        """get_helper_config returns the stored config for a known helper."""
+        from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        stored_item = {"id": "uid-123", "name": "My Flag", "icon": "mdi:flag"}
+        collection = _make_collection({"uid-123": stored_item})
+        mock_hass.data["input_boolean"] = collection
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "input_boolean.my_flag", "uid-123"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await get_helper_config(mock_hass, {"entity_id": "input_boolean.my_flag"})
+
+        body = json.loads(result["content"][0]["text"])
+        assert body["id"] == "uid-123"
+        assert body["name"] == "My Flag"
+
+    async def test_get_helper_config_non_helper_domain(self, mock_hass):
+        """get_helper_config returns an error for non-helper entities."""
+        from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        result = await get_helper_config(mock_hass, {"entity_id": "light.living_room"})
+
+        assert "Error getting helper config" in result["content"][0]["text"]
+        assert "not a helper entity" in result["content"][0]["text"]
+
+    async def test_get_helper_config_entity_not_in_registry(self, mock_hass):
+        """get_helper_config returns an error when entity is missing from registry."""
+        from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = None
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await get_helper_config(mock_hass, {"entity_id": "input_boolean.missing"})
+
+        assert "Error getting helper config" in result["content"][0]["text"]
+        assert "not found in entity registry" in result["content"][0]["text"]
+
+    async def test_get_helper_config_not_in_storage(self, mock_hass):
+        """get_helper_config returns an error when item is not in storage (YAML-configured)."""
+        from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        collection = _make_collection({})  # empty storage
+        mock_hass.data["input_boolean"] = collection
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "input_boolean.yaml_helper", "yaml-uid"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await get_helper_config(mock_hass, {"entity_id": "input_boolean.yaml_helper"})
+
+        assert "Error getting helper config" in result["content"][0]["text"]
+        assert "not found in storage" in result["content"][0]["text"]
+
+    async def test_get_helper_config_domain_not_loaded(self, mock_hass):
+        """get_helper_config returns an error when the domain is not loaded in hass."""
+        from custom_components.mcp_server_http_transport.tools.helpers import get_helper_config
+
+        # domain not in hass.data
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "schedule.my_schedule", "sched-1"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await get_helper_config(mock_hass, {"entity_id": "schedule.my_schedule"})
+
+        assert "Error getting helper config" in result["content"][0]["text"]
+        assert "not available" in result["content"][0]["text"]
+
+
+class TestCreateHelper:
+    """Tests for the create_helper tool."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = Mock()
+        hass.data = {}
+        return hass
+
+    async def test_create_helper_success(self, mock_hass):
+        """create_helper successfully creates a new helper."""
+        from custom_components.mcp_server_http_transport.tools.helpers import create_helper
+
+        collection = _make_collection()
+        collection.async_create_item.return_value = {"id": "new-id-456", "name": "My Counter"}
+        mock_hass.data["counter"] = collection
+
+        result = await create_helper(
+            mock_hass, {"domain": "counter", "config": {"name": "My Counter"}}
+        )
+
+        collection.async_create_item.assert_called_once_with({"name": "My Counter"})
+        text = result["content"][0]["text"]
+        assert "Successfully created counter helper" in text
+        assert "new-id-456" in text
+
+    async def test_create_helper_unknown_domain(self, mock_hass):
+        """create_helper rejects unsupported domains."""
+        from custom_components.mcp_server_http_transport.tools.helpers import create_helper
+
+        result = await create_helper(mock_hass, {"domain": "light", "config": {"name": "My Light"}})
+
+        text = result["content"][0]["text"]
+        assert "Unknown helper domain" in text
+        assert "light" in text
+
+    async def test_create_helper_domain_not_loaded(self, mock_hass):
+        """create_helper returns an error when the domain is not loaded."""
+        from custom_components.mcp_server_http_transport.tools.helpers import create_helper
+
+        result = await create_helper(mock_hass, {"domain": "timer", "config": {"name": "My Timer"}})
+
+        assert "Error creating helper" in result["content"][0]["text"]
+        assert "not available" in result["content"][0]["text"]
+
+    async def test_create_helper_collection_error(self, mock_hass):
+        """create_helper wraps collection errors in a user-friendly message."""
+        from custom_components.mcp_server_http_transport.tools.helpers import create_helper
+
+        collection = _make_collection()
+        collection.async_create_item.side_effect = ValueError("Invalid config")
+        mock_hass.data["input_select"] = collection
+
+        result = await create_helper(
+            mock_hass,
+            {"domain": "input_select", "config": {"name": "Bad Select"}},
+        )
+
+        assert "Error creating helper" in result["content"][0]["text"]
+        assert "Invalid config" in result["content"][0]["text"]
+
+    @pytest.mark.parametrize(
+        "domain",
+        [
+            "counter",
+            "input_boolean",
+            "input_button",
+            "input_datetime",
+            "input_number",
+            "input_select",
+            "input_text",
+            "schedule",
+            "timer",
+        ],
+    )
+    async def test_create_helper_all_supported_domains(self, mock_hass, domain):
+        """create_helper accepts all supported helper domains."""
+        from custom_components.mcp_server_http_transport.tools.helpers import create_helper
+
+        collection = _make_collection()
+        collection.async_create_item.return_value = {"id": "new-id", "name": "Test"}
+        mock_hass.data[domain] = collection
+
+        result = await create_helper(mock_hass, {"domain": domain, "config": {"name": "Test"}})
+
+        assert "Successfully created" in result["content"][0]["text"]
+        assert domain in result["content"][0]["text"]
+
+
+class TestUpdateHelper:
+    """Tests for the update_helper tool."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = Mock()
+        hass.data = {}
+        return hass
+
+    async def test_update_helper_success(self, mock_hass):
+        """update_helper calls async_update_item with correct args."""
+        from custom_components.mcp_server_http_transport.tools.helpers import update_helper
+
+        collection = _make_collection()
+        mock_hass.data["input_text"] = collection
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry("input_text.my_text", "txt-uid")
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await update_helper(
+                mock_hass,
+                {"entity_id": "input_text.my_text", "config": {"name": "Renamed"}},
+            )
+
+        collection.async_update_item.assert_called_once_with("txt-uid", {"name": "Renamed"})
+        assert "Successfully updated helper" in result["content"][0]["text"]
+
+    async def test_update_helper_non_helper_entity(self, mock_hass):
+        """update_helper rejects non-helper entity IDs."""
+        from custom_components.mcp_server_http_transport.tools.helpers import update_helper
+
+        result = await update_helper(
+            mock_hass, {"entity_id": "switch.my_switch", "config": {"name": "x"}}
+        )
+
+        assert "Error updating helper" in result["content"][0]["text"]
+        assert "not a helper entity" in result["content"][0]["text"]
+
+    async def test_update_helper_entity_not_in_registry(self, mock_hass):
+        """update_helper returns an error when entity is not in the registry."""
+        from custom_components.mcp_server_http_transport.tools.helpers import update_helper
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = None
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await update_helper(
+                mock_hass,
+                {"entity_id": "input_boolean.gone", "config": {"name": "x"}},
+            )
+
+        assert "Error updating helper" in result["content"][0]["text"]
+        assert "not found in entity registry" in result["content"][0]["text"]
+
+    async def test_update_helper_collection_error(self, mock_hass):
+        """update_helper wraps collection errors."""
+        from custom_components.mcp_server_http_transport.tools.helpers import update_helper
+
+        collection = _make_collection()
+        collection.async_update_item.side_effect = ValueError("Item not found")
+        mock_hass.data["counter"] = collection
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry("counter.my_counter", "cnt-uid")
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await update_helper(
+                mock_hass,
+                {"entity_id": "counter.my_counter", "config": {"name": "x"}},
+            )
+
+        assert "Error updating helper" in result["content"][0]["text"]
+        assert "Item not found" in result["content"][0]["text"]
+
+
+class TestDeleteHelper:
+    """Tests for the delete_helper tool."""
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = Mock()
+        hass.data = {}
+        return hass
+
+    async def test_delete_helper_success(self, mock_hass):
+        """delete_helper calls async_delete_item with the correct item_id."""
+        from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
+
+        collection = _make_collection()
+        mock_hass.data["input_number"] = collection
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "input_number.my_num", "num-uid"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await delete_helper(mock_hass, {"entity_id": "input_number.my_num"})
+
+        collection.async_delete_item.assert_called_once_with("num-uid")
+        assert "Successfully deleted helper" in result["content"][0]["text"]
+
+    async def test_delete_helper_non_helper_entity(self, mock_hass):
+        """delete_helper rejects non-helper entity IDs."""
+        from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
+
+        result = await delete_helper(mock_hass, {"entity_id": "sensor.temperature"})
+
+        assert "Error deleting helper" in result["content"][0]["text"]
+        assert "not a helper entity" in result["content"][0]["text"]
+
+    async def test_delete_helper_entity_not_in_registry(self, mock_hass):
+        """delete_helper returns an error when entity is not in the registry."""
+        from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = None
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await delete_helper(mock_hass, {"entity_id": "timer.gone"})
+
+        assert "Error deleting helper" in result["content"][0]["text"]
+        assert "not found in entity registry" in result["content"][0]["text"]
+
+    async def test_delete_helper_collection_error(self, mock_hass):
+        """delete_helper wraps collection errors."""
+        from custom_components.mcp_server_http_transport.tools.helpers import delete_helper
+
+        collection = _make_collection()
+        collection.async_delete_item.side_effect = ValueError("Not found")
+        mock_hass.data["input_datetime"] = collection
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry(
+            "input_datetime.my_dt", "dt-uid"
+        )
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+            return_value=mock_registry,
+        ):
+            result = await delete_helper(mock_hass, {"entity_id": "input_datetime.my_dt"})
+
+        assert "Error deleting helper" in result["content"][0]["text"]
+        assert "Not found" in result["content"][0]["text"]
+
+
+class TestHelperToolsViaHTTP:
+    """Integration-style tests for helper tools via the MCP HTTP endpoint."""
+
+    @pytest.fixture
+    def mock_server(self):
+        return Mock()
+
+    @pytest.fixture
+    def mock_hass(self):
+        hass = Mock()
+        # DOMAIN key must be truthy so _integration_loaded() passes
+        hass.data = {"mcp_server_http_transport": Mock()}
+        hass.states = Mock()
+        hass.services = Mock()
+        return hass
+
+    @pytest.fixture
+    def view(self, mock_hass, mock_server):
+        return MCPEndpointView(mock_hass, mock_server)
+
+    def _make_request(self, method: str, params: dict, request_id: int = 1) -> Mock:
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params,
+                "id": request_id,
+            }
+        )
+        return request
+
+    async def test_create_helper_via_http(self, view, mock_hass):
+        """create_helper is reachable and returns success via the HTTP endpoint."""
+        collection = _make_collection()
+        collection.async_create_item.return_value = {"id": "http-id", "name": "HTTP Helper"}
+        mock_hass.data["input_boolean"] = collection
+
+        request = self._make_request(
+            "tools/call",
+            {
+                "name": "create_helper",
+                "arguments": {"domain": "input_boolean", "config": {"name": "HTTP Helper"}},
+            },
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "Successfully created input_boolean helper" in body["result"]["content"][0]["text"]
+        assert "http-id" in body["result"]["content"][0]["text"]
+
+    async def test_delete_helper_via_http(self, view, mock_hass):
+        """delete_helper is reachable via the HTTP endpoint."""
+        collection = _make_collection()
+        mock_hass.data["counter"] = collection
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = _make_registry_entry("counter.my_counter", "cnt-uid")
+
+        request = self._make_request(
+            "tools/call",
+            {"name": "delete_helper", "arguments": {"entity_id": "counter.my_counter"}},
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+                return_value=mock_registry,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "Successfully deleted helper" in body["result"]["content"][0]["text"]
+
+    async def test_list_helpers_via_http(self, view, mock_hass):
+        """list_helpers is reachable via the HTTP endpoint."""
+        mock_hass.states.async_all.return_value = [
+            _make_state("input_boolean.flag"),
+        ]
+
+        mock_registry = Mock()
+        mock_registry.async_get.return_value = None
+
+        request = self._make_request(
+            "tools/call",
+            {"name": "list_helpers", "arguments": {}},
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
+                return_value=mock_registry,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        result_data = json.loads(body["result"]["content"][0]["text"])
+        assert any(h["entity_id"] == "input_boolean.flag" for h in result_data)
+
+    async def test_helper_tools_appear_in_tools_list(self, view, mock_hass):
+        """Helper tools are included in the tools/list response."""
+        request = self._make_request("tools/list", {})
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        tool_names = [t["name"] for t in body["result"]["tools"]]
+        assert "list_helpers" in tool_names
+        assert "get_helper_config" in tool_names
+        assert "create_helper" in tool_names
+        assert "update_helper" in tool_names
+        assert "delete_helper" in tool_names

--- a/tests/test_tools_helpers.py
+++ b/tests/test_tools_helpers.py
@@ -228,9 +228,7 @@ class TestGetHelperConfig:
         mock_hass.data = {}  # no websocket_api at all
 
         mock_registry = Mock()
-        mock_registry.async_get.return_value = _make_registry_entry(
-            "input_boolean.flag", "uid-1"
-        )
+        mock_registry.async_get.return_value = _make_registry_entry("input_boolean.flag", "uid-1")
 
         with patch(
             "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",
@@ -251,9 +249,7 @@ class TestGetHelperConfig:
         mock_hass.data = {"websocket_api": {"input_boolean/list": (plain_handler, None)}}
 
         mock_registry = Mock()
-        mock_registry.async_get.return_value = _make_registry_entry(
-            "input_boolean.flag", "uid-1"
-        )
+        mock_registry.async_get.return_value = _make_registry_entry("input_boolean.flag", "uid-1")
 
         with patch(
             "custom_components.mcp_server_http_transport.tools.helpers.er.async_get",


### PR DESCRIPTION
## Summary                                                                                                                                                                
                                                                                                    
  This PR adds full CRUD support for Home Assistant helper entities via five new MCP tools, complementing the existing automation, scene, and script management.            
                                         
  **New tools:**                                                                                                                                                            
  - `list_helpers` — list all helper entities, optionally filtered by domain               
  - `get_helper_config` — read the raw stored configuration of a UI-managed helper                                                                                          
  - `create_helper` — create a new helper in any supported domain                                                                                                           
  - `update_helper` — update an existing helper by entity ID                                                                                                                
  - `delete_helper` — delete a helper by entity ID                                                                                                                          
                                                                                                                                                                            
  **Supported domains:** `input_boolean`, `input_number`, `input_text`, `input_select`, `input_datetime`, `input_button`, `counter`, `timer`, `schedule`                    
                                                                                                    
  **Implementation notes:**                                                                                                                                                 
  - Uses HA's `StorageCollection` accessed via `hass.data["websocket_api"]["{domain}/list"].__self__.storage_collection`, as helper collections are not stored directly in
  `hass.data[domain]`                                                                                                                                                       
  - Only manages UI-created helpers (stored in `.storage/`); YAML-configured helpers are read-only with a clear error message
  - Completion support added for the `domain` argument in `create_helper`                                                                                                   
  - 34 new tests covering all tools including edge cases and HTTP endpoint integration                                                                                      
                                                                                                                                                                            
  ## Test plan                                                                                                                                                              
  - [x] `list_helpers()` returns all helper types                                                                                                                           
  - [x] `list_helpers(domain="input_boolean")` filters correctly                                                                                                            
  - [x] `create_helper(domain="input_boolean", config={"name": "..."})` creates and appears in HA   
  - [x] `update_helper` / `delete_helper` work via entity ID                                                                                                                
  - [x] Unsupported domains and YAML-only helpers return clear error messages                                                                                               
  - [x] All 348 existing tests still pass
  - [x] Tested on my own HA instance to create and update helpers for my usecases (thats why i added this)
  

  ## -> NEEDS "reload commands list" or re-connect of users connected MCP in eg. Claude "integrations", to list new commands