### PR TITLE
Add KNX tools: telegram history + entity read/write

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `list_integrations` | List installed integrations and their status |
 | `list_labels` | List all labels for cross-domain grouping |
 
+**KNX**
+
+| Tool | Description |
+|------|-------------|
+| `knx_recent_telegrams` | Read Home Assistant's KNX group-monitor telegram history — recent bus telegrams incl. **source device** and decoded value; regex-filter by group address / name, with a result limit. Retrospective (reads the stored buffer), ideal for finding which KNX device wrote a given group address |
+
 **Camera & Images**
 
 These tools are disabled by default; enable them per capability via Settings → Devices & Services → MCP Server → Configure. They return images directly to the model for visual analysis.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,11 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | Tool | Description |
 |------|-------------|
 | `knx_recent_telegrams` | Read Home Assistant's KNX group-monitor telegram history — recent bus telegrams incl. **source device** and decoded value; regex-filter by group address / name, with a result limit. Retrospective (reads the stored buffer), ideal for finding which KNX device wrote a given group address |
+| `knx_get_base_data` | KNX connection + project info: bus connection status, gateway address, xknx version, loaded ETS project metadata, and UI-creatable platforms |
+| `knx_get_entities` | List KNX group addresses and the entities bound to each (the KNX-specific group-address↔entity binding view); optional regex filter on the group address |
+| `knx_create_entity` | Create a KNX entity in the KNX UI config (config_store) from `platform` + `data` (experimental) |
+| `knx_update_entity` | Update a UI-managed KNX entity by `entity_id` (experimental) |
+| `knx_delete_entity` | Delete a UI-managed KNX entity by `entity_id` (experimental) |
 
 **Camera & Images**
 

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "mcp_server_http_transport",
   "name": "MCP Server (HTTP Transport)",
