### PR TITLE
fix: fall back to in-memory system log when log file is absent

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.8.1"
+  "version": "1.8.2"
 }

--- a/custom_components/mcp_server_http_transport/tools/system_admin.py
+++ b/custom_components/mcp_server_http_transport/tools/system_admin.py
@@ -77,12 +77,19 @@ def _read_system_log_buffer(hass: HomeAssistant, limit: int) -> str | None:
     to_list = getattr(getattr(handler, "records", None), "to_list", None)
     if not callable(to_list):
         return None
-    entries = to_list()
-    if not isinstance(entries, list) or not entries:
+    # The caller invokes this inside `except FileNotFoundError`, where a sibling
+    # `except Exception` can't catch a throw originating here. Guard the buffer
+    # read and formatting so any failure degrades to the not-found message
+    # rather than escaping as an internal error.
+    try:
+        entries = to_list()
+        if not isinstance(entries, list) or not entries:
+            return None
+        shown = entries[: max(1, limit)]
+        formatted = "\n".join(_format_system_log_entry(entry) for entry in shown)
+    except Exception as e:
+        _LOGGER.debug("Could not read system log buffer: %s", e)
         return None
-
-    shown = entries[: max(1, limit)]
-    formatted = "\n".join(_format_system_log_entry(entry) for entry in shown)
     header = (
         f"home-assistant.log not found; showing the {len(shown)} most recent "
         "WARNING/ERROR entries from Home Assistant's in-memory system log buffer "

--- a/custom_components/mcp_server_http_transport/tools/system_admin.py
+++ b/custom_components/mcp_server_http_transport/tools/system_admin.py
@@ -3,6 +3,7 @@
 import json
 import logging
 from collections import deque
+from datetime import datetime
 from typing import Any
 
 from homeassistant.const import __version__ as HA_VERSION
@@ -15,7 +16,11 @@ _LOGGER = logging.getLogger(__name__)
 
 @register_tool(
     name="get_error_log",
-    description="Fetch the Home Assistant error log. Returns the last N lines of the log file",
+    description=(
+        "Fetch the Home Assistant error log. Returns the last N lines of the log file. "
+        "If on-disk file logging is disabled, falls back to the recent WARNING/ERROR "
+        "entries Home Assistant keeps in memory"
+    ),
     input_schema={
         "type": "object",
         "properties": {
@@ -27,28 +32,98 @@ _LOGGER = logging.getLogger(__name__)
     },
 )
 async def get_error_log(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Fetch the Home Assistant error log."""
+    """Fetch the Home Assistant error log, falling back to the in-memory buffer."""
     lines = arguments.get("lines", 100)
     log_path = hass.config.path("home-assistant.log")
 
+    def _read_log():
+        with open(log_path) as f:
+            return "".join(deque(f, maxlen=lines))
+
     try:
-
-        def _read_log():
-            try:
-                with open(log_path) as f:
-                    return "".join(deque(f, maxlen=lines))
-            except FileNotFoundError:
-                return (
-                    f"Log file not found at {log_path}. "
-                    "Home Assistant may not be configured to write logs to disk; "
-                    "enable file logging via the 'logger:' integration in configuration.yaml."
-                )
-
         log_text = await hass.async_add_executor_job(_read_log)
         return {"content": [{"type": "text", "text": log_text}]}
+    except FileNotFoundError:
+        fallback = _read_system_log_buffer(hass, lines)
+        if fallback is not None:
+            return {"content": [{"type": "text", "text": fallback}]}
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Log file not found at {log_path}, and Home Assistant's in-memory "
+                        "system log buffer is empty or unavailable. Home Assistant may not be "
+                        "configured to write logs to disk; enable file logging via the "
+                        "'logger:' integration in configuration.yaml."
+                    ),
+                }
+            ]
+        }
     except Exception as e:
         _LOGGER.error("Error reading error log: %s", e)
         return {"content": [{"type": "text", "text": f"Error reading error log: {str(e)}"}]}
+
+
+def _read_system_log_buffer(hass: HomeAssistant, limit: int) -> str | None:
+    """Render recent WARNING/ERROR entries from HA's in-memory system log, or None.
+
+    The system_log component keeps a deduplicated buffer of recent warning and
+    error records in memory regardless of whether on-disk file logging is
+    enabled, so it gives useful output on installs where home-assistant.log is
+    absent. Returns None when the component is unavailable or the buffer is empty.
+    """
+    handler = hass.data.get("system_log")
+    to_list = getattr(getattr(handler, "records", None), "to_list", None)
+    if not callable(to_list):
+        return None
+    entries = to_list()
+    if not isinstance(entries, list) or not entries:
+        return None
+
+    shown = entries[: max(1, limit)]
+    formatted = "\n".join(_format_system_log_entry(entry) for entry in shown)
+    header = (
+        f"home-assistant.log not found; showing the {len(shown)} most recent "
+        "WARNING/ERROR entries from Home Assistant's in-memory system log buffer "
+        "(on-disk file logging appears to be disabled):\n\n"
+    )
+    return header + formatted
+
+
+def _format_system_log_entry(entry: dict[str, Any]) -> str:
+    """Format one system_log entry dict into a readable log-style line."""
+    timestamp = entry.get("timestamp")
+    try:
+        ts = datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S")
+    except (TypeError, ValueError, OSError):
+        ts = str(timestamp)
+
+    source = entry.get("source")
+    if isinstance(source, (list, tuple)) and len(source) == 2:
+        source_str = f"{source[0]}:{source[1]}"
+    elif source is not None:
+        source_str = str(source)
+    else:
+        source_str = "?"
+
+    messages = entry.get("message")
+    if isinstance(messages, (list, tuple)):
+        message = "; ".join(str(m) for m in messages)
+    else:
+        message = str(messages) if messages is not None else ""
+
+    count = entry.get("count", 1)
+    count_str = f" ({count}x)" if isinstance(count, int) and count > 1 else ""
+
+    line = (
+        f"{ts} {entry.get('level', '')} ({entry.get('name', '')}) "
+        f"[{source_str}] {message}{count_str}"
+    )
+    exception = entry.get("exception")
+    if exception:
+        line += f"\n{exception}"
+    return line
 
 
 @register_tool(

--- a/tests/test_tools_system_admin.py
+++ b/tests/test_tools_system_admin.py
@@ -7,6 +7,9 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from custom_components.mcp_server_http_transport.http import MCPEndpointView
+from custom_components.mcp_server_http_transport.tools.system_admin import (
+    _format_system_log_entry,
+)
 
 
 class TestToolsSystemAdmin:
@@ -640,3 +643,32 @@ class TestToolsSystemAdmin:
         body = json.loads(response.body)
         text = body["result"]["content"][0]["text"]
         assert "Error checking config" in text
+
+
+class TestFormatSystemLogEntry:
+    """Cover the defensive formatting branches for odd-shaped system_log entries."""
+
+    def test_odd_field_shapes(self):
+        """Non-numeric timestamp, string source, and string message all render."""
+        line = _format_system_log_entry(
+            {
+                "timestamp": "not-an-epoch",
+                "level": "WARNING",
+                "name": "custom.logger",
+                "source": "single-source",
+                "message": "plain string message",
+                "count": 1,
+            }
+        )
+        assert "not-an-epoch" in line  # timestamp parse fell back to str()
+        assert "WARNING" in line
+        assert "(custom.logger)" in line
+        assert "[single-source]" in line  # non-tuple source rendered as-is
+        assert "plain string message" in line
+        assert "(1x)" not in line  # count of 1 adds no suffix
+
+    def test_missing_source_and_message(self):
+        """Absent source and message degrade to a placeholder and empty string."""
+        line = _format_system_log_entry({"timestamp": 1_700_000_000.0, "level": "ERROR"})
+        assert "[?]" in line  # source is None -> "?"
+        assert "ERROR" in line

--- a/tests/test_tools_system_admin.py
+++ b/tests/test_tools_system_admin.py
@@ -84,7 +84,9 @@ class TestToolsSystemAdmin:
     async def test_post_tools_call_get_error_log_file_not_found(self, view, mock_hass):
         """Test POST with tools/call for get_error_log when file is missing."""
         mock_hass.config.path.return_value = "/config/home-assistant.log"
-        mock_hass.async_add_executor_job = AsyncMock(return_value="Log file not found")
+        # Integration loaded, but no system_log buffer available.
+        mock_hass.data = {"mcp_server_http_transport": True}
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=FileNotFoundError())
 
         request = Mock()
         request.headers = {"Authorization": "Bearer valid_token"}
@@ -457,6 +459,8 @@ class TestToolsSystemAdmin:
     async def test_post_tools_call_get_error_log_file_missing(self, view, mock_hass):
         """Test get_error_log when log file does not exist (FileNotFoundError)."""
         mock_hass.config.path.return_value = "/nonexistent/path/home-assistant.log"
+        # Integration loaded, but no system_log buffer available.
+        mock_hass.data = {"mcp_server_http_transport": True}
 
         async def run_fn(fn, *args):
             return fn(*args) if args else fn()
@@ -483,6 +487,79 @@ class TestToolsSystemAdmin:
         assert "Log file not found" in text
         # The checked path is included so users can confirm where we looked (#48).
         assert "/nonexistent/path/home-assistant.log" in text
+        assert "logger:" in text
+
+    async def test_get_error_log_falls_back_to_system_log_buffer(self, view, mock_hass):
+        """When the file is missing, fall back to the in-memory system_log buffer (#48)."""
+        mock_hass.config.path.return_value = "/nonexistent/home-assistant.log"
+
+        # Mimic homeassistant.components.system_log: hass.data["system_log"].records.to_list().
+        handler = Mock()
+        handler.records.to_list.return_value = [
+            {
+                "name": "homeassistant.components.foo",
+                "message": ["Something broke"],
+                "level": "ERROR",
+                "source": ["components/foo/__init__.py", 42],
+                "timestamp": 1_700_000_000.0,
+                "exception": "Traceback (most recent call last):\n  ...\nValueError: boom",
+                "count": 3,
+                "first_occurred": 1_700_000_000.0,
+            }
+        ]
+        mock_hass.data = {"mcp_server_http_transport": True, "system_log": handler}
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=FileNotFoundError())
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "get_error_log", "arguments": {}},
+                "id": 256,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        text = body["result"]["content"][0]["text"]
+        assert "in-memory system log buffer" in text
+        assert "Something broke" in text
+        assert "ERROR" in text
+        assert "components/foo/__init__.py:42" in text
+        assert "(3x)" in text
+        assert "ValueError: boom" in text
+
+    async def test_get_error_log_empty_buffer_returns_not_found(self, view, mock_hass):
+        """An empty system_log buffer falls through to the not-found message."""
+        mock_hass.config.path.return_value = "/nonexistent/home-assistant.log"
+        handler = Mock()
+        handler.records.to_list.return_value = []
+        mock_hass.data = {"mcp_server_http_transport": True, "system_log": handler}
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=FileNotFoundError())
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "get_error_log", "arguments": {}},
+                "id": 257,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        text = body["result"]["content"][0]["text"]
+        assert "Log file not found" in text
         assert "logger:" in text
 
     async def test_post_tools_call_restart_ha_error(self, view, mock_hass):

