### PR TITLE
Require access tokens to be audience-bound to this MCP server

### DIFF
--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -138,7 +138,18 @@ class MCPEndpointView(HomeAssistantView):
             )
 
             expected_issuer = get_issuer_from_request(request)
-            result = validate_access_token(self.hass, token, expected_issuer)
+            # This MCP server is the protected resource (RFC 8707); its canonical
+            # URI is the resource a compliant client (e.g. Claude) binds the token
+            # to. Require the token's aud to match it.
+            expected_audience = f"{expected_issuer}/api/mcp"
+            try:
+                result = validate_access_token(
+                    self.hass, token, expected_issuer, expected_audience=expected_audience
+                )
+            except TypeError:
+                # OIDC provider predates resource-aware validation; fall back to
+                # the legacy signature so an un-upgraded provider still works.
+                result = validate_access_token(self.hass, token, expected_issuer)
             if result is not None:
                 return result
         except ImportError as e:

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.9.0"
+  "version": "1.10.0"
 }

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -539,3 +539,63 @@ class TestNativeAuth:
         assert response.status == 200
         body = json.loads(response.body)
         assert body["result"]["protocolVersion"] == "2024-11-05"
+
+
+class TestOidcAudienceBinding:
+    """Test that OIDC validation binds the token audience to this resource."""
+
+    @pytest.fixture
+    def view(self):
+        """Create an MCPEndpointView (native auth disabled)."""
+        hass = Mock()
+        return MCPEndpointView(hass, Mock(), native_auth_enabled=False)
+
+    async def test_passes_expected_audience_to_validator(self, view):
+        """_validate_token derives the resource URI and passes it as audience."""
+        import sys
+
+        request = Mock()
+        request.headers = {
+            "Authorization": "Bearer t",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "ha.example.com",
+        }
+
+        mv = sys.modules["custom_components.oidc_provider.token_validator"]
+        mv.validate_access_token.reset_mock()
+        mv.validate_access_token.return_value = {"sub": "u"}
+        try:
+            result = await view._validate_token(request)
+        finally:
+            mv.validate_access_token.return_value = None
+
+        assert result == {"sub": "u"}
+        _, kwargs = mv.validate_access_token.call_args
+        assert kwargs.get("expected_audience") == "https://ha.example.com/api/mcp"
+
+    async def test_falls_back_to_legacy_signature_on_type_error(self, view):
+        """An older OIDC provider without expected_audience still works."""
+        import sys
+
+        request = Mock()
+        request.headers = {
+            "Authorization": "Bearer t",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "ha.example.com",
+        }
+
+        def side_effect(*args, **kwargs):
+            if "expected_audience" in kwargs:
+                raise TypeError("unexpected keyword argument 'expected_audience'")
+            return {"sub": "legacy"}
+
+        mv = sys.modules["custom_components.oidc_provider.token_validator"]
+        mv.validate_access_token.reset_mock()
+        mv.validate_access_token.side_effect = side_effect
+        try:
+            result = await view._validate_token(request)
+        finally:
+            mv.validate_access_token.side_effect = None
+            mv.validate_access_token.return_value = None
+
+        assert result == {"sub": "legacy"}


### PR DESCRIPTION
The MCP server is the OAuth protected resource, and the MCP authorization spec requires it to validate that access tokens were issued specifically for it as the audience (RFC 8707). It previously accepted any token whose `aud` matched a registered OIDC client, relying on the provider's weaker client-id audience.

`_validate_token` now passes the server's canonical resource URI (`{issuer}/api/mcp`) as the expected audience to `validate_access_token`, so only tokens minted for this server are accepted. It falls back to the legacy validator signature when paired with an OIDC provider that predates resource-aware validation.

Requires hass-oidc-server >= 1.5.0, which binds the token `aud` to the requested resource. Together they fix Claude connections failing with `McpAuthorizationError`.

Version bumped to 1.10.0.
