### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.10.0"
+  "version": "1.11.0"
 }


### PR DESCRIPTION
Bump version to 1.11.0 for the KNX tool set merged in #53 (telegram history, base data, entity bindings, and experimental entity create/update/delete).
