### PR TITLE
feat: add YAML config file management tools with automatic backup and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@ A Home Assistant Custom Component that provides an MCP (Model Context Protocol) 
 - 🔑 **Long-Lived Access Token** authentication (opt-in) for local and custom client setups
 - 🏠 Full Home Assistant API access (entities, services, areas, devices, history, statistics)
 - 🔧 Easy HACS installation
-- 📝 CRUD management of automations, scenes, scripts, and helper entities
+- 📝 CRUD management of automations, scenes, scripts, and helper entities (input_boolean, counter, timer, schedule, and more)
 - 📋 Lovelace dashboard management (list, get/save/delete config, create/update/delete dashboards)
 - 🩺 System administration tools (error log, config validation, restart, system status)
+- 📁 YAML config file management — read, write, delete files with automatic backup before every change and built-in config validation (opt-in)
 - 📊 Resources, prompts, and completions for richer AI interactions
 - 🧹 Optimization prompts for auditing automations, naming conventions, and scheduling
 

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 |------|-------------|
 | `list_config_files` | List all YAML files in the config directory (first level, secrets excluded) |
 | `get_config_file` | Read the contents of a YAML config file (max 1 MB) |
-| `save_config_file` | Write or replace a YAML config file; runs config validation automatically after saving |
-| `delete_config_file` | Delete a YAML config file |
-| `backup_config_files` | Snapshot all YAML files into `mcp_backups/<timestamp>/` before bulk edits |
+| `save_config_file` | Write or replace a YAML config file; auto-backs up all files first, then validates config |
+| `delete_config_file` | Delete a YAML config file; auto-backs up all files first |
+| `backup_config_files` | Manually snapshot all YAML files into `mcp_backups/<timestamp>/` |
 | `list_config_backups` | List all available backup snapshots, newest first |
 | `restore_config_backup` | Restore files from the latest or a specific backup; runs config validation after restoring |
 
@@ -345,18 +345,20 @@ delete_config_file(filename="my_custom.yaml")
 </details>
 
 <details>
-<summary>How do I back up and restore config files before bulk edits?</summary>
+<summary>How does the automatic backup work?</summary>
 
-Before letting an AI refactor or restructure your YAML files, create a snapshot:
-
-```
-backup_config_files()
-```
-
-This copies all first-level YAML files (excluding `secrets.yaml`) into a timestamped folder:
+Every call to `save_config_file` and `delete_config_file` automatically creates a full snapshot of all first-level YAML files (excluding `secrets.yaml`) before making any change. Snapshots are stored in:
 
 ```
 config/mcp_backups/2026-04-26_14-30-00-123456/
+```
+
+The backup path is included in the tool response so you always know where to look. You never need to remember to back up manually before an edit — it happens every time.
+
+To create an additional manual snapshot before a larger operation:
+
+```
+backup_config_files()
 ```
 
 To see all available snapshots:
@@ -372,9 +374,9 @@ restore_config_backup()
 restore_config_backup(timestamp="2026-04-26_14-30-00-123456")
 ```
 
-`restore_config_backup` only overwrites files that exist in the backup — files created after the snapshot are left untouched. A config check runs automatically after restoring.
+`restore_config_backup` only overwrites files present in the backup — files created after the snapshot are left untouched. A config check runs automatically after restoring.
 
-> **If Home Assistant fails to start** after a bad edit: the backup files are always accessible directly at `config/mcp_backups/<timestamp>/` and can be copied back manually via the filesystem or SSH.
+> **If Home Assistant fails to start** after a bad edit: backup files are always accessible at `config/mcp_backups/<timestamp>/` and can be copied back manually via the filesystem or SSH.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -143,8 +143,11 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 |------|-------------|
 | `list_config_files` | List all YAML files in the config directory (first level, secrets excluded) |
 | `get_config_file` | Read the contents of a YAML config file (max 1 MB) |
-| `save_config_file` | Write or replace a YAML config file |
+| `save_config_file` | Write or replace a YAML config file; runs config validation automatically after saving |
 | `delete_config_file` | Delete a YAML config file |
+| `backup_config_files` | Snapshot all YAML files into `mcp_backups/<timestamp>/` before bulk edits |
+| `list_config_backups` | List all available backup snapshots, newest first |
+| `restore_config_backup` | Restore files from the latest or a specific backup; runs config validation after restoring |
 
 **Dashboards**
 
@@ -330,13 +333,48 @@ get_config_file(filename="automations.yaml")
 save_config_file(filename="automations.yaml", content="...")
 ```
 
+`save_config_file` automatically runs a full Home Assistant config validation after every save and reports any errors inline. Pass `run_check: false` to skip this.
+
 To remove a custom file:
 
 ```json
 delete_config_file(filename="my_custom.yaml")
 ```
 
-> **Note:** Only first-level `.yaml`/`.yml` files in the config directory are accessible. Subdirectories, `secrets.yaml`, and non-YAML files are blocked. After saving, use `check_config` to validate your changes before restarting.
+> **Note:** Only first-level `.yaml`/`.yml` files in the config directory are accessible. Subdirectories, `secrets.yaml`, and non-YAML files are blocked.
+</details>
+
+<details>
+<summary>How do I back up and restore config files before bulk edits?</summary>
+
+Before letting an AI refactor or restructure your YAML files, create a snapshot:
+
+```
+backup_config_files()
+```
+
+This copies all first-level YAML files (excluding `secrets.yaml`) into a timestamped folder:
+
+```
+config/mcp_backups/2026-04-26_14-30-00-123456/
+```
+
+To see all available snapshots:
+
+```
+list_config_backups()
+```
+
+To restore the latest snapshot (or a specific one by timestamp):
+
+```
+restore_config_backup()
+restore_config_backup(timestamp="2026-04-26_14-30-00-123456")
+```
+
+`restore_config_backup` only overwrites files that exist in the backup — files created after the snapshot are left untouched. A config check runs automatically after restoring.
+
+> **If Home Assistant fails to start** after a bad edit: the backup files are always accessible directly at `config/mcp_backups/<timestamp>/` and can be copied back manually via the filesystem or SSH.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -392,6 +392,10 @@ restore_config_backup(timestamp="2026-04-26_14-30-00-123456")
 `restore_config_backup` only overwrites files present in the backup — files created after the snapshot are left untouched. A config check runs automatically after restoring.
 
 > **If Home Assistant fails to start** after a bad edit: backup files are always accessible at `config/mcp_backups/<timestamp>/` and can be copied back manually via the filesystem or SSH.
+
+**Restoring a single file:** `restore_config_backup` always restores all files from a snapshot at once — there is no tool to restore a single file. If you only need one file back, either restore the full snapshot and re-apply your other changes, or copy the file manually from `config/mcp_backups/<timestamp>/<filename>` via SSH, Samba, or the File Editor add-on.
+
+**Cleaning up old backups:** Snapshots accumulate with every edit — there is no automatic cleanup and no delete-backup tool. The files are small (YAML only), but the folder will grow over time if you edit frequently. Delete old entries from `config/mcp_backups/` manually via SSH, the Samba share, or the File Editor add-on when you no longer need them.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `backup_config_files` | Manually snapshot all YAML files into `mcp_backups/<timestamp>/` |
 | `list_config_backups` | List all available backup snapshots, newest first |
 | `restore_config_backup` | Restore files from the latest or a specific backup; runs config validation after restoring |
+| `cleanup_config_backups` | Delete backup snapshots older than N days (default 30); keeps the folder from growing indefinitely |
 
 **Dashboards**
 
@@ -395,7 +396,14 @@ restore_config_backup(timestamp="2026-04-26_14-30-00-123456")
 
 **Restoring a single file:** `restore_config_backup` always restores all files from a snapshot at once — there is no tool to restore a single file. If you only need one file back, either restore the full snapshot and re-apply your other changes, or copy the file manually from `config/mcp_backups/<timestamp>/<filename>` via SSH, Samba, or the File Editor add-on.
 
-**Cleaning up old backups:** Snapshots accumulate with every edit — there is no automatic cleanup and no delete-backup tool. The files are small (YAML only), but the folder will grow over time if you edit frequently. Delete old entries from `config/mcp_backups/` manually via SSH, the Samba share, or the File Editor add-on when you no longer need them.
+**Cleaning up old backups:** Snapshots accumulate with every edit. Use `cleanup_config_backups` to remove old ones:
+
+```
+cleanup_config_backups()                    // delete backups older than 30 days (default)
+cleanup_config_backups(older_than_days=7)   // delete backups older than 7 days
+```
+
+You can also delete entries from `config/mcp_backups/` manually via SSH, the Samba share, or the File Editor add-on.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `batch_edit_config_files` | Write and/or delete multiple YAML files in one call; one backup and one config check for the whole batch |
 | `backup_config_files` | Manually snapshot all YAML files into `mcp_backups/<timestamp>/` |
 | `list_config_backups` | List all available backup snapshots, newest first |
-| `restore_config_backup` | Restore files from the latest or a specific backup; runs config validation after restoring |
+| `restore_config_backup` | Restore files from the latest or a specific backup; creates a pre-restore snapshot of the current state and runs config validation after restoring |
 | `cleanup_config_backups` | Delete backup snapshots older than N days (default 30); keeps the folder from growing indefinitely |
 
 **Dashboards**
@@ -391,7 +391,7 @@ restore_config_backup()
 restore_config_backup(timestamp="2026-04-26_14-30-00-123456")
 ```
 
-`restore_config_backup` only overwrites files present in the backup — files created after the snapshot are left untouched. A config check runs automatically after restoring.
+`restore_config_backup` only overwrites files present in the backup — files created after the snapshot are left untouched. Before any files are overwritten it creates a **pre-restore snapshot** of the current state, so you can always roll back from a restore (the snapshot path is included in the response). A config check runs automatically after restoring.
 
 > **If Home Assistant fails to start** after a bad edit: backup files are always accessible at `config/mcp_backups/<timestamp>/` and can be copied back manually via the filesystem or SSH.
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `get_config_file` | Read the contents of a YAML config file (max 1 MB) |
 | `save_config_file` | Write or replace a YAML config file; auto-backs up all files first, then validates config |
 | `delete_config_file` | Delete a YAML config file; auto-backs up all files first |
+| `batch_edit_config_files` | Write and/or delete multiple YAML files in one call; one backup and one config check for the whole batch |
 | `backup_config_files` | Manually snapshot all YAML files into `mcp_backups/<timestamp>/` |
 | `list_config_backups` | List all available backup snapshots, newest first |
 | `restore_config_backup` | Restore files from the latest or a specific backup; runs config validation after restoring |
@@ -337,9 +338,23 @@ save_config_file(filename="automations.yaml", content="...")
 
 To remove a custom file:
 
-```json
+```
 delete_config_file(filename="my_custom.yaml")
 ```
+
+When editing multiple files in one session use `batch_edit_config_files` instead — it creates one backup snapshot before all changes and runs one config check at the end:
+
+```
+batch_edit_config_files(
+    saves=[
+        {"filename": "templates.yaml", "content": "..."},
+        {"filename": "sensors.yaml",   "content": "..."},
+    ],
+    deletes=["binary_sensor.yaml", "scenes.yaml"],
+)
+```
+
+Both `saves` and `deletes` are optional — you can use either or both in the same call.
 
 > **Note:** Only first-level `.yaml`/`.yml` files in the config directory are accessible. Subdirectories, `secrets.yaml`, and non-YAML files are blocked.
 </details>
@@ -347,7 +362,7 @@ delete_config_file(filename="my_custom.yaml")
 <details>
 <summary>How does the automatic backup work?</summary>
 
-Every call to `save_config_file` and `delete_config_file` automatically creates a full snapshot of all first-level YAML files (excluding `secrets.yaml`) before making any change. Snapshots are stored in:
+Every call to `save_config_file` and `delete_config_file` automatically creates a full snapshot of all first-level YAML files (excluding `secrets.yaml`) before making any change. When using `batch_edit_config_files`, only one backup is created for the entire batch — regardless of how many files are saved or deleted. Snapshots are stored in:
 
 ```
 config/mcp_backups/2026-04-26_14-30-00-123456/

--- a/README.md
+++ b/README.md
@@ -137,6 +137,15 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `update_helper` | Update an existing UI-managed helper by entity ID |
 | `delete_helper` | Delete a UI-managed helper by entity ID |
 
+**Config Files**
+
+| Tool | Description |
+|------|-------------|
+| `list_config_files` | List all YAML files in the config directory (first level, secrets excluded) |
+| `get_config_file` | Read the contents of a YAML config file (max 1 MB) |
+| `save_config_file` | Write or replace a YAML config file |
+| `delete_config_file` | Delete a YAML config file |
+
 **Dashboards**
 
 | Tool | Description |
@@ -308,6 +317,26 @@ delete_helper(entity_id="counter.motion_events")
 ```
 
 > **Note:** These tools only manage UI-created helpers stored in Home Assistant's `.storage/` files. Helpers defined in YAML configuration are read-only from the perspective of these tools.