--- a/tests/test_tools_system_admin.py
+++ b/tests/test_tools_system_admin.py
@@ -562,6 +562,34 @@ class TestToolsSystemAdmin:
         assert "Log file not found" in text
         assert "logger:" in text
 
+    async def test_get_error_log_buffer_read_failure_degrades_to_not_found(self, view, mock_hass):
+        """If the system_log buffer raises, degrade to the not-found message, not a 500."""
+        mock_hass.config.path.return_value = "/nonexistent/home-assistant.log"
+        handler = Mock()
+        handler.records.to_list.side_effect = RuntimeError("buffer exploded")
+        mock_hass.data = {"mcp_server_http_transport": True, "system_log": handler}
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=FileNotFoundError())
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "get_error_log", "arguments": {}},
+                "id": 258,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        text = body["result"]["content"][0]["text"]
+        assert "Log file not found" in text
+        assert "logger:" in text
+
     async def test_post_tools_call_restart_ha_error(self, view, mock_hass):
         """Test restart_ha when service call raises."""
         mock_hass.services.async_call = AsyncMock(side_effect=Exception("Service error"))


### PR DESCRIPTION
Completes the log-retrieval half of #48 that #49 only diagnosed.

`get_error_log` reads `home-assistant.log` from the config directory. On installs that don't write that file to disk (HAOS setups logging to journald, or any install without file logging configured) the tool returned only "Log file not found" and was effectively unusable, which is the original report in #48. #49 improved that message but did not make logs retrievable.

This adds a fallback: when the file is absent, the tool reads Home Assistant's `system_log` component buffer (`hass.data["system_log"].records`) and renders its deduplicated WARNING/ERROR entries (timestamp, level, logger, source, message, occurrence count, and any traceback). That buffer is maintained in memory regardless of file-logging configuration, so the tool now returns something useful on installs where the file is missing. When the component is unavailable or the buffer is empty, it falls through to the explanatory not-found message from #49.

The buffer read is in-memory only (no I/O), so it runs without the executor; the file read stays on the executor.

Version bumped 1.8.1 → 1.8.2.