-  "after_dependencies": ["recorder", "lovelace", "logbook", "camera"],
+  "after_dependencies": ["recorder", "lovelace", "camera"],
   "codeowners": ["@ganhammar"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "mcp_server_http_transport",
   "name": "MCP Server (HTTP Transport)",
-  "after_dependencies": ["recorder", "lovelace", "camera"],
+  "after_dependencies": ["recorder", "lovelace", "logbook", "camera", "knx"],
   "codeowners": ["@ganhammar"],
   "config_flow": true,
   "dependencies": [],

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -48,6 +48,7 @@ from . import (  # noqa: E402
     entities,  # noqa: F401
     helpers,  # noqa: F401
     images,  # noqa: F401
+    knx,  # noqa: F401
     statistics,  # noqa: F401
     system,  # noqa: F401
     system_admin,  # noqa: F401

--- a/custom_components/mcp_server_http_transport/tools/knx.py
+++ b/custom_components/mcp_server_http_transport/tools/knx.py
@@ -1,12 +1,13 @@
 """KNX bus tools — read Home Assistant's KNX group-monitor telegram history."""
 
+import json
 import logging
 import re
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from . import register_tool
+from . import _HAJSONEncoder, register_tool
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -109,11 +110,12 @@ async def knx_recent_telegrams(hass: HomeAssistant, arguments: dict[str, Any]) -
         and (name_re is None or name_re.search(str(t.get("destination_name", ""))))
     ]
 
-    limit = arguments.get("limit") or 200
+    _lim = arguments.get("limit")
+    limit = max(1, int(_lim) if _lim is not None else 200)
     returned = matched[-limit:]
     timestamps = [t.get("timestamp") for t in telegrams if t.get("timestamp")]
 
-    return {
+    result = {
         "buffer_size": len(telegrams),
         "buffer_span": {
             "oldest": min(timestamps) if timestamps else None,
@@ -123,6 +125,7 @@ async def knx_recent_telegrams(hass: HomeAssistant, arguments: dict[str, Any]) -
         "returned": len(returned),
         "telegrams": returned,
     }
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 def _not_setup() -> dict[str, Any]:
@@ -169,12 +172,13 @@ async def knx_get_base_data(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         project_info = knx.project.info
     except Exception:  # noqa: BLE001
         project_info = None
-    return {
+    result = {
         "connection": connection,
         "xknx_version": xknx_version,
         "project_info": project_info,
         "supported_platforms": _supported_platforms_ui(),
     }
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -230,8 +234,10 @@ async def knx_get_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         ents = list(identifiers) if isinstance(identifiers, (list, tuple, set)) else [identifiers]
         rows.append({"group_address": ga, "entities": [str(e) for e in ents]})
 
-    limit = arguments.get("limit") or 200
-    return {"count": len(rows), "entities_by_group": rows[:limit]}
+    _lim = arguments.get("limit")
+    limit = max(1, int(_lim) if _lim is not None else 200)
+    result = {"count": len(rows), "entities_by_group": rows[:limit]}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 # --- Write tools (experimental): mutate HA's KNX UI config via config_store ---
@@ -275,7 +281,8 @@ async def knx_create_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         entity_id = await knx.config_store.create_entity(platform, data)
     except Exception as err:  # noqa: BLE001
         return {"content": [{"type": "text", "text": f"create_entity failed: {err}"}]}
-    return {"created": True, "entity_id": entity_id, "platform": platform}
+    result = {"created": True, "entity_id": entity_id, "platform": platform}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -313,7 +320,8 @@ async def knx_update_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         await knx.config_store.update_entity(platform, entity_id, data)
     except Exception as err:  # noqa: BLE001
         return {"content": [{"type": "text", "text": f"update_entity failed: {err}"}]}
-    return {"updated": True, "entity_id": entity_id, "platform": platform}
+    result = {"updated": True, "entity_id": entity_id, "platform": platform}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 
 
 @register_tool(
@@ -340,4 +348,5 @@ async def knx_delete_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         await knx.config_store.delete_entity(entity_id)
     except Exception as err:  # noqa: BLE001
         return {"content": [{"type": "text", "text": f"delete_entity failed: {err}"}]}
-    return {"deleted": True, "entity_id": entity_id}
+    result = {"deleted": True, "entity_id": entity_id}
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}

--- a/custom_components/mcp_server_http_transport/tools/knx.py
+++ b/custom_components/mcp_server_http_transport/tools/knx.py
@@ -123,3 +123,221 @@ async def knx_recent_telegrams(hass: HomeAssistant, arguments: dict[str, Any]) -
         "returned": len(returned),
         "telegrams": returned,
     }
+
+
+def _not_setup() -> dict[str, Any]:
+    return {"content": [{"type": "text", "text": "KNX integration is not set up."}]}
+
+
+def _supported_platforms_ui():
+    """UI-creatable KNX platforms, or None if unavailable on this HA version."""
+    try:
+        from homeassistant.components.knx.const import SUPPORTED_PLATFORMS_UI
+
+        return sorted(str(p) for p in SUPPORTED_PLATFORMS_UI)
+    except Exception:  # pragma: no cover - older HA / KNX missing
+        return None
+
+
+@register_tool(
+    name="knx_get_base_data",
+    description=(
+        "Return KNX connection and project info: bus connection status, the "
+        "gateway's individual address, xknx version, the loaded ETS project "
+        "metadata (name / last modified), and the platforms creatable via the "
+        "KNX UI. Useful context before inspecting or creating KNX entities."
+    ),
+    input_schema={"type": "object", "properties": {}},
+)
+async def knx_get_base_data(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return KNX connection + project base data."""
+    knx = _get_knx_module(hass)
+    if knx is None:
+        return _not_setup()
+    connection: dict[str, Any] = {}
+    xknx_version = None
+    try:
+        xknx = knx.xknx
+        xknx_version = getattr(xknx, "version", None)
+        connection = {
+            "connected": bool(xknx.connection_manager.connected.is_set()),
+            "current_address": str(getattr(xknx, "current_address", "") or ""),
+        }
+    except Exception as err:  # noqa: BLE001
+        connection = {"error": str(err)[:120]}
+    try:
+        project_info = knx.project.info
+    except Exception:  # noqa: BLE001
+        project_info = None
+    return {
+        "connection": connection,
+        "xknx_version": xknx_version,
+        "project_info": project_info,
+        "supported_platforms": _supported_platforms_ui(),
+    }
+
+
+@register_tool(
+    name="knx_get_entities",
+    description=(
+        "List KNX group addresses and the entities bound to each — the "
+        "KNX-specific binding view (which group address maps to which entity) "
+        "that generic entity tools don't expose. Optional regex filter on the "
+        "group address, plus a limit."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "filter_ga": {
+                "type": "string",
+                "description": (
+                    "Regex matched against the group address (e.g. '^0/0/' or '^1/2/15$')."
+                ),
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Max number of group addresses to return (default 200).",
+            },
+        },
+    },
+)
+async def knx_get_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """List KNX group-address -> entity bindings."""
+    knx = _get_knx_module(hass)
+    if knx is None:
+        return _not_setup()
+    try:
+        mapping = dict(knx.group_address_entities)
+    except AttributeError:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "KNX group-address/entity mapping unavailable on this HA version.",
+                }
+            ]
+        }
+    try:
+        ga_re = re.compile(arguments["filter_ga"]) if arguments.get("filter_ga") else None
+    except re.error as err:
+        return {"content": [{"type": "text", "text": f"Invalid regex: {err}"}]}
+
+    rows = []
+    for ga, identifiers in mapping.items():
+        ga = str(ga)
+        if ga_re and not ga_re.search(ga):
+            continue
+        ents = list(identifiers) if isinstance(identifiers, (list, tuple, set)) else [identifiers]
+        rows.append({"group_address": ga, "entities": [str(e) for e in ents]})
+
+    limit = arguments.get("limit") or 200
+    return {"count": len(rows), "entities_by_group": rows[:limit]}
+
+
+# --- Write tools (experimental): mutate HA's KNX UI config via config_store ---
+
+
+@register_tool(
+    name="knx_create_entity",
+    description=(
+        "Create a KNX entity in Home Assistant's UI config (the KNX "
+        "config_store) — experimental. 'platform' is the KNX platform (light, "
+        "switch, climate, cover, binary_sensor, sensor, ...) and 'data' is the "
+        "platform-specific config (group addresses, DPTs, name) matching HA's "
+        "KNX UI schema. Returns the new entity_id and reloads the platform. "
+        "Use knx_get_base_data for the supported platforms."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "platform": {
+                "type": "string",
+                "description": "KNX platform (light, switch, climate, cover, ...).",
+            },
+            "data": {
+                "type": "object",
+                "description": "Platform-specific KNX entity config (HA KNX UI schema).",
+            },
+        },
+        "required": ["platform", "data"],
+    },
+)
+async def knx_create_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Create a KNX UI entity via the config_store."""
+    knx = _get_knx_module(hass)
+    if knx is None:
+        return _not_setup()
+    platform = arguments.get("platform")
+    data = arguments.get("data")
+    if not platform or data is None:
+        return {"content": [{"type": "text", "text": "Both 'platform' and 'data' are required."}]}
+    try:
+        entity_id = await knx.config_store.create_entity(platform, data)
+    except Exception as err:  # noqa: BLE001
+        return {"content": [{"type": "text", "text": f"create_entity failed: {err}"}]}
+    return {"created": True, "entity_id": entity_id, "platform": platform}
+
+
+@register_tool(
+    name="knx_update_entity",
+    description=(
+        "Update an existing UI-managed KNX entity (config_store) — "
+        "experimental. Requires 'entity_id', 'platform' and the full 'data' "
+        "config (same schema as create). Reloads the platform."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "entity_id": {"type": "string"},
+            "platform": {"type": "string"},
+            "data": {"type": "object"},
+        },
+        "required": ["entity_id", "platform", "data"],
+    },
+)
+async def knx_update_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Update a KNX UI entity via the config_store."""
+    knx = _get_knx_module(hass)
+    if knx is None:
+        return _not_setup()
+    entity_id = arguments.get("entity_id")
+    platform = arguments.get("platform")
+    data = arguments.get("data")
+    if not entity_id or not platform or data is None:
+        return {
+            "content": [
+                {"type": "text", "text": "'entity_id', 'platform' and 'data' are required."}
+            ]
+        }
+    try:
+        await knx.config_store.update_entity(platform, entity_id, data)
+    except Exception as err:  # noqa: BLE001
+        return {"content": [{"type": "text", "text": f"update_entity failed: {err}"}]}
+    return {"updated": True, "entity_id": entity_id, "platform": platform}
+
+
+@register_tool(
+    name="knx_delete_entity",
+    description=(
+        "Delete a UI-managed KNX entity (config_store) by entity_id — "
+        "experimental. Mutates the KNX UI config."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {"entity_id": {"type": "string"}},
+        "required": ["entity_id"],
+    },
+)
+async def knx_delete_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Delete a KNX UI entity via the config_store."""
+    knx = _get_knx_module(hass)
+    if knx is None:
+        return _not_setup()
+    entity_id = arguments.get("entity_id")
+    if not entity_id:
+        return {"content": [{"type": "text", "text": "'entity_id' is required."}]}
+    try:
+        await knx.config_store.delete_entity(entity_id)
+    except Exception as err:  # noqa: BLE001
+        return {"content": [{"type": "text", "text": f"delete_entity failed: {err}"}]}
+    return {"deleted": True, "entity_id": entity_id}

--- a/custom_components/mcp_server_http_transport/tools/knx.py
+++ b/custom_components/mcp_server_http_transport/tools/knx.py
@@ -1,0 +1,125 @@
+"""KNX bus tools — read Home Assistant's KNX group-monitor telegram history."""
+
+import logging
+import re
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from . import register_tool
+
+_LOGGER = logging.getLogger(__name__)
+
+# KNX_MODULE_KEY is where the KNX integration stores its runtime module
+# (same access path used by HA's own `knx/group_monitor_info` websocket command).
+# Imported defensively so the MCP server still loads when KNX isn't installed.
+try:
+    from homeassistant.components.knx.const import KNX_MODULE_KEY
+except Exception:  # pragma: no cover - KNX integration not available
+    KNX_MODULE_KEY = None
+
+
+def _get_knx_module(hass: HomeAssistant):
+    """Return the KNX runtime module from hass.data, or None if KNX isn't set up."""
+    if KNX_MODULE_KEY is None:
+        return None
+    return hass.data.get(KNX_MODULE_KEY)
+
+
+def _destination(telegram: dict[str, Any]) -> str:
+    """Group address of a telegram, tolerating key naming differences."""
+    return str(telegram.get("destination") or telegram.get("destination_address") or "")
+
+
+@register_tool(
+    name="knx_recent_telegrams",
+    description=(
+        "Return Home Assistant's recent KNX bus telegrams (the group-monitor "
+        "history buffer — typically the last several thousand telegrams, a few "
+        "hours of bus traffic). Each telegram includes the destination group "
+        "address, decoded value, telegram type, and the SOURCE device "
+        "(individual address + device name). This is RETROSPECTIVE — it reads "
+        "the stored buffer, unlike a live subscription — and is ideal for "
+        "diagnosing which KNX device wrote a given group address (e.g. a value "
+        "that flaps at dusk). Optional regex filters on group address / name "
+        "and a result limit keep the output small."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "filter_ga": {
+                "type": "string",
+                "description": (
+                    "Regex matched against the destination group address "
+                    "(e.g. '^0/0/249$' for one GA, or '^1/2/' for a sub-tree)."
+                ),
+            },
+            "filter_name": {
+                "type": "string",
+                "description": "Case-insensitive regex matched against the destination name.",
+            },
+            "limit": {
+                "type": "integer",
+                "description": (
+                    "Max number of most-recent matching telegrams to return (default 200)."
+                ),
+            },
+        },
+    },
+)
+async def knx_recent_telegrams(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return filtered recent KNX telegrams from the group-monitor buffer."""
+    knx = _get_knx_module(hass)
+    if knx is None:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "KNX integration is not set up on this Home Assistant instance.",
+                }
+            ]
+        }
+
+    try:
+        telegrams = [dict(t) for t in knx.telegrams.recent_telegrams]
+    except AttributeError:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "KNX telegram history is unavailable on this Home Assistant version.",
+                }
+            ]
+        }
+
+    try:
+        ga_re = re.compile(arguments["filter_ga"]) if arguments.get("filter_ga") else None
+        name_re = (
+            re.compile(arguments["filter_name"], re.IGNORECASE)
+            if arguments.get("filter_name")
+            else None
+        )
+    except re.error as err:
+        return {"content": [{"type": "text", "text": f"Invalid regex: {err}"}]}
+
+    matched = [
+        t
+        for t in telegrams
+        if (ga_re is None or ga_re.search(_destination(t)))
+        and (name_re is None or name_re.search(str(t.get("destination_name", ""))))
+    ]
+
+    limit = arguments.get("limit") or 200
+    returned = matched[-limit:]
+    timestamps = [t.get("timestamp") for t in telegrams if t.get("timestamp")]
+
+    return {
+        "buffer_size": len(telegrams),
+        "buffer_span": {
+            "oldest": min(timestamps) if timestamps else None,
+            "newest": max(timestamps) if timestamps else None,
+        },
+        "matched": len(matched),
+        "returned": len(returned),
+        "telegrams": returned,
+    }

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,11 +255,12 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 60
+        assert len(body["result"]["tools"]) == 65
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names
         assert "knx_recent_telegrams" in tool_names
+        assert "knx_create_entity" in tool_names
         assert "list_entities" in tool_names
         assert "get_error_log" in tool_names
         assert "restart_ha" in tool_names

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,10 +255,11 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 59
+        assert len(body["result"]["tools"]) == 60
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names
+        assert "knx_recent_telegrams" in tool_names
         assert "list_entities" in tool_names
         assert "get_error_log" in tool_names
         assert "restart_ha" in tool_names

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 60
+        assert len(tool_names) == 65
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 59
+        assert len(tool_names) == 60
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_tools_knx.py
+++ b/tests/test_tools_knx.py
@@ -1,6 +1,6 @@
 """Tests for KNX telegram-history tools."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -110,3 +110,81 @@ class TestKnxRecentTelegrams:
         result = await knx_mod.knx_recent_telegrams(hass, {})
         assert "content" in result
         assert "unavailable" in result["content"][0]["text"]
+
+
+class TestKnxEntityTools:
+    """Test the KNX base-data / entity read+write tools."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_key(self):
+        with patch.object(knx_mod, "KNX_MODULE_KEY", _KEY):
+            yield
+
+    def _hass(self, module):
+        hass = Mock()
+        hass.data = {_KEY: module}
+        return hass
+
+    async def test_get_base_data_fields(self):
+        module = Mock()
+        module.xknx.version = "3.0.0"
+        module.xknx.connection_manager.connected.is_set = Mock(return_value=True)
+        module.xknx.current_address = "1.0.255"
+        module.project.info = {"name": "Haus"}
+        result = await knx_mod.knx_get_base_data(self._hass(module), {})
+        assert result["connection"]["connected"] is True
+        assert result["connection"]["current_address"] == "1.0.255"
+        assert result["xknx_version"] == "3.0.0"
+        assert result["project_info"] == {"name": "Haus"}
+
+    async def test_get_entities_filter(self):
+        module = Mock()
+        module.group_address_entities = {
+            "0/0/249": ["light.gt_taster"],
+            "0/1/1": ["light.wz"],
+        }
+        result = await knx_mod.knx_get_entities(self._hass(module), {"filter_ga": "^0/0/249$"})
+        assert result["count"] == 1
+        assert result["entities_by_group"][0]["group_address"] == "0/0/249"
+        assert result["entities_by_group"][0]["entities"] == ["light.gt_taster"]
+
+    async def test_get_entities_not_setup(self):
+        hass = Mock()
+        hass.data = {}
+        result = await knx_mod.knx_get_entities(hass, {})
+        assert "content" in result
+
+    async def test_create_entity_calls_config_store(self):
+        module = Mock()
+        module.config_store.create_entity = AsyncMock(return_value="light.knx_new")
+        result = await knx_mod.knx_create_entity(
+            self._hass(module), {"platform": "light", "data": {"name": "x"}}
+        )
+        assert result["created"] is True
+        assert result["entity_id"] == "light.knx_new"
+        module.config_store.create_entity.assert_awaited_once_with("light", {"name": "x"})
+
+    async def test_create_entity_requires_args(self):
+        result = await knx_mod.knx_create_entity(self._hass(Mock()), {"platform": "light"})
+        assert "content" in result
+        assert "required" in result["content"][0]["text"]
+
+    async def test_update_entity_calls_config_store(self):
+        module = Mock()
+        module.config_store.update_entity = AsyncMock(return_value=None)
+        result = await knx_mod.knx_update_entity(
+            self._hass(module), {"entity_id": "light.x", "platform": "light", "data": {"a": 1}}
+        )
+        assert result["updated"] is True
+        module.config_store.update_entity.assert_awaited_once_with("light", "light.x", {"a": 1})
+
+    async def test_delete_entity_calls_config_store(self):
+        module = Mock()
+        module.config_store.delete_entity = AsyncMock(return_value=None)
+        result = await knx_mod.knx_delete_entity(self._hass(module), {"entity_id": "light.x"})
+        assert result["deleted"] is True
+        module.config_store.delete_entity.assert_awaited_once_with("light.x")
+
+    async def test_delete_entity_requires_id(self):
+        result = await knx_mod.knx_delete_entity(self._hass(Mock()), {})
+        assert "content" in result

--- a/tests/test_tools_knx.py
+++ b/tests/test_tools_knx.py
@@ -98,11 +98,13 @@ class TestKnxRecentTelegrams:
         assert "Invalid regex" in result["content"][0]["text"]
 
     async def test_history_unavailable_attribute_error(self):
+        class _NoHistory:
+            @property
+            def recent_telegrams(self):
+                raise AttributeError("no telegram history on this HA version")
+
         module = Mock()
-        # recent_telegrams raises AttributeError on access
-        type(module.telegrams).recent_telegrams = property(
-            lambda self: (_ for _ in ()).throw(AttributeError())
-        )
+        module.telegrams = _NoHistory()
         hass = Mock()
         hass.data = {_KEY: module}
         result = await knx_mod.knx_recent_telegrams(hass, {})

--- a/tests/test_tools_knx.py
+++ b/tests/test_tools_knx.py
@@ -1,5 +1,6 @@
 """Tests for KNX telegram-history tools."""
 
+import json
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -48,6 +49,12 @@ def _hass_with_knx(telegrams):
     return hass
 
 
+def _unpack(result: dict) -> dict:
+    """Unpack the MCP content envelope into the payload dict."""
+    assert "content" in result, f"Expected envelope with 'content', got: {result.keys()}"
+    return json.loads(result["content"][0]["text"])
+
+
 class TestKnxRecentTelegrams:
     """Test knx_recent_telegrams."""
 
@@ -66,30 +73,48 @@ class TestKnxRecentTelegrams:
     async def test_returns_all_with_buffer_span(self):
         hass = _hass_with_knx(_TELEGRAMS)
         result = await knx_mod.knx_recent_telegrams(hass, {})
-        assert result["buffer_size"] == 3
-        assert result["matched"] == 3
-        assert result["buffer_span"]["oldest"] == "2026-05-29T21:00:00+02:00"
-        assert result["buffer_span"]["newest"] == "2026-05-29T21:06:00+02:00"
+        data = _unpack(result)
+        assert data["buffer_size"] == 3
+        assert data["matched"] == 3
+        assert data["buffer_span"]["oldest"] == "2026-05-29T21:00:00+02:00"
+        assert data["buffer_span"]["newest"] == "2026-05-29T21:06:00+02:00"
 
     async def test_filter_ga(self):
         hass = _hass_with_knx(_TELEGRAMS)
         result = await knx_mod.knx_recent_telegrams(hass, {"filter_ga": "^0/0/249$"})
-        assert result["matched"] == 2
-        assert all(t["destination"] == "0/0/249" for t in result["telegrams"])
+        data = _unpack(result)
+        assert data["matched"] == 2
+        assert all(t["destination"] == "0/0/249" for t in data["telegrams"])
         # source device of the flapping GA is surfaced
-        assert result["telegrams"][0]["source_name"] == "MDT Logic Module"
+        assert data["telegrams"][0]["source_name"] == "MDT Logic Module"
 
     async def test_filter_name_case_insensitive(self):
         hass = _hass_with_knx(_TELEGRAMS)
         result = await knx_mod.knx_recent_telegrams(hass, {"filter_name": "licht"})
-        assert result["matched"] == 1
-        assert result["telegrams"][0]["destination"] == "0/1/1"
+        data = _unpack(result)
+        assert data["matched"] == 1
+        assert data["telegrams"][0]["destination"] == "0/1/1"
 
     async def test_limit_keeps_most_recent(self):
         hass = _hass_with_knx(_TELEGRAMS)
         result = await knx_mod.knx_recent_telegrams(hass, {"limit": 1})
-        assert result["returned"] == 1
-        assert result["telegrams"][0]["timestamp"] == "2026-05-29T21:06:00+02:00"
+        data = _unpack(result)
+        assert data["returned"] == 1
+        assert data["telegrams"][0]["timestamp"] == "2026-05-29T21:06:00+02:00"
+
+    async def test_limit_zero_is_clamped_to_one(self):
+        """limit=0 must not silently become 200."""
+        hass = _hass_with_knx(_TELEGRAMS)
+        result = await knx_mod.knx_recent_telegrams(hass, {"limit": 0})
+        data = _unpack(result)
+        assert data["returned"] == 1
+
+    async def test_limit_negative_is_clamped_to_one(self):
+        """Negative limit must not slice from the wrong end."""
+        hass = _hass_with_knx(_TELEGRAMS)
+        result = await knx_mod.knx_recent_telegrams(hass, {"limit": -5})
+        data = _unpack(result)
+        assert data["returned"] == 1
 
     async def test_invalid_regex_returns_error(self):
         hass = _hass_with_knx(_TELEGRAMS)
@@ -132,10 +157,11 @@ class TestKnxEntityTools:
         module.xknx.current_address = "1.0.255"
         module.project.info = {"name": "Haus"}
         result = await knx_mod.knx_get_base_data(self._hass(module), {})
-        assert result["connection"]["connected"] is True
-        assert result["connection"]["current_address"] == "1.0.255"
-        assert result["xknx_version"] == "3.0.0"
-        assert result["project_info"] == {"name": "Haus"}
+        data = _unpack(result)
+        assert data["connection"]["connected"] is True
+        assert data["connection"]["current_address"] == "1.0.255"
+        assert data["xknx_version"] == "3.0.0"
+        assert data["project_info"] == {"name": "Haus"}
 
     async def test_get_entities_filter(self):
         module = Mock()
@@ -144,9 +170,18 @@ class TestKnxEntityTools:
             "0/1/1": ["light.wz"],
         }
         result = await knx_mod.knx_get_entities(self._hass(module), {"filter_ga": "^0/0/249$"})
-        assert result["count"] == 1
-        assert result["entities_by_group"][0]["group_address"] == "0/0/249"
-        assert result["entities_by_group"][0]["entities"] == ["light.gt_taster"]
+        data = _unpack(result)
+        assert data["count"] == 1
+        assert data["entities_by_group"][0]["group_address"] == "0/0/249"
+        assert data["entities_by_group"][0]["entities"] == ["light.gt_taster"]
+
+    async def test_get_entities_limit_zero_clamped(self):
+        """limit=0 on knx_get_entities must not silently become 200."""
+        module = Mock()
+        module.group_address_entities = {f"0/0/{i}": [f"light.x{i}"] for i in range(5)}
+        result = await knx_mod.knx_get_entities(self._hass(module), {"limit": 0})
+        data = _unpack(result)
+        assert len(data["entities_by_group"]) == 1
 
     async def test_get_entities_not_setup(self):
         hass = Mock()
@@ -160,8 +195,9 @@ class TestKnxEntityTools:
         result = await knx_mod.knx_create_entity(
             self._hass(module), {"platform": "light", "data": {"name": "x"}}
         )
-        assert result["created"] is True
-        assert result["entity_id"] == "light.knx_new"
+        data = _unpack(result)
+        assert data["created"] is True
+        assert data["entity_id"] == "light.knx_new"
         module.config_store.create_entity.assert_awaited_once_with("light", {"name": "x"})
 
     async def test_create_entity_requires_args(self):
@@ -175,14 +211,16 @@ class TestKnxEntityTools:
         result = await knx_mod.knx_update_entity(
             self._hass(module), {"entity_id": "light.x", "platform": "light", "data": {"a": 1}}
         )
-        assert result["updated"] is True
+        data = _unpack(result)
+        assert data["updated"] is True
         module.config_store.update_entity.assert_awaited_once_with("light", "light.x", {"a": 1})
 
     async def test_delete_entity_calls_config_store(self):
         module = Mock()
         module.config_store.delete_entity = AsyncMock(return_value=None)
         result = await knx_mod.knx_delete_entity(self._hass(module), {"entity_id": "light.x"})
-        assert result["deleted"] is True
+        data = _unpack(result)
+        assert data["deleted"] is True
         module.config_store.delete_entity.assert_awaited_once_with("light.x")
 
     async def test_delete_entity_requires_id(self):

--- a/tests/test_tools_knx.py
+++ b/tests/test_tools_knx.py
@@ -1,0 +1,110 @@
+"""Tests for KNX telegram-history tools."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from custom_components.mcp_server_http_transport.tools import knx as knx_mod
+
+_KEY = "knx_test_module_key"
+
+_TELEGRAMS = [
+    {
+        "destination": "0/1/1",
+        "destination_name": "Licht Wohnzimmer",
+        "source": "1.1.5",
+        "source_name": "MDT Aktor",
+        "value": False,
+        "timestamp": "2026-05-29T21:00:00+02:00",
+        "telegramtype": "GroupValueWrite",
+    },
+    {
+        "destination": "0/0/249",
+        "destination_name": "GT TagNacht",
+        "source": "1.1.99",
+        "source_name": "MDT Logic Module",
+        "value": True,
+        "timestamp": "2026-05-29T21:05:00+02:00",
+        "telegramtype": "GroupValueWrite",
+    },
+    {
+        "destination": "0/0/249",
+        "destination_name": "GT TagNacht",
+        "source": "1.1.99",
+        "source_name": "MDT Logic Module",
+        "value": False,
+        "timestamp": "2026-05-29T21:06:00+02:00",
+        "telegramtype": "GroupValueWrite",
+    },
+]
+
+
+def _hass_with_knx(telegrams):
+    """Mock hass with a KNX module exposing recent_telegrams."""
+    module = Mock()
+    module.telegrams.recent_telegrams = telegrams
+    hass = Mock()
+    hass.data = {_KEY: module}
+    return hass
+
+
+class TestKnxRecentTelegrams:
+    """Test knx_recent_telegrams."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_key(self):
+        with patch.object(knx_mod, "KNX_MODULE_KEY", _KEY):
+            yield
+
+    async def test_returns_not_setup_when_knx_missing(self):
+        hass = Mock()
+        hass.data = {}
+        result = await knx_mod.knx_recent_telegrams(hass, {})
+        assert "content" in result
+        assert "not set up" in result["content"][0]["text"]
+
+    async def test_returns_all_with_buffer_span(self):
+        hass = _hass_with_knx(_TELEGRAMS)
+        result = await knx_mod.knx_recent_telegrams(hass, {})
+        assert result["buffer_size"] == 3
+        assert result["matched"] == 3
+        assert result["buffer_span"]["oldest"] == "2026-05-29T21:00:00+02:00"
+        assert result["buffer_span"]["newest"] == "2026-05-29T21:06:00+02:00"
+
+    async def test_filter_ga(self):
+        hass = _hass_with_knx(_TELEGRAMS)
+        result = await knx_mod.knx_recent_telegrams(hass, {"filter_ga": "^0/0/249$"})
+        assert result["matched"] == 2
+        assert all(t["destination"] == "0/0/249" for t in result["telegrams"])
+        # source device of the flapping GA is surfaced
+        assert result["telegrams"][0]["source_name"] == "MDT Logic Module"
+
+    async def test_filter_name_case_insensitive(self):
+        hass = _hass_with_knx(_TELEGRAMS)
+        result = await knx_mod.knx_recent_telegrams(hass, {"filter_name": "licht"})
+        assert result["matched"] == 1
+        assert result["telegrams"][0]["destination"] == "0/1/1"
+
+    async def test_limit_keeps_most_recent(self):
+        hass = _hass_with_knx(_TELEGRAMS)
+        result = await knx_mod.knx_recent_telegrams(hass, {"limit": 1})
+        assert result["returned"] == 1
+        assert result["telegrams"][0]["timestamp"] == "2026-05-29T21:06:00+02:00"
+
+    async def test_invalid_regex_returns_error(self):
+        hass = _hass_with_knx(_TELEGRAMS)
+        result = await knx_mod.knx_recent_telegrams(hass, {"filter_ga": "("})
+        assert "content" in result
+        assert "Invalid regex" in result["content"][0]["text"]
+
+    async def test_history_unavailable_attribute_error(self):
+        module = Mock()
+        # recent_telegrams raises AttributeError on access
+        type(module.telegrams).recent_telegrams = property(
+            lambda self: (_ for _ in ()).throw(AttributeError())
+        )
+        hass = Mock()
+        hass.data = {_KEY: module}
+        result = await knx_mod.knx_recent_telegrams(hass, {})
+        assert "content" in result
+        assert "unavailable" in result["content"][0]["text"]


### PR DESCRIPTION
## What

Adds a small **KNX tool set** to the MCP server, mirroring Home Assistant's KNX websocket commands via `hass.data[KNX_MODULE_KEY]`:

**Read**
- `knx_recent_telegrams` — recent group-monitor telegram history (incl. **source device** + decoded value), regex-filterable. Retrospective: find which KNX device wrote a given group address.
- `knx_get_base_data` — connection status, gateway address, xknx version, loaded ETS project info, UI-creatable platforms.
- `knx_get_entities` — group-address ↔ entity bindings (the KNX-specific view generic entity tools don't expose), regex filter on GA.

**Write (experimental)** — mutate the KNX UI config via `config_store`:
- `knx_create_entity` (`platform` + `data` → entity_id), `knx_update_entity`, `knx_delete_entity`.

## Why

The server already writes KNX via `call_service`→`knx.send` and reads entity state, but there's no way to inspect the **raw KNX bus**, the **group-address↔entity bindings**, or to **create/manage KNX UI entities** programmatically. These tools close that gap (e.g. diagnosing a value that flaps at dusk, or scripting missing KNX objects into HA).

## Notes

- All KNX-module access is **defensive**: `KNX_MODULE_KEY` import is guarded, and each tool returns a friendly "KNX is not set up" / "unavailable on this HA version" message instead of raising — the server still loads cleanly without the KNX integration.
- Write tools are marked **experimental** (consistent with the existing helper write-tools).
- Unit tests in `tests/test_tools_knx.py`; tool-count test bumped to 65; README updated with a **KNX** section. Verified green on the test + integration jobs across HA 2025.4 / 2025.10 / 2026.4.