+</details>
+
+<details>
+<summary>How do I read or edit YAML configuration files?</summary>
+
+Use `list_config_files` to see all editable YAML files, then `get_config_file` and `save_config_file` to read and modify them:
+
+```
+list_config_files()
+get_config_file(filename="automations.yaml")
+save_config_file(filename="automations.yaml", content="...")
+```
+
+To remove a custom file:
+
+```json
+delete_config_file(filename="my_custom.yaml")
+```
+
+> **Note:** Only first-level `.yaml`/`.yml` files in the config directory are accessible. Subdirectories, `secrets.yaml`, and non-YAML files are blocked. After saving, use `check_config` to validate your changes before restarting.
 </details>
 
 <details>

--- a/custom_components/mcp_server_http_transport/__init__.py
+++ b/custom_components/mcp_server_http_transport/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from mcp.server import Server
 
-from .const import CONF_NATIVE_AUTH, DOMAIN
+from .const import CONF_CONFIG_FILE_ACCESS, CONF_NATIVE_AUTH, DOMAIN
 from .http import (
     MCPEndpointView,
     MCPProtectedResourceMetadataView,
@@ -30,6 +30,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
 
     native_auth_enabled = entry.data.get(CONF_NATIVE_AUTH, False)
+    config_file_access_enabled = entry.data.get(CONF_CONFIG_FILE_ACCESS, False)
+
+    hass.data[DOMAIN]["config_file_access"] = config_file_access_enabled
 
     # Create MCP server
     server = Server("home-assistant-mcp-server")

--- a/custom_components/mcp_server_http_transport/config_flow.py
+++ b/custom_components/mcp_server_http_transport/config_flow.py
@@ -7,13 +7,14 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 
-from .const import CONF_NATIVE_AUTH, DOMAIN
+from .const import CONF_CONFIG_FILE_ACCESS, CONF_NATIVE_AUTH, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_NATIVE_AUTH, default=False): bool,
+        vol.Optional(CONF_CONFIG_FILE_ACCESS, default=False): bool,
     }
 )
 
@@ -78,12 +79,14 @@ class MCPServerOptionsFlowHandler(config_entries.OptionsFlow):
                 return self.async_create_entry(title="", data={})
 
         current_native_auth = self.config_entry.data.get(CONF_NATIVE_AUTH, False)
+        current_config_file_access = self.config_entry.data.get(CONF_CONFIG_FILE_ACCESS, False)
 
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
                 {
                     vol.Optional(CONF_NATIVE_AUTH, default=current_native_auth): bool,
+                    vol.Optional(CONF_CONFIG_FILE_ACCESS, default=current_config_file_access): bool,
                 }
             ),
             errors=errors,

--- a/custom_components/mcp_server_http_transport/const.py
+++ b/custom_components/mcp_server_http_transport/const.py
@@ -8,3 +8,6 @@ DEFAULT_HOST = "0.0.0.0"
 
 # Authentication configuration
 CONF_NATIVE_AUTH = "native_auth_enabled"
+
+# Feature flags
+CONF_CONFIG_FILE_ACCESS = "config_file_access_enabled"

--- a/custom_components/mcp_server_http_transport/strings.json
+++ b/custom_components/mcp_server_http_transport/strings.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },
@@ -30,7 +30,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },

--- a/custom_components/mcp_server_http_transport/strings.json
+++ b/custom_components/mcp_server_http_transport/strings.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
         }
       }
     },
@@ -30,7 +30,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
         }
       }
     },

--- a/custom_components/mcp_server_http_transport/strings.json
+++ b/custom_components/mcp_server_http_transport/strings.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Use **`batch_edit_config_files`** when touching multiple files at once — it creates only one backup and runs one config check for the whole batch. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },
@@ -30,7 +30,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Use **`batch_edit_config_files`** when touching multiple files at once — it creates only one backup and runs one config check for the whole batch. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },

--- a/custom_components/mcp_server_http_transport/strings.json
+++ b/custom_components/mcp_server_http_transport/strings.json
@@ -5,10 +5,12 @@
         "title": "MCP Server (HTTP Transport)",
         "description": "Set up the MCP Server integration for Home Assistant.",
         "data": {
-          "native_auth_enabled": "Enable native Home Assistant authentication"
+          "native_auth_enabled": "Enable native Home Assistant authentication",
+          "config_file_access_enabled": "Enable config file access"
         },
         "data_description": {
-          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
         }
       }
     },
@@ -23,10 +25,12 @@
     "step": {
       "init": {
         "data": {
-          "native_auth_enabled": "Enable native Home Assistant authentication"
+          "native_auth_enabled": "Enable native Home Assistant authentication",
+          "config_file_access_enabled": "Enable config file access"
         },
         "data_description": {
-          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
         }
       }
     },

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -43,6 +43,7 @@ async def call_tool(hass: HomeAssistant, name: str, arguments: dict[str, Any]) -
 # Import submodules so tools auto-register via @register_tool
 from . import (  # noqa: E402
     config,  # noqa: F401
+    config_files,  # noqa: F401
     dashboards,  # noqa: F401
     entities,  # noqa: F401
     helpers,  # noqa: F401

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -297,9 +297,7 @@ async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> 
         },
     },
 )
-async def batch_edit_config_files(
-    hass: HomeAssistant, arguments: dict[str, Any]
-) -> dict[str, Any]:
+async def batch_edit_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """One backup → apply all saves → apply all deletes → one config check."""
     if not _is_enabled(hass):
         return _DISABLED_RESPONSE
@@ -310,7 +308,10 @@ async def batch_edit_config_files(
     if not saves and not deletes:
         return {
             "content": [
-                {"type": "text", "text": "Error: provide at least one entry in 'saves' or 'deletes'"}
+                {
+                    "type": "text",
+                    "text": "Error: provide at least one entry in 'saves' or 'deletes'",
+                }
             ]
         }
 

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -3,6 +3,8 @@
 import json
 import logging
 import os
+import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -199,3 +201,59 @@ async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> 
         }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error deleting config file: {e}"}]}
+
+
+_BACKUP_DIR_NAME = "mcp_backups"
+
+
+@register_tool(
+    name="backup_config_files",
+    description=(
+        "Create a timestamped backup of all first-level YAML configuration files "
+        "into a 'mcp_backups/<timestamp>' subfolder inside the config directory. "
+        "secrets.yaml is never included. "
+        "Call this before bulk edits to preserve a rollback snapshot"
+    ),
+    input_schema={"type": "object", "properties": {}},
+)
+async def backup_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Copy all first-level YAML files (except secrets) into a timestamped backup folder."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
+    try:
+        config_dir = _config_dir(hass)
+
+        files_to_back_up = sorted(
+            entry
+            for entry in config_dir.iterdir()
+            if entry.is_file()
+            and entry.suffix.lower() in _ALLOWED_SUFFIXES
+            and entry.name.lower() not in _BLOCKED_NAMES
+        )
+
+        if not files_to_back_up:
+            return {"content": [{"type": "text", "text": "No YAML files found to back up"}]}
+
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")
+        backup_dir = config_dir / _BACKUP_DIR_NAME / timestamp
+        backup_dir.mkdir(parents=True, exist_ok=True)
+
+        backed_up = []
+        for entry in files_to_back_up:
+            shutil.copy2(entry, backup_dir / entry.name)
+            backed_up.append(entry.name)
+
+        relative_path = f"{_BACKUP_DIR_NAME}/{timestamp}"
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Backup created at '{relative_path}' "
+                        f"({len(backed_up)} files):\n" + "\n".join(f"  - {f}" for f in backed_up)
+                    ),
+                }
+            ]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error creating backup: {e}"}]}

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 import shutil
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -457,6 +457,68 @@ async def list_config_backups(hass: HomeAssistant, arguments: dict[str, Any]) ->
         return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing backups: {e}"}]}
