### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.7.4"
+  "version": "1.8.0"
 }


### PR DESCRIPTION
Cuts a release for the work landed since 1.7.4.

### Highlights

- **#41** — Helper entity CRUD tools (`list_helpers`, `get_helper_config`, `create_helper`, `update_helper`, `delete_helper`). All marked experimental in the README.
- **#42** — Opt-in config file access tools (`list_config_files`, `get_config_file`, `save_config_file`, `delete_config_file`, `batch_edit_config_files`, `backup_config_files`, `list_config_backups`, `cleanup_config_backups`, `restore_config_backup`). Gated behind a new `config_file_access_enabled` setting. Auto-backup before every write/delete and pre-restore snapshot for safety.
- **#45** — Hardening of the config file tools: atomic writes (tempfile + os.replace), backup I/O moved off the event loop, and direct edits to `automations.yaml` / `scenes.yaml` / `scripts.yaml` blocked in favor of the dedicated CRUD tools.

### Why minor

Two new tool families and a new opt-in config option, both backwards-compatible additions. Matches the prior 1.6.0 → 1.7.0 bump (native HA authentication) in scope.

### Release flow

Merging this triggers `.github/workflows/create-release.yml`, which tags `v1.8.0` and publishes a release with the integration zip.