### PR TITLE
feat: Add standard MCP tool annotations

### DIFF
--- a/custom_components/mcp_server_http_transport/prompts/__init__.py
+++ b/custom_components/mcp_server_http_transport/prompts/__init__.py
@@ -9,16 +9,25 @@ from homeassistant.core import HomeAssistant
 PROMPTS: dict[str, dict[str, Any]] = {}
 
 
-def register_prompt(name: str, description: str, arguments: list[dict[str, Any]] | None = None):
+def register_prompt(
+    name: str, 
+    description: str, 
+    arguments: list[dict[str, Any]] | None = None,
+    annotations: dict[str, Any] | None = None,
+):
     """Decorator to register a prompt with its definition and handler."""
 
     def decorator(func):
+        definition = {
+            "name": name,
+            "description": description,
+            "arguments": arguments or [],
+        }
+        if annotations is not None:
+            definition["annotations"] = annotations
+
         PROMPTS[name] = {
-            "definition": {
-                "name": name,
-                "description": description,
-                "arguments": arguments or [],
-            },
+            "definition": definition,
             "handler": func,
         }
         return func

--- a/custom_components/mcp_server_http_transport/prompts/__init__.py
+++ b/custom_components/mcp_server_http_transport/prompts/__init__.py
@@ -10,8 +10,8 @@ PROMPTS: dict[str, dict[str, Any]] = {}
 
 
 def register_prompt(
-    name: str, 
-    description: str, 
+    name: str,
+    description: str,
     arguments: list[dict[str, Any]] | None = None,
     annotations: dict[str, Any] | None = None,
 ):

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -9,17 +9,46 @@ from ..json_utils import _HAJSONEncoder  # noqa: F401
 # Tool registry: name -> {"schema": {...}, "handler": callable}
 TOOLS: dict[str, dict[str, Any]] = {}
 
+# Reusable MCP ToolAnnotations (see spec §ToolAnnotations).
+ANNOTATION_READ_ONLY: dict[str, Any] = {
+    "readOnlyHint": True,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+ANNOTATION_IDEMPOTENT: dict[str, Any] = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": True,
+    "openWorldHint": False,
+}
+ANNOTATION_DESTRUCTIVE: dict[str, Any] = {
+    "readOnlyHint": False,
+    "destructiveHint": True,
+    "idempotentHint": False,
+    "openWorldHint": False,
+}
 
-def register_tool(name: str, description: str, input_schema: dict[str, Any]):
+
+def register_tool(
+    name: str, 
+    description: str, 
+    input_schema: dict[str, Any],
+    annotations: dict[str, Any] | None = None,
+):
     """Decorator to register a tool with its schema and handler."""
 
     def decorator(func):
+        schema = {
+            "name": name,
+            "description": description,
+            "inputSchema": input_schema,
+        }
+        if annotations is not None:
+            schema["annotations"] = annotations
+
         TOOLS[name] = {
-            "schema": {
-                "name": name,
-                "description": description,
-                "inputSchema": input_schema,
-            },
+            "schema": schema,
             "handler": func,
         }
         return func

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -22,6 +22,12 @@ ANNOTATION_IDEMPOTENT: dict[str, Any] = {
     "idempotentHint": True,
     "openWorldHint": False,
 }