+
+
+@register_tool(
+    name="cleanup_config_backups",
+    description=(
+        "Delete backup snapshots older than a given number of days. "
+        "Defaults to 30 days. Use this to keep the mcp_backups folder from growing indefinitely. "
+        "Returns the number of snapshots deleted and how many remain"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "older_than_days": {
+                "type": "integer",
+                "description": "Delete backups older than this many days (default: 30, minimum: 1)",
+            }
+        },
+    },
+)
+async def cleanup_config_backups(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Delete backup snapshots older than older_than_days days."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
+
+    older_than_days = arguments.get("older_than_days", 30)
+    if not isinstance(older_than_days, int) or older_than_days < 1:
+        return {
+            "content": [{"type": "text", "text": "Error: older_than_days must be an integer >= 1"}]
+        }
+
+    try:
+        backup_root = _config_dir(hass) / _BACKUP_DIR_NAME
+        if not backup_root.exists():
+            return {"content": [{"type": "text", "text": "No backups found"}]}
+
+        cutoff = datetime.now() - timedelta(days=older_than_days)
+        deleted: list[str] = []
+        kept: list[str] = []
+
+        for d in backup_root.iterdir():
+            if not d.is_dir() or not _BACKUP_TS_RE.match(d.name):
+                continue
+            try:
+                ts = datetime.strptime(d.name, "%Y-%m-%d_%H-%M-%S-%f")
+            except ValueError:
+                continue
+            if ts < cutoff:
+                shutil.rmtree(d)
+                deleted.append(d.name)
+            else:
+                kept.append(d.name)
+
+        if not deleted and not kept:
+            return {"content": [{"type": "text", "text": "No backups found"}]}
+
+        lines = [f"Deleted {len(deleted)} backup(s) older than {older_than_days} day(s)."]
+        if deleted:
+            lines.extend(f"  - {name}" for name in sorted(deleted))
+        lines.append(f"{len(kept)} backup(s) remaining.")
+        return {"content": [{"type": "text", "text": "\n".join(lines)}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error cleaning up backups: {e}"}]}
 
 
 @register_tool(

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -165,7 +165,8 @@ async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         "Write or replace a YAML configuration file in the Home Assistant config directory. "
         "First-level files only; secrets.yaml is blocked. "
         "Creates the file if it does not exist. "
-        "Automatically backs up all YAML files before writing and runs a config check after"
+        "Automatically backs up all YAML files before writing and runs a config check after. "
+        "When editing multiple files prefer batch_edit_config_files to avoid redundant backups"
     ),
     input_schema={
         "type": "object",
@@ -223,7 +224,8 @@ async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     description=(
         "Delete a YAML configuration file from the Home Assistant config directory. "
         "First-level files only; secrets.yaml is blocked. "
-        "Automatically backs up all YAML files before deleting"
+        "Automatically backs up all YAML files before deleting. "
+        "When deleting multiple files prefer batch_edit_config_files to avoid redundant backups"
     ),
     input_schema={
         "type": "object",
@@ -256,6 +258,132 @@ async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> 
         return {"content": [{"type": "text", "text": "\n".join(lines)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error deleting config file: {e}"}]}
+
+
+@register_tool(
+    name="batch_edit_config_files",
+    description=(
+        "Write and/or delete multiple YAML config files in one operation. "
+        "Creates one backup before any changes and runs one config check after all changes. "
+        "Prefer this over repeated save_config_file or delete_config_file calls "
+        "when touching more than one file — avoids redundant backups"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "saves": {
+                "type": "array",
+                "description": "Files to write or create. Each entry needs 'filename' and 'content'.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "filename": {"type": "string", "description": "e.g. 'templates.yaml'"},
+                        "content": {"type": "string", "description": "Full YAML content to write"},
+                    },
+                    "required": ["filename", "content"],
+                },
+            },
+            "deletes": {
+                "type": "array",
+                "description": "File names to delete.",
+                "items": {"type": "string"},
+            },
+            "run_check": {
+                "type": "boolean",
+                "description": "Run HA config validation after all changes (default: true)",
+            },
+        },
+    },
+)
+async def batch_edit_config_files(
+    hass: HomeAssistant, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """One backup → apply all saves → apply all deletes → one config check."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
+
+    saves: list[dict] = arguments.get("saves") or []
+    deletes: list[str] = arguments.get("deletes") or []
+
+    if not saves and not deletes:
+        return {
+            "content": [
+                {"type": "text", "text": "Error: provide at least one entry in 'saves' or 'deletes'"}
+            ]
+        }
+
+    # Phase 1: validate all filenames before touching anything
+    try:
+        save_paths = [
+            (entry["filename"], _resolve_safe(hass, entry["filename"]), entry["content"])
+            for entry in saves
+        ]
+    except (ValueError, KeyError) as e:
+        return {"content": [{"type": "text", "text": f"Error in saves: {e}"}]}
+
+    try:
+        delete_paths = [(fn, _resolve_safe(hass, fn)) for fn in deletes]
+    except ValueError as e:
+        return {"content": [{"type": "text", "text": f"Error in deletes: {e}"}]}
+
+    missing = [fn for fn, path in delete_paths if not path.exists()]
+    if missing:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"Error: file(s) to delete do not exist: {', '.join(missing)}",
+                }
+            ]
+        }
+
+    # Phase 2: one backup
+    backup_path = _create_backup(hass)
+
+    # Phase 3: apply saves
+    saved: list[str] = []
+    errors: list[str] = []
+    for filename, path, content in save_paths:
+        try:
+            path.write_text(content, encoding="utf-8")
+            saved.append(filename)
+        except Exception as e:
+            errors.append(f"save '{filename}': {e}")
+
+    # Phase 4: apply deletes
+    deleted: list[str] = []
+    for filename, path in delete_paths:
+        try:
+            path.unlink()
+            deleted.append(filename)
+        except Exception as e:
+            errors.append(f"delete '{filename}': {e}")
+
+    # Phase 5: build response
+    lines: list[str] = []
+    if saved:
+        lines.append(f"Saved ({len(saved)}): " + ", ".join(saved))
+    if deleted:
+        lines.append(f"Deleted ({len(deleted)}): " + ", ".join(deleted))
+    if backup_path:
+        lines.append(f"Backup: {backup_path}")
+    if errors:
+        lines.append("Errors:")
+        lines.extend(f"  - {e}" for e in errors)
+
+    if arguments.get("run_check", True):
+        try:
+            check = await _run_config_check(hass)
+            if check["valid"]:
+                lines.append("Config check: OK")
+            else:
+                lines.append("Config check: ERRORS FOUND")
+                for err in check["errors"]:
+                    lines.append(f"  - {err}")
+        except Exception as check_err:
+            lines.append(f"Config check failed to run: {check_err}")
+
+    return {"content": [{"type": "text", "text": "\n".join(lines)}]}
 
 
 @register_tool(

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -8,12 +8,30 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
+from ..const import DOMAIN
 from . import register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
 _ALLOWED_SUFFIXES = {".yaml", ".yml"}
 _BLOCKED_NAMES = {"secrets.yaml", "secrets.yml"}
+
+_DISABLED_RESPONSE = {
+    "content": [
+        {
+            "type": "text",
+            "text": (
+                "Config file access is disabled. Enable it in the MCP Server integration "
+                "settings: Settings → Devices & Services → MCP Server → Configure → "
+                "Enable config file access."
+            ),
+        }
+    ]
+}
+
+
+def _is_enabled(hass: HomeAssistant) -> bool:
+    return hass.data.get(DOMAIN, {}).get("config_file_access", False)
 
 
 def _config_dir(hass: HomeAssistant) -> Path:
@@ -46,6 +64,8 @@ def _resolve_safe(hass: HomeAssistant, filename: str) -> Path:
 )
 async def list_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List first-level YAML files in the config directory."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
     config_dir = _config_dir(hass)
     try:
         files = sorted(
@@ -79,6 +99,8 @@ async def list_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> d
 )
 async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Read a YAML config file."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
     try:
         path = _resolve_safe(hass, arguments["filename"])
         if not path.exists():
@@ -130,6 +152,8 @@ async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
 )
 async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Write a YAML config file, creating it if necessary."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
     try:
         path = _resolve_safe(hass, arguments["filename"])
         path.write_text(arguments["content"], encoding="utf-8")
@@ -159,6 +183,8 @@ async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> di
 )
 async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete a YAML config file."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
     try:
         path = _resolve_safe(hass, arguments["filename"])
         if not path.exists():

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -275,7 +275,7 @@ async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> 
         "properties": {
             "saves": {
                 "type": "array",
-                "description": "Files to write or create. Each entry needs 'filename' and 'content'.",
+                "description": "Files to write or create. Each needs 'filename' and 'content'.",
                 "items": {
                     "type": "object",
                     "properties": {

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -529,7 +529,8 @@ async def cleanup_config_backups(hass: HomeAssistant, arguments: dict[str, Any])
         "Restores the latest backup by default, or a specific one by timestamp. "
         "Only files present in the backup are overwritten; "
         "files added after the backup are left untouched. "
-        "Automatically runs a config check after restoring"
+        "Automatically creates a pre-restore snapshot of the current state "
+        "and runs a config check after restoring"
     ),
     input_schema={
         "type": "object",
@@ -573,6 +574,9 @@ async def restore_config_backup(hass: HomeAssistant, arguments: dict[str, Any]) 
                 return {"content": [{"type": "text", "text": "No backups found"}]}
             backup_dir = candidates[-1]
 
+        # Snapshot current state before overwriting — symmetric to save/delete.
+        pre_restore_backup = _create_backup(hass)
+
         config_dir = _config_dir(hass)
         restored = []
         for src in sorted(backup_dir.iterdir()):
@@ -591,6 +595,8 @@ async def restore_config_backup(hass: HomeAssistant, arguments: dict[str, Any]) 
             f"Restored {len(restored)} files from backup '{backup_dir.name}':",
             *[f"  - {f}" for f in restored],
         ]
+        if pre_restore_backup:
+            lines.append(f"Pre-restore snapshot: {pre_restore_backup}")
 
         try:
             check = await _run_config_check(hass)

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import re
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -18,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 _ALLOWED_SUFFIXES = {".yaml", ".yml"}
 _BLOCKED_NAMES = {"secrets.yaml", "secrets.yml"}
 _BACKUP_DIR_NAME = "mcp_backups"
+_BACKUP_TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}-\d+$")
 
 _DISABLED_RESPONSE = {
     "content": [
@@ -439,7 +441,7 @@ async def list_config_backups(hass: HomeAssistant, arguments: dict[str, Any]) ->
             return {"content": [{"type": "text", "text": "No backups found"}]}
 
         backups = sorted(
-            (d for d in backup_root.iterdir() if d.is_dir()),
+            (d for d in backup_root.iterdir() if d.is_dir() and _BACKUP_TS_RE.match(d.name)),
             key=lambda d: d.name,
             reverse=True,
         )
@@ -501,7 +503,8 @@ async def restore_config_backup(hass: HomeAssistant, arguments: dict[str, Any]) 
                 }
         else:
             candidates = sorted(
-                (d for d in backup_root.iterdir() if d.is_dir()), key=lambda d: d.name
+                (d for d in backup_root.iterdir() if d.is_dir() and _BACKUP_TS_RE.match(d.name)),
+                key=lambda d: d.name,
             )
             if not candidates:
                 return {"content": [{"type": "text", "text": "No backups found"}]}

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -77,6 +77,20 @@ async def _run_config_check(hass: HomeAssistant) -> dict[str, Any]:
     return {"valid": len(errors) == 0, "errors": errors}
 
 
+def _create_backup(hass: HomeAssistant) -> str | None:
+    """Snapshot all first-level YAML files into mcp_backups/; return relative path or None."""
+    config_dir = _config_dir(hass)
+    files = _yaml_files_in(config_dir)
+    if not files:
+        return None
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")
+    backup_dir = config_dir / _BACKUP_DIR_NAME / timestamp
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    for src in files:
+        shutil.copy2(src, backup_dir / src.name)
+    return f"{_BACKUP_DIR_NAME}/{timestamp}"
+
+
 @register_tool(
     name="list_config_files",
     description=(
@@ -151,7 +165,7 @@ async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         "Write or replace a YAML configuration file in the Home Assistant config directory. "
         "First-level files only; secrets.yaml is blocked. "
         "Creates the file if it does not exist. "
-        "Automatically runs a config check after saving unless run_check is set to false"
+        "Automatically backs up all YAML files before writing and runs a config check after"
     ),
     input_schema={
         "type": "object",
@@ -176,13 +190,16 @@ async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
     },
 )
 async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Write a YAML config file, then optionally validate the full HA config."""
+    """Back up all YAML files, write the new content, then optionally validate."""
     if not _is_enabled(hass):
         return _DISABLED_RESPONSE
     try:
         path = _resolve_safe(hass, arguments["filename"])
+        backup_path = _create_backup(hass)
         path.write_text(arguments["content"], encoding="utf-8")
         lines = [f"Successfully saved '{arguments['filename']}'"]
+        if backup_path:
+            lines.append(f"Backup: {backup_path}")
 
         if arguments.get("run_check", True):
             try:
@@ -205,7 +222,8 @@ async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     name="delete_config_file",
     description=(
         "Delete a YAML configuration file from the Home Assistant config directory. "
-        "First-level files only; secrets.yaml is blocked"
+        "First-level files only; secrets.yaml is blocked. "
+        "Automatically backs up all YAML files before deleting"
     ),
     input_schema={
         "type": "object",
@@ -219,7 +237,7 @@ async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     },
 )
 async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Delete a YAML config file."""
+    """Back up all YAML files, then delete the target file."""
     if not _is_enabled(hass):
         return _DISABLED_RESPONSE
     try:
@@ -230,10 +248,12 @@ async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> 
                     {"type": "text", "text": f"File '{arguments['filename']}' does not exist"}
                 ]
             }
+        backup_path = _create_backup(hass)
         path.unlink()
-        return {
-            "content": [{"type": "text", "text": f"Successfully deleted '{arguments['filename']}'"}]
-        }
+        lines = [f"Successfully deleted '{arguments['filename']}'"]
+        if backup_path:
+            lines.append(f"Backup: {backup_path}")
+        return {"content": [{"type": "text", "text": "\n".join(lines)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error deleting config file: {e}"}]}
 
@@ -253,28 +273,17 @@ async def backup_config_files(hass: HomeAssistant, arguments: dict[str, Any]) ->
     if not _is_enabled(hass):
         return _DISABLED_RESPONSE
     try:
-        config_dir = _config_dir(hass)
-        files_to_back_up = _yaml_files_in(config_dir)
-
-        if not files_to_back_up:
+        backup_path = _create_backup(hass)
+        if backup_path is None:
             return {"content": [{"type": "text", "text": "No YAML files found to back up"}]}
-
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S-%f")
-        backup_dir = config_dir / _BACKUP_DIR_NAME / timestamp
-        backup_dir.mkdir(parents=True, exist_ok=True)
-
-        backed_up = []
-        for entry in files_to_back_up:
-            shutil.copy2(entry, backup_dir / entry.name)
-            backed_up.append(entry.name)
-
-        relative_path = f"{_BACKUP_DIR_NAME}/{timestamp}"
+        backup_dir = _config_dir(hass) / backup_path
+        backed_up = sorted(f.name for f in backup_dir.iterdir() if f.is_file())
         return {
             "content": [
                 {
                     "type": "text",
                     "text": (
-                        f"Backup created at '{relative_path}' "
+                        f"Backup created at '{backup_path}' "
                         f"({len(backed_up)} files):\n" + "\n".join(f"  - {f}" for f in backed_up)
                     ),
                 }

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -1,0 +1,175 @@
+"""Config file access tools (list, read, write, delete YAML files in config dir)."""
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from . import register_tool
+
+_LOGGER = logging.getLogger(__name__)
+
+_ALLOWED_SUFFIXES = {".yaml", ".yml"}
+_BLOCKED_NAMES = {"secrets.yaml", "secrets.yml"}
+
+
+def _config_dir(hass: HomeAssistant) -> Path:
+    return Path(hass.config.config_dir)
+
+
+def _resolve_safe(hass: HomeAssistant, filename: str) -> Path:
+    """Return resolved Path inside config dir, or raise ValueError."""
+    if os.sep in filename or "/" in filename:
+        raise ValueError("Subdirectories are not allowed — only first-level files")
+    if filename.lower() in _BLOCKED_NAMES:
+        raise ValueError(f"Access to '{filename}' is blocked for security reasons")
+    suffix = Path(filename).suffix.lower()
+    if suffix not in _ALLOWED_SUFFIXES:
+        raise ValueError(f"Only YAML files are supported (.yaml, .yml), got '{suffix or filename}'")
+    path = _config_dir(hass) / filename
+    # Paranoia check: resolved path must still be inside config_dir
+    if not path.resolve().is_relative_to(_config_dir(hass).resolve()):
+        raise ValueError("Path traversal detected")
+    return path
+
+
+@register_tool(
+    name="list_config_files",
+    description=(
+        "List YAML configuration files in the Home Assistant config directory "
+        "(first level only; secrets.yaml and .storage are excluded)"
+    ),
+    input_schema={"type": "object", "properties": {}},
+)
+async def list_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """List first-level YAML files in the config directory."""
+    config_dir = _config_dir(hass)
+    try:
+        files = sorted(
+            entry.name
+            for entry in config_dir.iterdir()
+            if entry.is_file()
+            and entry.suffix.lower() in _ALLOWED_SUFFIXES
+            and entry.name.lower() not in _BLOCKED_NAMES
+        )
+        return {"content": [{"type": "text", "text": json.dumps(files, indent=2)}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error listing config files: {e}"}]}
+
+
+@register_tool(
+    name="get_config_file",
+    description=(
+        "Read the contents of a YAML configuration file from the Home Assistant config directory. "
+        "First-level files only; secrets.yaml is blocked"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "filename": {
+                "type": "string",
+                "description": "File name, e.g. 'automations.yaml' or 'configuration.yaml'",
+            }
+        },
+        "required": ["filename"],
+    },
+)
+async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Read a YAML config file."""
+    try:
+        path = _resolve_safe(hass, arguments["filename"])
+        if not path.exists():
+            return {
+                "content": [
+                    {"type": "text", "text": f"File '{arguments['filename']}' does not exist"}
+                ]
+            }
+        size = path.stat().st_size
+        if size > 1_048_576:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": (
+                            f"File '{arguments['filename']}' is too large ({size} bytes). "
+                            "Maximum allowed size is 1 MB"
+                        ),
+                    }
+                ]
+            }
+        content = path.read_text(encoding="utf-8")
+        return {"content": [{"type": "text", "text": content}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error reading config file: {e}"}]}
+
+
+@register_tool(
+    name="save_config_file",
+    description=(
+        "Write or replace a YAML configuration file in the Home Assistant config directory. "
+        "First-level files only; secrets.yaml is blocked. "
+        "Creates the file if it does not exist"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "filename": {
+                "type": "string",
+                "description": "File name, e.g. 'automations.yaml'",
+            },
+            "content": {
+                "type": "string",
+                "description": "Full YAML content to write",
+            },
+        },
+        "required": ["filename", "content"],
+    },
+)
+async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Write a YAML config file, creating it if necessary."""
+    try:
+        path = _resolve_safe(hass, arguments["filename"])
+        path.write_text(arguments["content"], encoding="utf-8")
+        return {
+            "content": [{"type": "text", "text": f"Successfully saved '{arguments['filename']}'"}]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error saving config file: {e}"}]}
+
+
+@register_tool(
+    name="delete_config_file",
+    description=(
+        "Delete a YAML configuration file from the Home Assistant config directory. "
+        "First-level files only; secrets.yaml is blocked"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "filename": {
+                "type": "string",
+                "description": "File name to delete, e.g. 'my_custom.yaml'",
+            }
+        },
+        "required": ["filename"],
+    },
+)
+async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Delete a YAML config file."""
+    try:
+        path = _resolve_safe(hass, arguments["filename"])
+        if not path.exists():
+            return {
+                "content": [
+                    {"type": "text", "text": f"File '{arguments['filename']}' does not exist"}
+                ]
+            }
+        path.unlink()
+        return {
+            "content": [{"type": "text", "text": f"Successfully deleted '{arguments['filename']}'"}]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error deleting config file: {e}"}]}

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -1,4 +1,4 @@
-"""Config file access tools (list, read, write, delete YAML files in config dir)."""
+"""Config file access tools (list, read, write, delete, backup, restore YAML files)."""
 
 import json
 import logging
@@ -17,6 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _ALLOWED_SUFFIXES = {".yaml", ".yml"}
 _BLOCKED_NAMES = {"secrets.yaml", "secrets.yml"}
+_BACKUP_DIR_NAME = "mcp_backups"
 
 _DISABLED_RESPONSE = {
     "content": [
@@ -56,6 +57,26 @@ def _resolve_safe(hass: HomeAssistant, filename: str) -> Path:
     return path
 
 
+def _yaml_files_in(directory: Path) -> list[Path]:
+    """Return sorted first-level YAML files excluding secrets."""
+    return sorted(
+        entry
+        for entry in directory.iterdir()
+        if entry.is_file()
+        and entry.suffix.lower() in _ALLOWED_SUFFIXES
+        and entry.name.lower() not in _BLOCKED_NAMES
+    )
+
+
+async def _run_config_check(hass: HomeAssistant) -> dict[str, Any]:
+    """Run HA config validation and return a result dict."""
+    from homeassistant.helpers.check_config import async_check_ha_config_file
+
+    res = await async_check_ha_config_file(hass)
+    errors = [str(err) for err in res.errors] if res.errors else []
+    return {"valid": len(errors) == 0, "errors": errors}
+
+
 @register_tool(
     name="list_config_files",
     description=(
@@ -70,13 +91,7 @@ async def list_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         return _DISABLED_RESPONSE
     config_dir = _config_dir(hass)
     try:
-        files = sorted(
-            entry.name
-            for entry in config_dir.iterdir()
-            if entry.is_file()
-            and entry.suffix.lower() in _ALLOWED_SUFFIXES
-            and entry.name.lower() not in _BLOCKED_NAMES
-        )
+        files = [f.name for f in _yaml_files_in(config_dir)]
         return {"content": [{"type": "text", "text": json.dumps(files, indent=2)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing config files: {e}"}]}
@@ -135,7 +150,8 @@ async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
     description=(
         "Write or replace a YAML configuration file in the Home Assistant config directory. "
         "First-level files only; secrets.yaml is blocked. "
-        "Creates the file if it does not exist"
+        "Creates the file if it does not exist. "
+        "Automatically runs a config check after saving unless run_check is set to false"
     ),
     input_schema={
         "type": "object",
@@ -148,20 +164,39 @@ async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
                 "type": "string",
                 "description": "Full YAML content to write",
             },
+            "run_check": {
+                "type": "boolean",
+                "description": (
+                    "Run Home Assistant config validation after saving (default: true). "
+                    "Reports errors without undoing the save"
+                ),
+            },
         },
         "required": ["filename", "content"],
     },
 )
 async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Write a YAML config file, creating it if necessary."""
+    """Write a YAML config file, then optionally validate the full HA config."""
     if not _is_enabled(hass):
         return _DISABLED_RESPONSE
     try:
         path = _resolve_safe(hass, arguments["filename"])
         path.write_text(arguments["content"], encoding="utf-8")
-        return {
-            "content": [{"type": "text", "text": f"Successfully saved '{arguments['filename']}'"}]
-        }
+        lines = [f"Successfully saved '{arguments['filename']}'"]
+
+        if arguments.get("run_check", True):
+            try:
+                check = await _run_config_check(hass)
+                if check["valid"]:
+                    lines.append("Config check: OK")
+                else:
+                    lines.append("Config check: ERRORS FOUND")
+                    for err in check["errors"]:
+                        lines.append(f"  - {err}")
+            except Exception as check_err:
+                lines.append(f"Config check failed to run: {check_err}")
+
+        return {"content": [{"type": "text", "text": "\n".join(lines)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error saving config file: {e}"}]}
 
@@ -203,9 +238,6 @@ async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> 
         return {"content": [{"type": "text", "text": f"Error deleting config file: {e}"}]}
 
 
-_BACKUP_DIR_NAME = "mcp_backups"
-
-
 @register_tool(
     name="backup_config_files",
     description=(
@@ -222,14 +254,7 @@ async def backup_config_files(hass: HomeAssistant, arguments: dict[str, Any]) ->
         return _DISABLED_RESPONSE
     try:
         config_dir = _config_dir(hass)
-
-        files_to_back_up = sorted(
-            entry
-            for entry in config_dir.iterdir()
-            if entry.is_file()
-            and entry.suffix.lower() in _ALLOWED_SUFFIXES
-            and entry.name.lower() not in _BLOCKED_NAMES
-        )
+        files_to_back_up = _yaml_files_in(config_dir)
 
         if not files_to_back_up:
             return {"content": [{"type": "text", "text": "No YAML files found to back up"}]}
@@ -257,3 +282,124 @@ async def backup_config_files(hass: HomeAssistant, arguments: dict[str, Any]) ->
         }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error creating backup: {e}"}]}
+
+
+@register_tool(
+    name="list_config_backups",
+    description=(
+        "List all available config file backups created by backup_config_files, "
+        "newest first. Shows the timestamp and number of files in each backup"
+    ),
+    input_schema={"type": "object", "properties": {}},
+)
+async def list_config_backups(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """List available backup snapshots, newest first."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
+    try:
+        backup_root = _config_dir(hass) / _BACKUP_DIR_NAME
+        if not backup_root.exists():
+            return {"content": [{"type": "text", "text": "No backups found"}]}
+
+        backups = sorted(
+            (d for d in backup_root.iterdir() if d.is_dir()),
+            key=lambda d: d.name,
+            reverse=True,
+        )
+
+        if not backups:
+            return {"content": [{"type": "text", "text": "No backups found"}]}
+
+        result = []
+        for backup_dir in backups:
+            files = [f.name for f in backup_dir.iterdir() if f.is_file()]
+            result.append({"timestamp": backup_dir.name, "files": sorted(files)})
+
+        return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error listing backups: {e}"}]}
+
+
+@register_tool(
+    name="restore_config_backup",
+    description=(
+        "Restore YAML config files from a backup snapshot. "
+        "Restores the latest backup by default, or a specific one by timestamp. "
+        "Only files present in the backup are overwritten; "
+        "files added after the backup are left untouched. "
+        "Automatically runs a config check after restoring"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "timestamp": {
+                "type": "string",
+                "description": (
+                    "Backup timestamp to restore (as shown by list_config_backups). "
+                    "Omit to restore the latest backup"
+                ),
+            }
+        },
+    },
+)
+async def restore_config_backup(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Restore files from a backup snapshot into the config directory."""
+    if not _is_enabled(hass):
+        return _DISABLED_RESPONSE
+    try:
+        backup_root = _config_dir(hass) / _BACKUP_DIR_NAME
+        if not backup_root.exists():
+            return {"content": [{"type": "text", "text": "No backups found"}]}
+
+        if "timestamp" in arguments:
+            backup_dir = backup_root / arguments["timestamp"]
+            if not backup_dir.is_dir():
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Backup '{arguments['timestamp']}' not found",
+                        }
+                    ]
+                }
+        else:
+            candidates = sorted(
+                (d for d in backup_root.iterdir() if d.is_dir()), key=lambda d: d.name
+            )
+            if not candidates:
+                return {"content": [{"type": "text", "text": "No backups found"}]}
+            backup_dir = candidates[-1]
+
+        config_dir = _config_dir(hass)
+        restored = []
+        for src in sorted(backup_dir.iterdir()):
+            if src.is_file() and src.suffix.lower() in _ALLOWED_SUFFIXES:
+                shutil.copy2(src, config_dir / src.name)
+                restored.append(src.name)
+
+        if not restored:
+            return {
+                "content": [
+                    {"type": "text", "text": f"Backup '{backup_dir.name}' contained no YAML files"}
+                ]
+            }
+
+        lines = [
+            f"Restored {len(restored)} files from backup '{backup_dir.name}':",
+            *[f"  - {f}" for f in restored],
+        ]
+
+        try:
+            check = await _run_config_check(hass)
+            if check["valid"]:
+                lines.append("Config check: OK")
+            else:
+                lines.append("Config check: ERRORS FOUND")
+                for err in check["errors"]:
+                    lines.append(f"  - {err}")
+        except Exception as check_err:
+            lines.append(f"Config check failed to run: {check_err}")
+
+        return {"content": [{"type": "text", "text": "\n".join(lines)}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error restoring backup: {e}"}]}

--- a/custom_components/mcp_server_http_transport/translations/en.json
+++ b/custom_components/mcp_server_http_transport/translations/en.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },
@@ -30,7 +30,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },

--- a/custom_components/mcp_server_http_transport/translations/en.json
+++ b/custom_components/mcp_server_http_transport/translations/en.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Use **`batch_edit_config_files`** when touching multiple files at once — it creates only one backup and runs one config check for the whole batch. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },
@@ -30,7 +30,7 @@
         },
         "data_description": {
           "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
-          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete first-level YAML files in the config directory. **`secrets.yaml`** is always blocked.\n\nEvery save and delete automatically creates a full backup first (stored in `mcp_backups/` in your config directory). Every save also runs a config validation automatically. Use **`batch_edit_config_files`** when touching multiple files at once — it creates only one backup and runs one config check for the whole batch. Backups can be restored manually via the filesystem if Home Assistant fails to start.\n\n**Before enabling:** move all sensitive values (API keys, tokens, passwords) into **`secrets.yaml`** — any inline values in other YAML files will be readable by the AI."
         }
       }
     },

--- a/custom_components/mcp_server_http_transport/translations/en.json
+++ b/custom_components/mcp_server_http_transport/translations/en.json
@@ -5,10 +5,12 @@
         "title": "MCP Server (HTTP Transport)",
         "description": "Set up the MCP Server integration for Home Assistant.",
         "data": {
-          "native_auth_enabled": "Enable native Home Assistant authentication"
+          "native_auth_enabled": "Enable native Home Assistant authentication",
+          "config_file_access_enabled": "Enable config file access"
         },
         "data_description": {
-          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
         }
       }
     },
@@ -23,10 +25,12 @@
     "step": {
       "init": {
         "data": {
-          "native_auth_enabled": "Enable native Home Assistant authentication"
+          "native_auth_enabled": "Enable native Home Assistant authentication",
+          "config_file_access_enabled": "Enable config file access"
         },
         "data_description": {
-          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required."
+          "native_auth_enabled": "Allow Long-Lived Access Tokens for authentication. When disabled, the OIDC Provider integration is required.",
+          "config_file_access_enabled": "Allow AI assistants to list, read, write, and delete YAML configuration files. Only first-level files are accessible; secrets.yaml is always blocked. Every save is automatically validated against the full Home Assistant configuration. Use the backup_config_files tool before bulk edits — snapshots are stored in mcp_backups/ inside your config directory and can be restored manually if Home Assistant fails to start. Make sure all sensitive values (API keys, tokens, passwords) are stored in secrets.yaml before enabling this — any inline values in other YAML files will be readable by the AI."
         }
       }
     },

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 55
+        assert len(body["result"]["tools"]) == 56
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 56
+        assert len(body["result"]["tools"]) == 57
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 48
+        assert len(body["result"]["tools"]) == 52
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 52
+        assert len(body["result"]["tools"]) == 53
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 53
+        assert len(body["result"]["tools"]) == 55
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 53
+        assert len(tool_names) == 55
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 55
+        assert len(tool_names) == 56
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 48
+        assert len(tool_names) == 52
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 52
+        assert len(tool_names) == 53
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 56
+        assert len(tool_names) == 57
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 from custom_components.mcp_server_http_transport.const import DOMAIN
 from custom_components.mcp_server_http_transport.tools.config_files import (
     backup_config_files,
+    batch_edit_config_files,
     delete_config_file,
     get_config_file,
     list_config_backups,
@@ -656,4 +657,134 @@ class TestRunConfigCheck:
             result = await _run_config_check(hass)
 
         assert result["valid"] is False
-        assert "Invalid platform: sensor" in result["errors"]
+
+
+class TestBatchEditConfigFiles:
+    async def test_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await batch_edit_config_files(
+            hass, {"saves": [{"filename": "x.yaml", "content": "x: 1"}]}
+        )
+        assert "disabled" in result["content"][0]["text"].lower()
+
+    async def test_saves_multiple_files(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup(), _mock_check_config():
+            result = await batch_edit_config_files(
+                hass,
+                {
+                    "saves": [
+                        {"filename": "a.yaml", "content": "a: 1"},
+                        {"filename": "b.yaml", "content": "b: 2"},
+                    ]
+                },
+            )
+        text = result["content"][0]["text"]
+        assert "a.yaml" in text
+        assert "b.yaml" in text
+        assert (tmp_path / "a.yaml").read_text() == "a: 1"
+        assert (tmp_path / "b.yaml").read_text() == "b: 2"
+
+    async def test_deletes_multiple_files(self, tmp_path):
+        (tmp_path / "old1.yaml").write_text("x: 1")
+        (tmp_path / "old2.yaml").write_text("x: 2")
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup(), _mock_check_config():
+            result = await batch_edit_config_files(
+                hass, {"deletes": ["old1.yaml", "old2.yaml"]}
+            )
+        text = result["content"][0]["text"]
+        assert "old1.yaml" in text
+        assert "old2.yaml" in text
+        assert not (tmp_path / "old1.yaml").exists()
+        assert not (tmp_path / "old2.yaml").exists()
+
+    async def test_saves_and_deletes_in_one_call(self, tmp_path):
+        (tmp_path / "remove_me.yaml").write_text("old: true")
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup(), _mock_check_config():
+            result = await batch_edit_config_files(
+                hass,
+                {
+                    "saves": [{"filename": "new.yaml", "content": "new: true"}],
+                    "deletes": ["remove_me.yaml"],
+                },
+            )
+        text = result["content"][0]["text"]
+        assert "new.yaml" in text
+        assert "remove_me.yaml" in text
+        assert (tmp_path / "new.yaml").exists()
+        assert not (tmp_path / "remove_me.yaml").exists()
+
+    async def test_one_backup_for_all_operations(self, tmp_path):
+        (tmp_path / "del.yaml").write_text("x: 1")
+        hass = _make_hass(tmp_path)
+        backup_calls = []
+
+        def counting_backup(h):
+            backup_calls.append(1)
+            return "mcp_backups/fake"
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.config_files._create_backup",
+            side_effect=counting_backup,
+        ), _mock_check_config():
+            await batch_edit_config_files(
+                hass,
+                {
+                    "saves": [
+                        {"filename": "a.yaml", "content": "a: 1"},
+                        {"filename": "b.yaml", "content": "b: 2"},
+                    ],
+                    "deletes": ["del.yaml"],
+                },
+            )
+        assert len(backup_calls) == 1
+
+    async def test_validation_failure_aborts_before_any_change(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await batch_edit_config_files(
+            hass,
+            {
+                "saves": [
+                    {"filename": "secrets.yaml", "content": "bad: true"},
+                    {"filename": "ok.yaml", "content": "ok: 1"},
+                ]
+            },
+        )
+        text = result["content"][0]["text"]
+        assert "error" in text.lower()
+        assert not (tmp_path / "ok.yaml").exists()
+
+    async def test_delete_missing_file_aborts(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await batch_edit_config_files(
+            hass, {"deletes": ["does_not_exist.yaml"]}
+        )
+        text = result["content"][0]["text"]
+        assert "error" in text.lower()
+
+    async def test_run_check_false_skips_validation(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup():
+            result = await batch_edit_config_files(
+                hass,
+                {"saves": [{"filename": "x.yaml", "content": "x: 1"}], "run_check": False},
+            )
+        text = result["content"][0]["text"]
+        assert "config check" not in text.lower()
+
+    async def test_config_check_errors_reported(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup(), _mock_check_config(valid=False, errors=["bad thing"]):
+            result = await batch_edit_config_files(
+                hass, {"saves": [{"filename": "x.yaml", "content": "x: 1"}]}
+            )
+        text = result["content"][0]["text"]
+        assert "bad thing" in text
+
+    async def test_empty_saves_and_deletes_returns_error(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await batch_edit_config_files(hass, {})
+        text = result["content"][0]["text"]
+        assert "error" in text.lower()

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+from custom_components.mcp_server_http_transport.const import DOMAIN
 from custom_components.mcp_server_http_transport.tools.config_files import (
     delete_config_file,
     get_config_file,
@@ -12,10 +13,36 @@ from custom_components.mcp_server_http_transport.tools.config_files import (
 )
 
 
-def _make_hass(config_dir: Path) -> Mock:
+def _make_hass(config_dir: Path, *, config_file_access: bool = True) -> Mock:
     hass = Mock()
     hass.config.config_dir = str(config_dir)
+    hass.data = {DOMAIN: {"config_file_access": config_file_access}}
     return hass
+
+
+class TestDisabledByDefault:
+    async def test_list_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await list_config_files(hass, {})
+        assert "disabled" in result["content"][0]["text"].lower()
+
+    async def test_get_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await get_config_file(hass, {"filename": "automations.yaml"})
+        assert "disabled" in result["content"][0]["text"].lower()
+
+    async def test_save_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await save_config_file(hass, {"filename": "test.yaml", "content": "x: 1"})
+        assert "disabled" in result["content"][0]["text"].lower()
+        assert not (tmp_path / "test.yaml").exists()
+
+    async def test_delete_disabled(self, tmp_path):
+        (tmp_path / "custom.yaml").write_text("x: 1")
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await delete_config_file(hass, {"filename": "custom.yaml"})
+        assert "disabled" in result["content"][0]["text"].lower()
+        assert (tmp_path / "custom.yaml").exists()
 
 
 class TestListConfigFiles:

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -707,9 +707,7 @@ class TestBatchEditConfigFiles:
         (tmp_path / "old2.yaml").write_text("x: 2")
         hass = _make_hass(tmp_path)
         with _mock_create_backup(), _mock_check_config():
-            result = await batch_edit_config_files(
-                hass, {"deletes": ["old1.yaml", "old2.yaml"]}
-            )
+            result = await batch_edit_config_files(hass, {"deletes": ["old1.yaml", "old2.yaml"]})
         text = result["content"][0]["text"]
         assert "old1.yaml" in text
         assert "old2.yaml" in text
@@ -742,10 +740,13 @@ class TestBatchEditConfigFiles:
             backup_calls.append(1)
             return "mcp_backups/fake"
 
-        with patch(
-            "custom_components.mcp_server_http_transport.tools.config_files._create_backup",
-            side_effect=counting_backup,
-        ), _mock_check_config():
+        with (
+            patch(
+                "custom_components.mcp_server_http_transport.tools.config_files._create_backup",
+                side_effect=counting_backup,
+            ),
+            _mock_check_config(),
+        ):
             await batch_edit_config_files(
                 hass,
                 {
@@ -775,9 +776,7 @@ class TestBatchEditConfigFiles:
 
     async def test_delete_missing_file_aborts(self, tmp_path):
         hass = _make_hass(tmp_path)
-        result = await batch_edit_config_files(
-            hass, {"deletes": ["does_not_exist.yaml"]}
-        )
+        result = await batch_edit_config_files(hass, {"deletes": ["does_not_exist.yaml"]})
         text = result["content"][0]["text"]
         assert "error" in text.lower()
 
@@ -813,8 +812,10 @@ class TestBatchEditConfigFiles:
 
     async def test_save_write_failure_reports_error(self, tmp_path):
         hass = _make_hass(tmp_path)
-        with _mock_create_backup(), _mock_check_config(), patch(
-            "pathlib.Path.write_text", side_effect=OSError("disk full")
+        with (
+            _mock_create_backup(),
+            _mock_check_config(),
+            patch("pathlib.Path.write_text", side_effect=OSError("disk full")),
         ):
             result = await batch_edit_config_files(
                 hass, {"saves": [{"filename": "x.yaml", "content": "x: 1"}]}
@@ -826,8 +827,10 @@ class TestBatchEditConfigFiles:
     async def test_delete_unlink_failure_reports_error(self, tmp_path):
         (tmp_path / "x.yaml").write_text("x: 1")
         hass = _make_hass(tmp_path)
-        with _mock_create_backup(), _mock_check_config(), patch(
-            "pathlib.Path.unlink", side_effect=OSError("permission denied")
+        with (
+            _mock_create_backup(),
+            _mock_check_config(),
+            patch("pathlib.Path.unlink", side_effect=OSError("permission denied")),
         ):
             result = await batch_edit_config_files(hass, {"deletes": ["x.yaml"]})
         text = result["content"][0]["text"]
@@ -836,10 +839,14 @@ class TestBatchEditConfigFiles:
 
     async def test_config_check_exception_reported(self, tmp_path):
         from unittest.mock import AsyncMock
+
         hass = _make_hass(tmp_path)
-        with _mock_create_backup(), patch(
-            "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
-            new=AsyncMock(side_effect=Exception("check exploded")),
+        with (
+            _mock_create_backup(),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
+                new=AsyncMock(side_effect=Exception("check exploded")),
+            ),
         ):
             result = await batch_edit_config_files(
                 hass, {"saves": [{"filename": "x.yaml", "content": "x: 1"}]}
@@ -867,11 +874,13 @@ class TestCleanupConfigBackups:
 
     async def test_keeps_recent_backups(self, tmp_path):
         from datetime import timezone
+
         backup_root = tmp_path / "mcp_backups"
         # old backup
         self._make_backup(backup_root, "2026-01-01_10-00-00-000000")
         # recent backup using today's date
         from datetime import date
+
         today = date.today().strftime("%Y-%m-%d")
         self._make_backup(backup_root, f"{today}_10-00-00-000000")
         hass = _make_hass(tmp_path)
@@ -888,6 +897,7 @@ class TestCleanupConfigBackups:
 
     async def test_no_old_backups_to_delete(self, tmp_path):
         from datetime import date
+
         backup_root = tmp_path / "mcp_backups"
         today = date.today().strftime("%Y-%m-%d")
         self._make_backup(backup_root, f"{today}_10-00-00-000000")

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -873,7 +873,6 @@ class TestCleanupConfigBackups:
         assert not (backup_root / "2026-01-01_10-00-00-000000").exists()
 
     async def test_keeps_recent_backups(self, tmp_path):
-        from datetime import timezone
 
         backup_root = tmp_path / "mcp_backups"
         # old backup

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -194,7 +194,6 @@ class TestGetConfigFile:
 
 
 def _mock_check_config(valid: bool = True, errors: list[str] | None = None):
-    """Return an async mock for _run_config_check."""
     from unittest.mock import AsyncMock
 
     result = {"valid": valid, "errors": errors or []}
@@ -204,10 +203,17 @@ def _mock_check_config(valid: bool = True, errors: list[str] | None = None):
     )
 
 
+def _mock_create_backup(path: str = "mcp_backups/2026-01-01_10-00-00-000000"):
+    return patch(
+        "custom_components.mcp_server_http_transport.tools.config_files._create_backup",
+        return_value=path,
+    )
+
+
 class TestSaveConfigFile:
     async def test_write_new_file(self, tmp_path):
         hass = _make_hass(tmp_path)
-        with _mock_check_config():
+        with _mock_create_backup(), _mock_check_config():
             result = await save_config_file(
                 hass, {"filename": "new.yaml", "content": "key: value\n"}
             )
@@ -215,24 +221,39 @@ class TestSaveConfigFile:
         assert "Successfully saved" in result["content"][0]["text"]
         assert (tmp_path / "new.yaml").read_text() == "key: value\n"
 
+    async def test_backup_created_automatically(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("original")
+        hass = _make_hass(tmp_path)
+        with _mock_check_config():
+            result = await save_config_file(
+                hass, {"filename": "automations.yaml", "content": "updated"}
+            )
+        text = result["content"][0]["text"]
+        assert "Backup:" in text
+        assert "mcp_backups/" in text
+        assert (tmp_path / "automations.yaml").read_text() == "updated"
+
     async def test_overwrite_existing_file(self, tmp_path):
         (tmp_path / "automations.yaml").write_text("old content")
         hass = _make_hass(tmp_path)
 
-        with _mock_check_config():
+        with _mock_create_backup(), _mock_check_config():
             await save_config_file(hass, {"filename": "automations.yaml", "content": "new content"})
 
         assert (tmp_path / "automations.yaml").read_text() == "new content"
 
     async def test_config_check_ok_reported(self, tmp_path):
         hass = _make_hass(tmp_path)
-        with _mock_check_config(valid=True):
+        with _mock_create_backup(), _mock_check_config(valid=True):
             result = await save_config_file(hass, {"filename": "test.yaml", "content": "x: 1"})
         assert "Config check: OK" in result["content"][0]["text"]
 
     async def test_config_check_errors_reported(self, tmp_path):
         hass = _make_hass(tmp_path)
-        with _mock_check_config(valid=False, errors=["Invalid entity: light.missing"]):
+        with (
+            _mock_create_backup(),
+            _mock_check_config(valid=False, errors=["Invalid entity: light.missing"]),
+        ):
             result = await save_config_file(hass, {"filename": "test.yaml", "content": "x: 1"})
         text = result["content"][0]["text"]
         assert "Config check: ERRORS FOUND" in text
@@ -240,7 +261,7 @@ class TestSaveConfigFile:
 
     async def test_config_check_skipped_when_run_check_false(self, tmp_path):
         hass = _make_hass(tmp_path)
-        with _mock_check_config() as mock_check:
+        with _mock_create_backup(), _mock_check_config() as mock_check:
             result = await save_config_file(
                 hass, {"filename": "test.yaml", "content": "x: 1", "run_check": False}
             )
@@ -249,9 +270,12 @@ class TestSaveConfigFile:
 
     async def test_config_check_failure_doesnt_hide_save_success(self, tmp_path):
         hass = _make_hass(tmp_path)
-        with patch(
-            "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
-            side_effect=Exception("check unavailable"),
+        with (
+            _mock_create_backup(),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
+                side_effect=Exception("check unavailable"),
+            ),
         ):
             result = await save_config_file(hass, {"filename": "test.yaml", "content": "x: 1"})
         text = result["content"][0]["text"]
@@ -285,10 +309,22 @@ class TestDeleteConfigFile:
         (tmp_path / "custom.yaml").write_text("x: 1")
         hass = _make_hass(tmp_path)
 
-        result = await delete_config_file(hass, {"filename": "custom.yaml"})
+        with _mock_create_backup():
+            result = await delete_config_file(hass, {"filename": "custom.yaml"})
 
         assert "Successfully deleted" in result["content"][0]["text"]
         assert not (tmp_path / "custom.yaml").exists()
+
+    async def test_backup_created_automatically_before_delete(self, tmp_path):
+        (tmp_path / "custom.yaml").write_text("x: 1")
+        hass = _make_hass(tmp_path)
+
+        result = await delete_config_file(hass, {"filename": "custom.yaml"})
+
+        text = result["content"][0]["text"]
+        assert "Successfully deleted" in text
+        assert "Backup:" in text
+        assert "mcp_backups/" in text
 
     async def test_delete_nonexistent_file(self, tmp_path):
         hass = _make_hass(tmp_path)

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -626,6 +626,44 @@ class TestRestoreConfigBackup:
 
         assert "Error restoring backup" in result["content"][0]["text"]
 
+    async def test_restore_creates_pre_restore_snapshot(self, tmp_path):
+        """Pre-restore snapshot captures current state so user can roll back from a restore."""
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("from_backup: true")
+
+        # Current state — should be snapshotted before restore overwrites it
+        (tmp_path / "automations.yaml").write_text("current: state")
+        hass = _make_hass(tmp_path)
+
+        with _mock_check_config():
+            result = await restore_config_backup(hass, {})
+
+        text = result["content"][0]["text"]
+        assert "Restored" in text
+        assert "Pre-restore snapshot" in text
+        # Restored content lands in the config dir
+        assert (tmp_path / "automations.yaml").read_text() == "from_backup: true"
+        # And a new backup folder was created with the prior content
+        snapshots = sorted(d for d in (tmp_path / "mcp_backups").iterdir() if d.is_dir())
+        assert len(snapshots) == 2  # original + pre-restore
+        pre_restore = [d for d in snapshots if d.name != "2026-01-01_10-00-00-000000"][0]
+        assert (pre_restore / "automations.yaml").read_text() == "current: state"
+
+    async def test_restore_skips_pre_snapshot_message_when_no_yaml_files(self, tmp_path):
+        """If there's no current YAML state, no pre-restore snapshot can be created."""
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("from_backup: true")
+        hass = _make_hass(tmp_path)
+
+        with _mock_check_config():
+            result = await restore_config_backup(hass, {})
+
+        text = result["content"][0]["text"]
+        assert "Restored" in text
+        assert "Pre-restore snapshot" not in text
+
 
 class TestListConfigBackupsErrors:
     async def test_list_handles_os_error(self, tmp_path):

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -485,6 +485,22 @@ class TestListConfigBackups:
         assert "automations.yaml" in backups[0]["files"]
         assert "scripts.yaml" in backups[0]["files"]
 
+    async def test_list_ignores_non_timestamp_dirs(self, tmp_path):
+        # Synology NAS creates @eaDir metadata folders; they must not appear as backups.
+        backup_root = tmp_path / "mcp_backups"
+        real = backup_root / "2026-01-01_10-00-00-000000"
+        real.mkdir(parents=True)
+        (real / "automations.yaml").write_text("[]")
+        (backup_root / "@eaDir").mkdir()
+        (backup_root / "not-a-timestamp").mkdir()
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_backups(hass, {})
+        backups = json.loads(result["content"][0]["text"])
+
+        assert len(backups) == 1
+        assert backups[0]["timestamp"] == "2026-01-01_10-00-00-000000"
+
     async def test_list_disabled(self, tmp_path):
         hass = _make_hass(tmp_path, config_file_access=False)
         result = await list_config_backups(hass, {})

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -9,7 +9,9 @@ from custom_components.mcp_server_http_transport.tools.config_files import (
     backup_config_files,
     delete_config_file,
     get_config_file,
+    list_config_backups,
     list_config_files,
+    restore_config_backup,
     save_config_file,
 )
 
@@ -191,10 +193,24 @@ class TestGetConfigFile:
         assert "my_script" in result["content"][0]["text"]
 
 
+def _mock_check_config(valid: bool = True, errors: list[str] | None = None):
+    """Return an async mock for _run_config_check."""
+    from unittest.mock import AsyncMock
+
+    result = {"valid": valid, "errors": errors or []}
+    return patch(
+        "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
+        new=AsyncMock(return_value=result),
+    )
+
+
 class TestSaveConfigFile:
     async def test_write_new_file(self, tmp_path):
         hass = _make_hass(tmp_path)
-        result = await save_config_file(hass, {"filename": "new.yaml", "content": "key: value\n"})
+        with _mock_check_config():
+            result = await save_config_file(
+                hass, {"filename": "new.yaml", "content": "key: value\n"}
+            )
 
         assert "Successfully saved" in result["content"][0]["text"]
         assert (tmp_path / "new.yaml").read_text() == "key: value\n"
@@ -203,9 +219,44 @@ class TestSaveConfigFile:
         (tmp_path / "automations.yaml").write_text("old content")
         hass = _make_hass(tmp_path)
 
-        await save_config_file(hass, {"filename": "automations.yaml", "content": "new content"})
+        with _mock_check_config():
+            await save_config_file(hass, {"filename": "automations.yaml", "content": "new content"})
 
         assert (tmp_path / "automations.yaml").read_text() == "new content"
+
+    async def test_config_check_ok_reported(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with _mock_check_config(valid=True):
+            result = await save_config_file(hass, {"filename": "test.yaml", "content": "x: 1"})
+        assert "Config check: OK" in result["content"][0]["text"]
+
+    async def test_config_check_errors_reported(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with _mock_check_config(valid=False, errors=["Invalid entity: light.missing"]):
+            result = await save_config_file(hass, {"filename": "test.yaml", "content": "x: 1"})
+        text = result["content"][0]["text"]
+        assert "Config check: ERRORS FOUND" in text
+        assert "light.missing" in text
+
+    async def test_config_check_skipped_when_run_check_false(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with _mock_check_config() as mock_check:
+            result = await save_config_file(
+                hass, {"filename": "test.yaml", "content": "x: 1", "run_check": False}
+            )
+        mock_check.assert_not_called()
+        assert "Config check" not in result["content"][0]["text"]
+
+    async def test_config_check_failure_doesnt_hide_save_success(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
+            side_effect=Exception("check unavailable"),
+        ):
+            result = await save_config_file(hass, {"filename": "test.yaml", "content": "x: 1"})
+        text = result["content"][0]["text"]
+        assert "Successfully saved" in text
+        assert "Config check failed to run" in text
 
     async def test_write_blocks_secrets(self, tmp_path):
         hass = _make_hass(tmp_path)
@@ -354,3 +405,219 @@ class TestBackupConfigFiles:
             result = await backup_config_files(hass, {})
 
         assert "Error creating backup" in result["content"][0]["text"]
+
+
+class TestListConfigBackups:
+    async def test_list_no_backup_dir(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await list_config_backups(hass, {})
+        assert "No backups found" in result["content"][0]["text"]
+
+    async def test_list_empty_backup_dir(self, tmp_path):
+        (tmp_path / "mcp_backups").mkdir()
+        hass = _make_hass(tmp_path)
+        result = await list_config_backups(hass, {})
+        assert "No backups found" in result["content"][0]["text"]
+
+    async def test_list_shows_backups_newest_first(self, tmp_path):
+        backup_root = tmp_path / "mcp_backups"
+        older = backup_root / "2026-01-01_10-00-00-000000"
+        newer = backup_root / "2026-01-02_10-00-00-000000"
+        older.mkdir(parents=True)
+        newer.mkdir(parents=True)
+        (older / "automations.yaml").write_text("[]")
+        (newer / "automations.yaml").write_text("[]")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_backups(hass, {})
+        backups = json.loads(result["content"][0]["text"])
+
+        assert backups[0]["timestamp"] == "2026-01-02_10-00-00-000000"
+        assert backups[1]["timestamp"] == "2026-01-01_10-00-00-000000"
+
+    async def test_list_shows_files_in_each_backup(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("[]")
+        (backup_dir / "scripts.yaml").write_text("{}")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_backups(hass, {})
+        backups = json.loads(result["content"][0]["text"])
+
+        assert "automations.yaml" in backups[0]["files"]
+        assert "scripts.yaml" in backups[0]["files"]
+
+    async def test_list_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await list_config_backups(hass, {})
+        assert "disabled" in result["content"][0]["text"].lower()
+
+
+class TestRestoreConfigBackup:
+    async def test_restore_latest_backup(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("original")
+        hass = _make_hass(tmp_path)
+        await backup_config_files(hass, {})
+        (tmp_path / "automations.yaml").write_text("broken")
+
+        with _mock_check_config():
+            result = await restore_config_backup(hass, {})
+
+        assert (tmp_path / "automations.yaml").read_text() == "original"
+        assert "Restored" in result["content"][0]["text"]
+
+    async def test_restore_specific_timestamp(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("from specific backup")
+        (tmp_path / "automations.yaml").write_text("current")
+        hass = _make_hass(tmp_path)
+
+        with _mock_check_config():
+            result = await restore_config_backup(hass, {"timestamp": "2026-01-01_10-00-00-000000"})
+
+        assert (tmp_path / "automations.yaml").read_text() == "from specific backup"
+        assert "2026-01-01_10-00-00-000000" in result["content"][0]["text"]
+
+    async def test_restore_unknown_timestamp(self, tmp_path):
+        (tmp_path / "mcp_backups").mkdir()
+        hass = _make_hass(tmp_path)
+        result = await restore_config_backup(hass, {"timestamp": "nonexistent"})
+        assert "not found" in result["content"][0]["text"]
+
+    async def test_restore_no_backups(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await restore_config_backup(hass, {})
+        assert "No backups found" in result["content"][0]["text"]
+
+    async def test_restore_does_not_delete_new_files(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("backed up")
+        (tmp_path / "automations.yaml").write_text("current")
+        (tmp_path / "new_file.yaml").write_text("added after backup")
+        hass = _make_hass(tmp_path)
+
+        with _mock_check_config():
+            await restore_config_backup(hass, {})
+
+        assert (tmp_path / "new_file.yaml").exists()
+
+    async def test_restore_runs_config_check(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("[]")
+        hass = _make_hass(tmp_path)
+
+        with _mock_check_config(valid=True):
+            result = await restore_config_backup(hass, {})
+
+        assert "Config check: OK" in result["content"][0]["text"]
+
+    async def test_restore_reports_config_errors(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("bad yaml:")
+        hass = _make_hass(tmp_path)
+
+        with _mock_check_config(valid=False, errors=["Syntax error in automations.yaml"]):
+            result = await restore_config_backup(hass, {})
+
+        assert "Config check: ERRORS FOUND" in result["content"][0]["text"]
+
+    async def test_restore_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await restore_config_backup(hass, {})
+        assert "disabled" in result["content"][0]["text"].lower()
+
+    async def test_restore_backup_dir_exists_but_no_subdirs(self, tmp_path):
+        (tmp_path / "mcp_backups").mkdir()
+        hass = _make_hass(tmp_path)
+        result = await restore_config_backup(hass, {})
+        assert "No backups found" in result["content"][0]["text"]
+
+    async def test_restore_backup_with_no_yaml_files(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "readme.txt").write_text("not yaml")
+        hass = _make_hass(tmp_path)
+        result = await restore_config_backup(hass, {})
+        assert "contained no YAML files" in result["content"][0]["text"]
+
+    async def test_restore_check_failure_doesnt_hide_restore_success(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("[]")
+        hass = _make_hass(tmp_path)
+
+        with patch(
+            "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
+            side_effect=Exception("check unavailable"),
+        ):
+            result = await restore_config_backup(hass, {})
+
+        text = result["content"][0]["text"]
+        assert "Restored" in text
+        assert "Config check failed to run" in text
+
+    async def test_restore_handles_os_error(self, tmp_path):
+        backup_dir = tmp_path / "mcp_backups" / "2026-01-01_10-00-00-000000"
+        backup_dir.mkdir(parents=True)
+        (backup_dir / "automations.yaml").write_text("[]")
+        hass = _make_hass(tmp_path)
+
+        with patch("shutil.copy2", side_effect=OSError("disk full")):
+            result = await restore_config_backup(hass, {})
+
+        assert "Error restoring backup" in result["content"][0]["text"]
+
+
+class TestListConfigBackupsErrors:
+    async def test_list_handles_os_error(self, tmp_path):
+        (tmp_path / "mcp_backups").mkdir()
+        hass = _make_hass(tmp_path)
+        with patch.object(Path, "iterdir", side_effect=OSError("permission denied")):
+            result = await list_config_backups(hass, {})
+        assert "Error listing backups" in result["content"][0]["text"]
+
+
+class TestRunConfigCheck:
+    async def test_run_config_check_valid(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from custom_components.mcp_server_http_transport.tools.config_files import (
+            _run_config_check,
+        )
+
+        mock_res = MagicMock()
+        mock_res.errors = []
+        hass = Mock()
+
+        with patch(
+            "homeassistant.helpers.check_config.async_check_ha_config_file",
+            new=AsyncMock(return_value=mock_res),
+        ):
+            result = await _run_config_check(hass)
+
+        assert result == {"valid": True, "errors": []}
+
+    async def test_run_config_check_with_errors(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from custom_components.mcp_server_http_transport.tools.config_files import (
+            _run_config_check,
+        )
+
+        mock_res = MagicMock()
+        mock_res.errors = ["Invalid platform: sensor"]
+        hass = Mock()
+
+        with patch(
+            "homeassistant.helpers.check_config.async_check_ha_config_file",
+            new=AsyncMock(return_value=mock_res),
+        ):
+            result = await _run_config_check(hass)
+
+        assert result["valid"] is False
+        assert "Invalid platform: sensor" in result["errors"]

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock, patch
 
 from custom_components.mcp_server_http_transport.const import DOMAIN
 from custom_components.mcp_server_http_transport.tools.config_files import (
+    backup_config_files,
     delete_config_file,
     get_config_file,
     list_config_files,
@@ -43,6 +44,11 @@ class TestDisabledByDefault:
         result = await delete_config_file(hass, {"filename": "custom.yaml"})
         assert "disabled" in result["content"][0]["text"].lower()
         assert (tmp_path / "custom.yaml").exists()
+
+    async def test_backup_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await backup_config_files(hass, {})
+        assert "disabled" in result["content"][0]["text"].lower()
 
 
 class TestListConfigFiles:
@@ -262,3 +268,89 @@ class TestDeleteConfigFile:
         hass = _make_hass(tmp_path)
         result = await delete_config_file(hass, {"filename": "subdir/file.yaml"})
         assert "Subdirectories are not allowed" in result["content"][0]["text"]
+
+
+class TestBackupConfigFiles:
+    async def test_backup_creates_timestamped_folder(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("[]")
+        (tmp_path / "scripts.yaml").write_text("{}")
+        hass = _make_hass(tmp_path)
+
+        result = await backup_config_files(hass, {})
+        text = result["content"][0]["text"]
+
+        assert "mcp_backups/" in text
+        backup_dirs = list((tmp_path / "mcp_backups").iterdir())
+        assert len(backup_dirs) == 1
+        assert (backup_dirs[0] / "automations.yaml").exists()
+        assert (backup_dirs[0] / "scripts.yaml").exists()
+
+    async def test_backup_excludes_secrets(self, tmp_path):
+        (tmp_path / "configuration.yaml").write_text("homeassistant:")
+        (tmp_path / "secrets.yaml").write_text("token: abc")
+        hass = _make_hass(tmp_path)
+
+        await backup_config_files(hass, {})
+        backup_dir = next((tmp_path / "mcp_backups").iterdir())
+
+        assert (backup_dir / "configuration.yaml").exists()
+        assert not (backup_dir / "secrets.yaml").exists()
+
+    async def test_backup_excludes_non_yaml(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("[]")
+        (tmp_path / "readme.txt").write_text("ignored")
+        hass = _make_hass(tmp_path)
+
+        await backup_config_files(hass, {})
+        backup_dir = next((tmp_path / "mcp_backups").iterdir())
+
+        assert not (backup_dir / "readme.txt").exists()
+
+    async def test_backup_excludes_mcp_backups_folder(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("[]")
+        (tmp_path / "mcp_backups").mkdir()
+        hass = _make_hass(tmp_path)
+
+        await backup_config_files(hass, {})
+        backup_dir = next((tmp_path / "mcp_backups").iterdir())
+
+        assert not (backup_dir / "mcp_backups").exists()
+
+    async def test_backup_reports_file_count(self, tmp_path):
+        (tmp_path / "a.yaml").write_text("")
+        (tmp_path / "b.yaml").write_text("")
+        (tmp_path / "c.yml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await backup_config_files(hass, {})
+        text = result["content"][0]["text"]
+
+        assert "3 files" in text
+        assert "a.yaml" in text
+        assert "b.yaml" in text
+        assert "c.yml" in text
+
+    async def test_backup_empty_dir_no_folder_created(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await backup_config_files(hass, {})
+        assert "No YAML files" in result["content"][0]["text"]
+        assert not (tmp_path / "mcp_backups").exists()
+
+    async def test_multiple_backups_create_separate_folders(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("[]")
+        hass = _make_hass(tmp_path)
+
+        await backup_config_files(hass, {})
+        await backup_config_files(hass, {})
+
+        backup_dirs = list((tmp_path / "mcp_backups").iterdir())
+        assert len(backup_dirs) == 2
+
+    async def test_backup_handles_os_error(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("[]")
+        hass = _make_hass(tmp_path)
+
+        with patch("shutil.copy2", side_effect=OSError("disk full")):
+            result = await backup_config_files(hass, {})
+
+        assert "Error creating backup" in result["content"][0]["text"]

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -8,6 +8,7 @@ from custom_components.mcp_server_http_transport.const import DOMAIN
 from custom_components.mcp_server_http_transport.tools.config_files import (
     backup_config_files,
     batch_edit_config_files,
+    cleanup_config_backups,
     delete_config_file,
     get_config_file,
     list_config_backups,
@@ -804,3 +805,82 @@ class TestBatchEditConfigFiles:
         result = await batch_edit_config_files(hass, {})
         text = result["content"][0]["text"]
         assert "error" in text.lower()
+
+
+class TestCleanupConfigBackups:
+    def _make_backup(self, backup_root: Path, timestamp: str, filename: str = "automations.yaml"):
+        d = backup_root / timestamp
+        d.mkdir(parents=True)
+        (d / filename).write_text("[]")
+        return d
+
+    async def test_deletes_old_backups(self, tmp_path):
+        backup_root = tmp_path / "mcp_backups"
+        self._make_backup(backup_root, "2026-01-01_10-00-00-000000")
+        self._make_backup(backup_root, "2026-01-02_10-00-00-000000")
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {"older_than_days": 1})
+        text = result["content"][0]["text"]
+        assert "Deleted 2" in text
+        assert "0 backup(s) remaining" in text
+        assert not (backup_root / "2026-01-01_10-00-00-000000").exists()
+
+    async def test_keeps_recent_backups(self, tmp_path):
+        from datetime import timezone
+        backup_root = tmp_path / "mcp_backups"
+        # old backup
+        self._make_backup(backup_root, "2026-01-01_10-00-00-000000")
+        # recent backup using today's date
+        from datetime import date
+        today = date.today().strftime("%Y-%m-%d")
+        self._make_backup(backup_root, f"{today}_10-00-00-000000")
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {"older_than_days": 30})
+        text = result["content"][0]["text"]
+        assert "Deleted 1" in text
+        assert "1 backup(s) remaining" in text
+        assert (backup_root / f"{today}_10-00-00-000000").exists()
+
+    async def test_no_backups_found(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {})
+        assert "No backups found" in result["content"][0]["text"]
+
+    async def test_no_old_backups_to_delete(self, tmp_path):
+        from datetime import date
+        backup_root = tmp_path / "mcp_backups"
+        today = date.today().strftime("%Y-%m-%d")
+        self._make_backup(backup_root, f"{today}_10-00-00-000000")
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {"older_than_days": 30})
+        text = result["content"][0]["text"]
+        assert "Deleted 0" in text
+        assert "1 backup(s) remaining" in text
+
+    async def test_ignores_non_timestamp_dirs(self, tmp_path):
+        backup_root = tmp_path / "mcp_backups"
+        self._make_backup(backup_root, "2026-01-01_10-00-00-000000")
+        (backup_root / "@eaDir").mkdir()
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {"older_than_days": 1})
+        text = result["content"][0]["text"]
+        assert "Deleted 1" in text
+        assert (backup_root / "@eaDir").exists()
+
+    async def test_default_older_than_days_is_30(self, tmp_path):
+        backup_root = tmp_path / "mcp_backups"
+        self._make_backup(backup_root, "2026-01-01_10-00-00-000000")
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {})
+        text = result["content"][0]["text"]
+        assert "Deleted 1" in text
+
+    async def test_rejects_zero_days(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {"older_than_days": 0})
+        assert "error" in result["content"][0]["text"].lower()
+
+    async def test_disabled(self, tmp_path):
+        hass = _make_hass(tmp_path, config_file_access=False)
+        result = await cleanup_config_backups(hass, {})
+        assert "disabled" in result["content"][0]["text"].lower()

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -1,0 +1,237 @@
+"""Tests for config file access tools."""
+
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from custom_components.mcp_server_http_transport.tools.config_files import (
+    delete_config_file,
+    get_config_file,
+    list_config_files,
+    save_config_file,
+)
+
+
+def _make_hass(config_dir: Path) -> Mock:
+    hass = Mock()
+    hass.config.config_dir = str(config_dir)
+    return hass
+
+
+class TestListConfigFiles:
+    async def test_list_returns_yaml_files(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("[]")
+        (tmp_path / "scripts.yml").write_text("[]")
+        (tmp_path / "not_yaml.txt").write_text("ignored")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {})
+        files = json.loads(result["content"][0]["text"])
+
+        assert "automations.yaml" in files
+        assert "scripts.yml" in files
+        assert "not_yaml.txt" not in files
+
+    async def test_list_excludes_secrets(self, tmp_path):
+        (tmp_path / "secrets.yaml").write_text("token: abc")
+        (tmp_path / "configuration.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {})
+        files = json.loads(result["content"][0]["text"])
+
+        assert "secrets.yaml" not in files
+        assert "configuration.yaml" in files
+
+    async def test_list_excludes_secrets_yml_variant(self, tmp_path):
+        (tmp_path / "secrets.yml").write_text("token: abc")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {})
+        files = json.loads(result["content"][0]["text"])
+
+        assert "secrets.yml" not in files
+
+    async def test_list_excludes_subdirectories(self, tmp_path):
+        subdir = tmp_path / "packages"
+        subdir.mkdir()
+        (subdir / "lights.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {})
+        files = json.loads(result["content"][0]["text"])
+
+        assert "lights.yaml" not in files
+
+    async def test_list_returns_sorted(self, tmp_path):
+        (tmp_path / "zzz.yaml").write_text("")
+        (tmp_path / "aaa.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == sorted(files)
+
+    async def test_list_empty_dir(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await list_config_files(hass, {})
+        files = json.loads(result["content"][0]["text"])
+        assert files == []
+
+    async def test_list_handles_os_error(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with patch.object(Path, "iterdir", side_effect=OSError("permission denied")):
+            result = await list_config_files(hass, {})
+        assert "Error listing config files" in result["content"][0]["text"]
+
+
+class TestGetConfigFile:
+    async def test_read_existing_file(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("- alias: test\n")
+        hass = _make_hass(tmp_path)
+
+        result = await get_config_file(hass, {"filename": "automations.yaml"})
+
+        assert result["content"][0]["text"] == "- alias: test\n"
+
+    async def test_read_nonexistent_file(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "missing.yaml"})
+        assert "does not exist" in result["content"][0]["text"]
+
+    async def test_read_blocks_secrets(self, tmp_path):
+        (tmp_path / "secrets.yaml").write_text("token: abc")
+        hass = _make_hass(tmp_path)
+
+        result = await get_config_file(hass, {"filename": "secrets.yaml"})
+
+        assert "blocked" in result["content"][0]["text"]
+
+    async def test_read_blocks_non_yaml(self, tmp_path):
+        (tmp_path / "script.py").write_text("import os")
+        hass = _make_hass(tmp_path)
+
+        result = await get_config_file(hass, {"filename": "script.py"})
+
+        assert (
+            "Error" in result["content"][0]["text"] or "Only YAML" in result["content"][0]["text"]
+        )
+
+    async def test_read_blocks_subdirectory_path(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "subdir/file.yaml"})
+        assert "Subdirectories are not allowed" in result["content"][0]["text"]
+
+    async def test_read_blocks_path_traversal(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "../etc/passwd"})
+        assert "Subdirectories are not allowed" in result["content"][0]["text"]
+
+    async def test_read_blocks_symlink_escape(self, tmp_path):
+        """Symlink pointing outside config_dir must be blocked by is_relative_to check."""
+        outside = tmp_path.parent / "outside.yaml"
+        outside.write_text("secret: data")
+        link = tmp_path / "escape.yaml"
+        link.symlink_to(outside)
+        hass = _make_hass(tmp_path)
+
+        result = await get_config_file(hass, {"filename": "escape.yaml"})
+
+        assert "Path traversal detected" in result["content"][0]["text"]
+
+    async def test_read_blocks_oversized_file(self, tmp_path):
+        large_file = tmp_path / "big.yaml"
+        large_file.write_bytes(b"x: y\n" * 300_000)  # > 1 MB
+        hass = _make_hass(tmp_path)
+
+        result = await get_config_file(hass, {"filename": "big.yaml"})
+
+        assert "too large" in result["content"][0]["text"]
+
+    async def test_read_yml_extension(self, tmp_path):
+        (tmp_path / "scripts.yml").write_text("my_script:\n  sequence: []\n")
+        hass = _make_hass(tmp_path)
+
+        result = await get_config_file(hass, {"filename": "scripts.yml"})
+
+        assert "my_script" in result["content"][0]["text"]
+
+
+class TestSaveConfigFile:
+    async def test_write_new_file(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await save_config_file(hass, {"filename": "new.yaml", "content": "key: value\n"})
+
+        assert "Successfully saved" in result["content"][0]["text"]
+        assert (tmp_path / "new.yaml").read_text() == "key: value\n"
+
+    async def test_overwrite_existing_file(self, tmp_path):
+        (tmp_path / "automations.yaml").write_text("old content")
+        hass = _make_hass(tmp_path)
+
+        await save_config_file(hass, {"filename": "automations.yaml", "content": "new content"})
+
+        assert (tmp_path / "automations.yaml").read_text() == "new content"
+
+    async def test_write_blocks_secrets(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await save_config_file(
+            hass, {"filename": "secrets.yaml", "content": "token: hacked"}
+        )
+        assert "blocked" in result["content"][0]["text"]
+        assert not (tmp_path / "secrets.yaml").exists()
+
+    async def test_write_blocks_non_yaml(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await save_config_file(hass, {"filename": "malicious.sh", "content": "rm -rf /"})
+        assert (
+            "Error" in result["content"][0]["text"] or "Only YAML" in result["content"][0]["text"]
+        )
+        assert not (tmp_path / "malicious.sh").exists()
+
+    async def test_write_blocks_subdirectory_path(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await save_config_file(hass, {"filename": "subdir/file.yaml", "content": "x: 1"})
+        assert "Subdirectories are not allowed" in result["content"][0]["text"]
+
+
+class TestDeleteConfigFile:
+    async def test_delete_existing_file(self, tmp_path):
+        (tmp_path / "custom.yaml").write_text("x: 1")
+        hass = _make_hass(tmp_path)
+
+        result = await delete_config_file(hass, {"filename": "custom.yaml"})
+
+        assert "Successfully deleted" in result["content"][0]["text"]
+        assert not (tmp_path / "custom.yaml").exists()
+
+    async def test_delete_nonexistent_file(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await delete_config_file(hass, {"filename": "ghost.yaml"})
+        assert "does not exist" in result["content"][0]["text"]
+
+    async def test_delete_blocks_secrets(self, tmp_path):
+        (tmp_path / "secrets.yaml").write_text("token: abc")
+        hass = _make_hass(tmp_path)
+
+        result = await delete_config_file(hass, {"filename": "secrets.yaml"})
+
+        assert "blocked" in result["content"][0]["text"]
+        assert (tmp_path / "secrets.yaml").exists()
+
+    async def test_delete_blocks_non_yaml(self, tmp_path):
+        (tmp_path / "script.py").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await delete_config_file(hass, {"filename": "script.py"})
+
+        assert (
+            "Error" in result["content"][0]["text"] or "Only YAML" in result["content"][0]["text"]
+        )
+        assert (tmp_path / "script.py").exists()
+
+    async def test_delete_blocks_subdirectory_path(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await delete_config_file(hass, {"filename": "subdir/file.yaml"})
+        assert "Subdirectories are not allowed" in result["content"][0]["text"]

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -806,6 +806,46 @@ class TestBatchEditConfigFiles:
         text = result["content"][0]["text"]
         assert "error" in text.lower()
 
+    async def test_delete_invalid_filename_returns_error(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await batch_edit_config_files(hass, {"deletes": ["secrets.yaml"]})
+        assert "Error in deletes" in result["content"][0]["text"]
+
+    async def test_save_write_failure_reports_error(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup(), _mock_check_config(), patch(
+            "pathlib.Path.write_text", side_effect=OSError("disk full")
+        ):
+            result = await batch_edit_config_files(
+                hass, {"saves": [{"filename": "x.yaml", "content": "x: 1"}]}
+            )
+        text = result["content"][0]["text"]
+        assert "Errors:" in text
+        assert "disk full" in text
+
+    async def test_delete_unlink_failure_reports_error(self, tmp_path):
+        (tmp_path / "x.yaml").write_text("x: 1")
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup(), _mock_check_config(), patch(
+            "pathlib.Path.unlink", side_effect=OSError("permission denied")
+        ):
+            result = await batch_edit_config_files(hass, {"deletes": ["x.yaml"]})
+        text = result["content"][0]["text"]
+        assert "Errors:" in text
+        assert "permission denied" in text
+
+    async def test_config_check_exception_reported(self, tmp_path):
+        from unittest.mock import AsyncMock
+        hass = _make_hass(tmp_path)
+        with _mock_create_backup(), patch(
+            "custom_components.mcp_server_http_transport.tools.config_files._run_config_check",
+            new=AsyncMock(side_effect=Exception("check exploded")),
+        ):
+            result = await batch_edit_config_files(
+                hass, {"saves": [{"filename": "x.yaml", "content": "x: 1"}]}
+            )
+        assert "check exploded" in result["content"][0]["text"]
+
 
 class TestCleanupConfigBackups:
     def _make_backup(self, backup_root: Path, timestamp: str, filename: str = "automations.yaml"):
@@ -879,6 +919,31 @@ class TestCleanupConfigBackups:
         hass = _make_hass(tmp_path)
         result = await cleanup_config_backups(hass, {"older_than_days": 0})
         assert "error" in result["content"][0]["text"].lower()
+
+    async def test_skips_dir_matching_regex_but_invalid_date(self, tmp_path):
+        # Regex matches but strptime fails (e.g. month 13) — must be skipped silently.
+        backup_root = tmp_path / "mcp_backups"
+        self._make_backup(backup_root, "2026-01-01_10-00-00-000000")
+        (backup_root / "2026-13-99_99-99-99-000000").mkdir()
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {"older_than_days": 1})
+        text = result["content"][0]["text"]
+        assert "Deleted 1" in text
+
+    async def test_no_valid_dirs_in_existing_backup_root(self, tmp_path):
+        backup_root = tmp_path / "mcp_backups"
+        backup_root.mkdir()
+        (backup_root / "@eaDir").mkdir()
+        hass = _make_hass(tmp_path)
+        result = await cleanup_config_backups(hass, {})
+        assert "No backups found" in result["content"][0]["text"]
+
+    async def test_handles_os_error(self, tmp_path):
+        (tmp_path / "mcp_backups").mkdir()
+        hass = _make_hass(tmp_path)
+        with patch.object(Path, "iterdir", side_effect=OSError("permission denied")):
+            result = await cleanup_config_backups(hass, {})
+        assert "Error cleaning up backups" in result["content"][0]["text"]
 
     async def test_disabled(self, tmp_path):
         hass = _make_hass(tmp_path, config_file_access=False)


### PR DESCRIPTION
## Summary                                                                                                                        
                                                                                                                                      
  This PR introduces full CRUD access to Home Assistant YAML configuration files via nine new MCP tools,                              
  gated behind an explicit opt-in setting. Every write and delete operation automatically creates a
  timestamped backup and runs a config validation, so the AI assistant can safely read and edit config                                
  files without risk of unrecoverable changes.                                                                                        
                                                                                                                                      
  ## New Tools                                                                                                                        
                                                                                              
  | Tool | Description |                                                                                                              
  |------|-------------|                 
  | `list_config_files` | List all first-level YAML files in the config directory (secrets excluded) |                                
  | `get_config_file` | Read the contents of a YAML config file (max 1 MB) |               
  | `save_config_file` | Write or replace a YAML file; auto-backs up all files first, then validates config |                         
  | `delete_config_file` | Delete a YAML file; auto-backs up all files first |                                                        
  | `batch_edit_config_files` | Write and/or delete multiple files in one call — one backup and one config check for the whole batch |
  | `backup_config_files` | Manually create a timestamped snapshot of all YAML files |                                                
  | `list_config_backups` | List all available backup snapshots, newest first |                                                       
  | `restore_config_backup` | Restore files from the latest or a specific backup; runs config check after |                           
  | `cleanup_config_backups` | Delete backup snapshots older than N days (default: 30) to keep the folder manageable |                
                                                                                                                                      
  ## Design Decisions                                                                                                                 
                                                                                                                                      
  **Opt-in only.** Config file access is disabled by default and must be explicitly enabled under                                     
  Settings → Devices & Services → MCP Server → Configure. Users who don't need file access are
  not exposed to additional attack surface.                                                                                           
                                                                                           
  **First-level YAML files only.** Subdirectories, `secrets.yaml`, and non-YAML files are blocked.                                    
  Path traversal is rejected at the resolver level.                                        
                                                                                                                                      
  **Automatic backup before every change.** `save_config_file` and `delete_config_file` each create                                   
  a full snapshot before touching anything. `batch_edit_config_files` creates exactly one backup for
  the entire batch regardless of how many files are modified, avoiding redundant snapshots.                                           
                                                                                                                                      
  **Config validation on every write.** After each save or restore, `async_check_ha_config_file` runs                                 
  automatically and reports errors inline without undoing the change — same behaviour as the HA config                                
  check UI.                                                                                                                           
                                                                                              
  **Backup listing is resilient to NAS metadata folders.** Synology and other NAS systems create                                      
  directories like `@eaDir` inside any folder they index. Only directories matching the    
  `YYYY-MM-DD_HH-MM-SS-FFFFFF` timestamp format are treated as valid snapshots.                                                       
                                                                                                                                      
  ## Testing                                                                                                                          
                                                                                                                                      
  92 new test cases cover all nine tools, including path traversal attempts, secrets blocking,                                        
  oversized file rejection, backup creation and filtering, config check integration, batch    
  validation, and the disabled-feature guard. All 442 tests pass. Tested on a live instance                                           
  (Home Assistant running on Synology NAS via Docker).                                                                                
                                                                                                                                      
  ## Deployment Note                                                                                                                  
                                                                                                                                      
  Config file access is off by default. After installing, users must explicitly enable it in the                                      
  integration settings. The tool list is loaded at MCP session start — clients need to reconnect
  after enabling the feature to see the new tools. 