+ANNOTATION_NON_IDEMPOTENT: dict[str, Any] = {
+    "readOnlyHint": False,
+    "destructiveHint": False,
+    "idempotentHint": False,
+    "openWorldHint": False,
+}
 ANNOTATION_DESTRUCTIVE: dict[str, Any] = {
     "readOnlyHint": False,
     "destructiveHint": True,
@@ -31,8 +37,8 @@ ANNOTATION_DESTRUCTIVE: dict[str, Any] = {
 
 
 def register_tool(
-    name: str, 
-    description: str, 
+    name: str,
+    description: str,
     input_schema: dict[str, Any],
     annotations: dict[str, Any] | None = None,
 ):

--- a/custom_components/mcp_server_http_transport/tools/config.py
+++ b/custom_components/mcp_server_http_transport/tools/config.py
@@ -6,7 +6,13 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_IDEMPOTENT,
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +35,7 @@ _LOGGER = logging.getLogger(__name__)
         },
         "required": ["config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def create_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a new automation."""
@@ -65,6 +72,7 @@ async def create_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         },
         "required": ["automation_id", "config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def update_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Update an existing automation."""
@@ -96,6 +104,7 @@ async def update_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         },
         "required": ["automation_id"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def delete_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete an automation."""
@@ -115,6 +124,7 @@ async def delete_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_automations(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List all automations with full config."""
@@ -142,6 +152,7 @@ async def list_automations(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         },
         "required": ["automation_id"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_automation_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get a single automation's full config."""
@@ -172,6 +183,7 @@ async def get_automation_config(hass: HomeAssistant, arguments: dict[str, Any]) 
         },
         "required": ["config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def create_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a new scene."""
@@ -203,6 +215,7 @@ async def create_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         },
         "required": ["scene_id", "config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def update_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Update an existing scene."""
@@ -230,6 +243,7 @@ async def update_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         },
         "required": ["scene_id"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def delete_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete a scene."""
@@ -249,6 +263,7 @@ async def delete_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_scenes(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List all scenes with full config."""
@@ -276,6 +291,7 @@ async def list_scenes(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
         },
         "required": ["scene_id"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_scene_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get a single scene's full config."""
@@ -310,6 +326,7 @@ async def get_scene_config(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         },
         "required": ["key", "config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def create_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a new script."""
@@ -343,6 +360,7 @@ async def create_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         },
         "required": ["key", "config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def update_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Update an existing script."""
@@ -370,6 +388,7 @@ async def update_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         },
         "required": ["key"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def delete_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete a script."""
@@ -389,6 +408,7 @@ async def delete_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_scripts(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List all scripts with full config."""
@@ -416,6 +436,7 @@ async def list_scripts(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         },
         "required": ["key"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_script_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get a single script's full config."""

--- a/custom_components/mcp_server_http_transport/tools/config.py
+++ b/custom_components/mcp_server_http_transport/tools/config.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_IDEMPOTENT,
+    ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
     _HAJSONEncoder,
     register_tool,
@@ -35,7 +36,7 @@ _LOGGER = logging.getLogger(__name__)
         },
         "required": ["config"],
     },
-    annotations=ANNOTATION_IDEMPOTENT,
+    annotations=ANNOTATION_NON_IDEMPOTENT,
 )
 async def create_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a new automation."""

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -12,7 +12,12 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from ..const import DOMAIN
-from . import register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_IDEMPOTENT,
+    ANNOTATION_READ_ONLY,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -158,6 +163,7 @@ def _atomic_write(path: Path, content: str) -> None:
         "edited directly — use the dedicated CRUD tools for those instead"
     ),
     input_schema={"type": "object", "properties": {}},
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List first-level YAML files in the config directory."""
@@ -195,6 +201,7 @@ def _list_yaml_filenames_sync(config_dir: Path) -> list[str]:
         },
         "required": ["filename"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Read a YAML config file."""
@@ -253,6 +260,7 @@ def _read_config_file_sync(path: Path, filename: str) -> str:
         },
         "required": ["filename", "content"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Back up all YAML files, write the new content, then optionally validate."""
@@ -304,6 +312,7 @@ async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         },
         "required": ["filename"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def delete_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Back up all YAML files, then delete the target file."""
@@ -414,6 +423,7 @@ def _apply_batch_edit_sync(
             },
         },
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def batch_edit_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """One backup → apply all saves → apply all deletes → one config check."""
@@ -507,6 +517,7 @@ async def batch_edit_config_files(hass: HomeAssistant, arguments: dict[str, Any]
         "Call this before bulk edits to preserve a rollback snapshot"
     ),
     input_schema={"type": "object", "properties": {}},
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def backup_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Copy all first-level YAML files (except secrets) into a timestamped backup folder."""
@@ -549,6 +560,7 @@ def _backup_and_list_sync(config_dir: Path) -> dict[str, Any]:
         "newest first. Shows the timestamp and number of files in each backup"
     ),
     input_schema={"type": "object", "properties": {}},
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_config_backups(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List available backup snapshots, newest first."""
@@ -596,6 +608,7 @@ def _list_backups_sync(config_dir: Path) -> list[dict[str, Any]]:
             }
         },
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def cleanup_config_backups(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete backup snapshots older than older_than_days days."""
@@ -672,6 +685,7 @@ def _cleanup_backups_sync(config_dir: Path, older_than_days: int) -> dict[str, l
             }
         },
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def restore_config_backup(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Restore files from a backup snapshot into the config directory."""

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -15,6 +15,7 @@ from ..const import DOMAIN
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_IDEMPOTENT,
+    ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
     register_tool,
 )
@@ -517,7 +518,7 @@ async def batch_edit_config_files(hass: HomeAssistant, arguments: dict[str, Any]
         "Call this before bulk edits to preserve a rollback snapshot"
     ),
     input_schema={"type": "object", "properties": {}},
-    annotations=ANNOTATION_IDEMPOTENT,
+    annotations=ANNOTATION_NON_IDEMPOTENT,
 )
 async def backup_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Copy all first-level YAML files (except secrets) into a timestamped backup folder."""

--- a/custom_components/mcp_server_http_transport/tools/dashboards.py
+++ b/custom_components/mcp_server_http_transport/tools/dashboards.py
@@ -6,7 +6,13 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_IDEMPOTENT,
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -18,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List all dashboards."""
@@ -53,6 +60,7 @@ async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -
         },
         "required": ["url_path"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_dashboard_config_tool(
     hass: HomeAssistant, arguments: dict[str, Any]
@@ -92,6 +100,7 @@ async def get_dashboard_config_tool(
         },
         "required": ["url_path", "config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def save_dashboard_config_tool(
     hass: HomeAssistant, arguments: dict[str, Any]
@@ -132,6 +141,7 @@ async def save_dashboard_config_tool(
         },
         "required": ["url_path"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def delete_dashboard_config_tool(
     hass: HomeAssistant, arguments: dict[str, Any]
@@ -185,6 +195,7 @@ async def delete_dashboard_config_tool(
         },
         "required": ["url_path", "title"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def create_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a new dashboard."""
@@ -246,6 +257,7 @@ async def create_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) 
         },
         "required": ["url_path"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def update_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Update dashboard metadata."""
@@ -288,6 +300,7 @@ async def update_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) 
         },
         "required": ["url_path"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def delete_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete a dashboard."""

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -10,7 +10,12 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import label_registry as lr
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +50,7 @@ def _get_aliases(hass: HomeAssistant, entry: er.RegistryEntry) -> list[str]:
         },
         "required": ["entity_id"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get entity state."""
@@ -100,6 +106,7 @@ async def get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str,
         },
         "required": ["domain", "service"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def call_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Call a Home Assistant service."""
@@ -155,6 +162,7 @@ async def call_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             },
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List entities."""
@@ -212,6 +220,7 @@ async def list_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_areas(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List all areas."""
@@ -240,6 +249,7 @@ async def list_areas(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
             }
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_devices(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List devices."""
@@ -278,6 +288,7 @@ async def list_devices(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             }
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_services(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List available services."""
@@ -328,6 +339,7 @@ async def list_services(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
             },
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Search entities by various criteria."""
@@ -413,6 +425,7 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_labels(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List all labels."""
@@ -456,6 +469,7 @@ async def list_labels(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
         },
         "required": ["entity_ids"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get state for multiple entities."""

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -311,6 +311,7 @@ async def list_devices(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         },
         "required": ["device_id"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_device_details(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get a device and the entities registered to it."""
@@ -419,6 +420,7 @@ async def list_services(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         },
         "required": ["domain"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def describe_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Describe a service's parameters, selectors, and targets."""

--- a/custom_components/mcp_server_http_transport/tools/helpers.py
+++ b/custom_components/mcp_server_http_transport/tools/helpers.py
@@ -7,7 +7,13 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_IDEMPOTENT,
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -87,6 +93,7 @@ async def _entity_id_to_item_id(hass: HomeAssistant, entity_id: str) -> tuple[st
             }
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_helpers(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List helpers, optionally filtered by domain."""
@@ -146,6 +153,7 @@ async def list_helpers(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         },
         "required": ["entity_id"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_helper_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get a helper's stored config."""
@@ -191,6 +199,7 @@ async def get_helper_config(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         },
         "required": ["domain", "config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a new helper."""
@@ -244,6 +253,7 @@ async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         },
         "required": ["entity_id", "config"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def update_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Update an existing helper."""
@@ -269,6 +279,7 @@ async def update_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         },
         "required": ["entity_id"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def delete_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete a helper."""

--- a/custom_components/mcp_server_http_transport/tools/helpers.py
+++ b/custom_components/mcp_server_http_transport/tools/helpers.py
@@ -10,6 +10,7 @@ from homeassistant.helpers import entity_registry as er
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_IDEMPOTENT,
+    ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
     _HAJSONEncoder,
     register_tool,
@@ -199,7 +200,7 @@ async def get_helper_config(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         },
         "required": ["domain", "config"],
     },
-    annotations=ANNOTATION_IDEMPOTENT,
+    annotations=ANNOTATION_NON_IDEMPOTENT,
 )
 async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a new helper."""

--- a/custom_components/mcp_server_http_transport/tools/images.py
+++ b/custom_components/mcp_server_http_transport/tools/images.py
@@ -8,7 +8,10 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 
 from ..const import DOMAIN
-from . import register_tool
+from . import (
+    ANNOTATION_READ_ONLY,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -105,6 +108,7 @@ def _text(message: str) -> dict[str, Any]:
         },
         "required": ["entity_id"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_camera_image(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Capture a camera entity's current frame and return it as image content."""
@@ -160,6 +164,7 @@ async def get_camera_image(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         },
         "required": ["path"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_image_file(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Read an allowed image file from disk and return it as image content."""

--- a/custom_components/mcp_server_http_transport/tools/knx.py
+++ b/custom_components/mcp_server_http_transport/tools/knx.py
@@ -7,7 +7,13 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_IDEMPOTENT,
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -67,6 +73,7 @@ def _destination(telegram: dict[str, Any]) -> str:
             },
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def knx_recent_telegrams(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Return filtered recent KNX telegrams from the group-monitor buffer."""
@@ -151,6 +158,7 @@ def _supported_platforms_ui():
         "KNX UI. Useful context before inspecting or creating KNX entities."
     ),
     input_schema={"type": "object", "properties": {}},
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def knx_get_base_data(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Return KNX connection + project base data."""
@@ -204,6 +212,7 @@ async def knx_get_base_data(hass: HomeAssistant, arguments: dict[str, Any]) -> d
             },
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def knx_get_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List KNX group-address -> entity bindings."""
@@ -267,6 +276,7 @@ async def knx_get_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         },
         "required": ["platform", "data"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def knx_create_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a KNX UI entity via the config_store."""
@@ -301,6 +311,7 @@ async def knx_create_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         },
         "required": ["entity_id", "platform", "data"],
     },
+    annotations=ANNOTATION_IDEMPOTENT,
 )
 async def knx_update_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Update a KNX UI entity via the config_store."""
@@ -335,6 +346,7 @@ async def knx_update_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         "properties": {"entity_id": {"type": "string"}},
         "required": ["entity_id"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def knx_delete_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete a KNX UI entity via the config_store."""

--- a/custom_components/mcp_server_http_transport/tools/knx.py
+++ b/custom_components/mcp_server_http_transport/tools/knx.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_IDEMPOTENT,
+    ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
     _HAJSONEncoder,
     register_tool,
@@ -276,7 +277,7 @@ async def knx_get_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         },
         "required": ["platform", "data"],
     },
-    annotations=ANNOTATION_IDEMPOTENT,
+    annotations=ANNOTATION_NON_IDEMPOTENT,
 )
 async def knx_create_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Create a KNX UI entity via the config_store."""

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -8,7 +8,11 @@ from typing import Any
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,6 +51,7 @@ _VALID_PERIODS = {"5minute", "hour", "day", "week", "month"}
         },
         "required": ["entity_id", "start_time"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Fetch long-term statistics for an entity."""

--- a/custom_components/mcp_server_http_transport/tools/system.py
+++ b/custom_components/mcp_server_http_transport/tools/system.py
@@ -9,7 +9,12 @@ from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get Home Assistant configuration."""
@@ -58,6 +64,7 @@ async def get_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         },
         "required": ["template"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def render_template(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Render a Jinja2 template."""
@@ -95,6 +102,7 @@ async def render_template(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         },
         "required": ["entity_id", "start_time"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_history(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get state history for an entity."""
@@ -168,6 +176,7 @@ _BLOCKED_EVENT_TYPES = frozenset(
         },
         "required": ["event_type"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def fire_event(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Fire an event on the Home Assistant event bus."""
@@ -217,6 +226,7 @@ async def fire_event(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         },
         "required": ["start_time"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_logbook(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get logbook entries for an entity or time range."""

--- a/custom_components/mcp_server_http_transport/tools/system_admin.py
+++ b/custom_components/mcp_server_http_transport/tools/system_admin.py
@@ -9,7 +9,12 @@ from typing import Any
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant
 
-from . import _HAJSONEncoder, register_tool
+from . import (
+    ANNOTATION_DESTRUCTIVE,
+    ANNOTATION_READ_ONLY,
+    _HAJSONEncoder,
+    register_tool,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +35,7 @@ _LOGGER = logging.getLogger(__name__)
             }
         },
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_error_log(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Fetch the Home Assistant error log, falling back to the in-memory buffer."""
@@ -149,6 +155,7 @@ def _format_system_log_entry(entry: dict[str, Any]) -> str:
         },
         "required": ["confirm"],
     },
+    annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def restart_ha(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Restart Home Assistant."""
@@ -186,6 +193,7 @@ async def restart_ha(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_system_status(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get system status overview."""
@@ -229,6 +237,7 @@ async def get_system_status(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         },
         "required": ["domain"],
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def get_domain_stats(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Get aggregate stats for a domain."""
@@ -272,6 +281,7 @@ async def get_domain_stats(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def check_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Validate HA configuration."""
@@ -299,6 +309,7 @@ async def check_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         "type": "object",
         "properties": {},
     },
+    annotations=ANNOTATION_READ_ONLY,
 )
 async def list_integrations(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """List installed integrations."""


### PR DESCRIPTION
Adds `readOnlyHint`, `destructiveHint`, and `idempotentHint` to all MCP tools based on their effect. This prevents clients from defaulting to the worst-case scenario (e.g. asking for user permission before invoking any tool).

- Adds annotation constants to `tools/__init__.py`.
- Applies the appropriate annotations to all 50+ tool endpoints.