### PR TITLE
feat: add category support to automations, scenes, scripts, and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `update_helper` | Update an existing UI-managed helper by entity ID (experimental) |
 | `delete_helper` | Delete a UI-managed helper by entity ID (experimental) |
 
+**Categories**
+
+| Tool | Description |
+|------|-------------|
+| `list_categories` | List categories in a scope (automation, script, scene, entity) |
+| `create_category` | Create a category in a scope |
+| `update_category` | Rename or change the icon of a category |
+| `delete_category` | Delete a category (HA clears it from all assigned entities) |
+
+Assign objects to categories by passing the optional `category` (category name) argument to `create_automation`/`update_automation`, `create_scene`/`update_scene`, `create_script`/`update_script`, and `create_helper`/`update_helper`; on the update tools, pass an empty/null `category` to remove it.
+
 **Config Files**
 
 | Tool | Description |

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -42,6 +42,7 @@ async def call_tool(hass: HomeAssistant, name: str, arguments: dict[str, Any]) -
 
 # Import submodules so tools auto-register via @register_tool
 from . import (  # noqa: E402
+    categories,  # noqa: F401
     config,  # noqa: F401
     config_files,  # noqa: F401
     dashboards,  # noqa: F401

--- a/custom_components/mcp_server_http_transport/tools/categories.py
+++ b/custom_components/mcp_server_http_transport/tools/categories.py
@@ -1,0 +1,233 @@
+"""Category definition CRUD tools and shared category-assignment helpers."""
+
+import json
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import category_registry as cr
+from homeassistant.helpers import entity_registry as er
+
+from . import _HAJSONEncoder, register_tool
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_SCOPES = frozenset({"automation", "script", "scene", "entity"})
+
+
+def resolve_category_id(hass: HomeAssistant, scope: str, name: str) -> str:
+    """Return the category_id for a category name within a scope, or raise."""
+    reg = cr.async_get(hass)
+    for entry in reg.async_list_categories(scope=scope):
+        if entry.name.casefold() == name.casefold():
+            return entry.category_id
+    raise ValueError(
+        f"No category named '{name}' in scope '{scope}'. Create it with create_category first."
+    )
+
+
+def write_entity_category(
+    hass: HomeAssistant, entity_id: str, scope: str, category_id: str | None
+) -> None:
+    """Set (category_id given) or clear (None) the entity's category for a scope."""
+    ent_reg = er.async_get(hass)
+    entry = ent_reg.async_get(entity_id)
+    if entry is None:
+        raise ValueError(f"Entity '{entity_id}' not found in entity registry")
+    categories = dict(entry.categories)
+    if category_id is None:
+        categories.pop(scope, None)
+    else:
+        categories[scope] = category_id
+    ent_reg.async_update_entity(entity_id, categories=categories)
+
+
+def _category_dict(entry: cr.CategoryEntry) -> dict[str, Any]:
+    return {
+        "category_id": entry.category_id,
+        "name": entry.name,
+        "icon": entry.icon,
+        "created_at": entry.created_at,
+        "modified_at": entry.modified_at,
+    }
+
+
+@register_tool(
+    name="list_categories",
+    description="List all category definitions within a scope",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "scope": {
+                "type": "string",
+                "description": "One of: automation, script, scene, entity",
+            }
+        },
+        "required": ["scope"],
+    },
+)
+async def list_categories(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """List category definitions in a scope."""
+    try:
+        scope = arguments["scope"]
+        if scope not in VALID_SCOPES:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Unknown scope '{scope}'. "
+                        f"Supported: {', '.join(sorted(VALID_SCOPES))}",
+                    }
+                ]
+            }
+        reg = cr.async_get(hass)
+        cats = [_category_dict(c) for c in reg.async_list_categories(scope=scope)]
+        return {
+            "content": [{"type": "text", "text": json.dumps(cats, indent=2, cls=_HAJSONEncoder)}]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error listing categories: {str(e)}"}]}
+
+
+@register_tool(
+    name="create_category",
+    description="Create a new category definition within a scope",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "scope": {
+                "type": "string",
+                "description": "One of: automation, script, scene, entity",
+            },
+            "name": {
+                "type": "string",
+                "description": "Category name",
+            },
+            "icon": {
+                "type": "string",
+                "description": "Optional icon, e.g. 'mdi:lightbulb'",
+            },
+        },
+        "required": ["scope", "name"],
+    },
+)
+async def create_category(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Create a category definition in a scope."""
+    try:
+        scope = arguments["scope"]
+        if scope not in VALID_SCOPES:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Unknown scope '{scope}'. "
+                        f"Supported: {', '.join(sorted(VALID_SCOPES))}",
+                    }
+                ]
+            }
+        entry = cr.async_get(hass).async_create(
+            scope=scope, name=arguments["name"], icon=arguments.get("icon")
+        )
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"Created category '{entry.name}' with id: {entry.category_id}",
+                }
+            ]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error creating category: {str(e)}"}]}
+
+
+@register_tool(
+    name="update_category",
+    description="Rename or change the icon of a category definition",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "scope": {
+                "type": "string",
+                "description": "One of: automation, script, scene, entity",
+            },
+            "category_id": {
+                "type": "string",
+                "description": "The category ID to update",
+            },
+            "name": {
+                "type": "string",
+                "description": "New category name",
+            },
+            "icon": {
+                "type": "string",
+                "description": "New icon, e.g. 'mdi:lightbulb'",
+            },
+        },
+        "required": ["scope", "category_id"],
+    },
+)
+async def update_category(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Update a category definition in a scope."""
+    try:
+        scope = arguments["scope"]
+        if scope not in VALID_SCOPES:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Unknown scope '{scope}'. "
+                        f"Supported: {', '.join(sorted(VALID_SCOPES))}",
+                    }
+                ]
+            }
+        kwargs: dict[str, Any] = {}
+        if "name" in arguments:
+            kwargs["name"] = arguments["name"]
+        if "icon" in arguments:
+            kwargs["icon"] = arguments["icon"]
+        entry = cr.async_get(hass).async_update(
+            scope=scope, category_id=arguments["category_id"], **kwargs
+        )
+        return {"content": [{"type": "text", "text": f"Updated category {entry.category_id}"}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error updating category: {str(e)}"}]}
+
+
+@register_tool(
+    name="delete_category",
+    description="Delete a category definition (HA clears it from all assigned entities)",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "scope": {
+                "type": "string",
+                "description": "One of: automation, script, scene, entity",
+            },
+            "category_id": {
+                "type": "string",
+                "description": "The category ID to delete",
+            },
+        },
+        "required": ["scope", "category_id"],
+    },
+)
+async def delete_category(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Delete a category definition from a scope."""
+    try:
+        scope = arguments["scope"]
+        if scope not in VALID_SCOPES:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": f"Unknown scope '{scope}'. "
+                        f"Supported: {', '.join(sorted(VALID_SCOPES))}",
+                    }
+                ]
+            }
+        cr.async_get(hass).async_delete(scope=scope, category_id=arguments["category_id"])
+        return {
+            "content": [{"type": "text", "text": f"Deleted category {arguments['category_id']}"}]
+        }
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error deleting category: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/config.py
+++ b/custom_components/mcp_server_http_transport/tools/config.py
@@ -5,8 +5,10 @@ import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from . import _HAJSONEncoder, register_tool
+from .categories import resolve_category_id, write_entity_category
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +27,15 @@ _LOGGER = logging.getLogger(__name__)
                 "description": (
                     "Automation configuration (alias, trigger, action, condition, mode, etc.)"
                 ),
-            }
+            },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this automation to (scope: automation). "
+                    "The category must already exist (use create_category). "
+                    "On update, pass null/empty to remove the category."
+                ),
+            },
         },
         "required": ["config"],
     },
@@ -35,12 +45,31 @@ async def create_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     from ..config_manager import create_list_entry
 
     try:
+        category = arguments.get("category")
+        category_id = resolve_category_id(hass, "automation", category) if category else None
         entry_id = await create_list_entry(
             hass, "automations.yaml", arguments["config"], "automation"
         )
+        if category_id is not None:
+            entity_id = er.async_get(hass).async_get_entity_id("automation", "automation", entry_id)
+            if entity_id is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Created automation with id: {entry_id}, but its entity "
+                            "is not registered yet; category not applied.",
+                        }
+                    ]
+                }
+            write_entity_category(hass, entity_id, "automation", category_id)
+        suffix = f" in category '{category}'" if category else ""
         return {
             "content": [
-                {"type": "text", "text": f"Successfully created automation with id: {entry_id}"}
+                {
+                    "type": "text",
+                    "text": f"Successfully created automation with id: {entry_id}{suffix}",
+                }
             ]
         }
     except Exception as e:
@@ -62,6 +91,14 @@ async def create_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> d
                 "description": "Updated automation config"
                 " (alias, trigger, action, condition, mode, etc.)",
             },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this automation to (scope: automation). "
+                    "The category must already exist (use create_category). "
+                    "On update, pass null/empty to remove the category."
+                ),
+            },
         },
         "required": ["automation_id", "config"],
     },
@@ -71,6 +108,11 @@ async def update_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     from ..config_manager import update_list_entry
 
     try:
+        has_cat = "category" in arguments
+        category = arguments.get("category")
+        category_id = (
+            resolve_category_id(hass, "automation", category) if (has_cat and category) else None
+        )
         await update_list_entry(
             hass,
             "automations.yaml",
@@ -78,6 +120,21 @@ async def update_automation(hass: HomeAssistant, arguments: dict[str, Any]) -> d
             arguments["config"],
             "automation",
         )
+        if has_cat:
+            entity_id = er.async_get(hass).async_get_entity_id(
+                "automation", "automation", arguments["automation_id"]
+            )
+            if entity_id is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Updated automation, but entity not registered; "
+                            "category not changed.",
+                        }
+                    ]
+                }
+            write_entity_category(hass, entity_id, "automation", category_id)
         return {"content": [{"type": "text", "text": "Successfully updated automation"}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error updating automation: {str(e)}"}]}
@@ -168,7 +225,15 @@ async def get_automation_config(hass: HomeAssistant, arguments: dict[str, Any]) 
             "config": {
                 "type": "object",
                 "description": "Scene configuration (name, entities, etc.)",
-            }
+            },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this scene to (scope: scene). "
+                    "The category must already exist (use create_category). "
+                    "On update, pass null/empty to remove the category."
+                ),
+            },
         },
         "required": ["config"],
     },
@@ -178,9 +243,27 @@ async def create_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
     from ..config_manager import create_list_entry
 
     try:
+        category = arguments.get("category")
+        category_id = resolve_category_id(hass, "scene", category) if category else None
         entry_id = await create_list_entry(hass, "scenes.yaml", arguments["config"], "scene")
+        if category_id is not None:
+            entity_id = er.async_get(hass).async_get_entity_id("scene", "homeassistant", entry_id)
+            if entity_id is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Created scene with id: {entry_id}, but its entity "
+                            "is not registered yet; category not applied.",
+                        }
+                    ]
+                }
+            write_entity_category(hass, entity_id, "scene", category_id)
+        suffix = f" in category '{category}'" if category else ""
         return {
-            "content": [{"type": "text", "text": f"Successfully created scene with id: {entry_id}"}]
+            "content": [
+                {"type": "text", "text": f"Successfully created scene with id: {entry_id}{suffix}"}
+            ]
         }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error creating scene: {str(e)}"}]}
@@ -200,6 +283,14 @@ async def create_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
                 "type": "object",
                 "description": "Updated scene configuration (name, entities, etc.)",
             },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this scene to (scope: scene). "
+                    "The category must already exist (use create_category). "
+                    "On update, pass null/empty to remove the category."
+                ),
+            },
         },
         "required": ["scene_id", "config"],
     },
@@ -209,9 +300,29 @@ async def update_scene(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
     from ..config_manager import update_list_entry
 
     try:
+        has_cat = "category" in arguments
+        category = arguments.get("category")
+        category_id = (
+            resolve_category_id(hass, "scene", category) if (has_cat and category) else None
+        )
         await update_list_entry(
             hass, "scenes.yaml", arguments["scene_id"], arguments["config"], "scene"
         )
+        if has_cat:
+            entity_id = er.async_get(hass).async_get_entity_id(
+                "scene", "homeassistant", arguments["scene_id"]
+            )
+            if entity_id is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Updated scene, but entity not registered; "
+                            "category not changed.",
+                        }
+                    ]
+                }
+            write_entity_category(hass, entity_id, "scene", category_id)
         return {"content": [{"type": "text", "text": "Successfully updated scene"}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error updating scene: {str(e)}"}]}
@@ -307,6 +418,14 @@ async def get_scene_config(hass: HomeAssistant, arguments: dict[str, Any]) -> di
                 "type": "object",
                 "description": "Script configuration (alias, sequence, mode, etc.)",
             },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this script to (scope: script). "
+                    "The category must already exist (use create_category). "
+                    "On update, pass null/empty to remove the category."
+                ),
+            },
         },
         "required": ["key", "config"],
     },
@@ -316,11 +435,18 @@ async def create_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
     from ..config_manager import create_dict_entry
 
     try:
+        category = arguments.get("category")
+        category_id = resolve_category_id(hass, "script", category) if category else None
         key = await create_dict_entry(
             hass, "scripts.yaml", arguments["key"], arguments["config"], "script"
         )
+        if category_id is not None:
+            write_entity_category(hass, f"script.{key}", "script", category_id)
+        suffix = f" in category '{category}'" if category else ""
         return {
-            "content": [{"type": "text", "text": f"Successfully created script with key: {key}"}]
+            "content": [
+                {"type": "text", "text": f"Successfully created script with key: {key}{suffix}"}
+            ]
         }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error creating script: {str(e)}"}]}
@@ -340,6 +466,14 @@ async def create_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
                 "type": "object",
                 "description": "Updated script configuration (alias, sequence, mode, etc.)",
             },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this script to (scope: script). "
+                    "The category must already exist (use create_category). "
+                    "On update, pass null/empty to remove the category."
+                ),
+            },
         },
         "required": ["key", "config"],
     },
@@ -349,9 +483,16 @@ async def update_script(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
     from ..config_manager import update_dict_entry
 
     try:
+        has_cat = "category" in arguments
+        category = arguments.get("category")
+        category_id = (
+            resolve_category_id(hass, "script", category) if (has_cat and category) else None
+        )
         await update_dict_entry(
             hass, "scripts.yaml", arguments["key"], arguments["config"], "script"
         )
+        if has_cat:
+            write_entity_category(hass, f"script.{arguments['key']}", "script", category_id)
         return {"content": [{"type": "text", "text": "Successfully updated script"}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error updating script: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/helpers.py
+++ b/custom_components/mcp_server_http_transport/tools/helpers.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import _HAJSONEncoder, register_tool
+from .categories import resolve_category_id, write_entity_category
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -188,6 +189,13 @@ async def get_helper_config(hass: HomeAssistant, arguments: dict[str, Any]) -> d
                     "Optional for most types: icon, initial, restore"
                 ),
             },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this helper to. "
+                    "Must already exist (use create_category)."
+                ),
+            },
         },
         "required": ["domain", "config"],
     },
@@ -211,13 +219,31 @@ async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
         }
 
     try:
+        category = arguments.get("category")
+        category_id = resolve_category_id(hass, "entity", category) if category else None
         collection = _get_collection(hass, domain)
         item = await collection.async_create_item(config)
+        if category_id is not None:
+            entity_id = er.async_get(hass).async_get_entity_id(domain, domain, item["id"])
+            if entity_id is None:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": f"Successfully created {domain} helper with id: "
+                            f"{item['id']}, but its entity is not registered yet; "
+                            "category not applied.",
+                        }
+                    ]
+                }
+            write_entity_category(hass, entity_id, "entity", category_id)
+        suffix = f" in category '{category}'" if category else ""
         return {
             "content": [
                 {
                     "type": "text",
-                    "text": f"Successfully created {domain} helper with id: {item['id']}",
+                    "text": f"Successfully created {domain} helper with id: "
+                    f"{item['id']}{suffix}",
                 }
             ]
         }
@@ -241,6 +267,14 @@ async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
                     "Updated helper configuration. Include all fields, not just changed ones"
                 ),
             },
+            "category": {
+                "type": "string",
+                "description": (
+                    "Category name to assign this helper to. "
+                    "Must already exist (use create_category). "
+                    "Pass null/empty to remove the category."
+                ),
+            },
         },
         "required": ["entity_id", "config"],
     },
@@ -248,9 +282,17 @@ async def create_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
 async def update_helper(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Update an existing helper."""
     try:
-        domain, item_id = await _entity_id_to_item_id(hass, arguments["entity_id"])
+        has_cat = "category" in arguments
+        category = arguments.get("category")
+        category_id = (
+            resolve_category_id(hass, "entity", category) if (has_cat and category) else None
+        )
+        entity_id = arguments["entity_id"]
+        domain, item_id = await _entity_id_to_item_id(hass, entity_id)
         collection = _get_collection(hass, domain)
         await collection.async_update_item(item_id, arguments["config"])
+        if has_cat:
+            write_entity_category(hass, entity_id, "entity", category_id)
         return {"content": [{"type": "text", "text": "Successfully updated helper"}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error updating helper: {str(e)}"}]}

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 65
+        assert len(body["result"]["tools"]) == 69
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 65
+        assert len(tool_names) == 69
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_tools_categories.py
+++ b/tests/test_tools_categories.py
@@ -1,0 +1,166 @@
+"""Tests for category definition CRUD tools and shared assignment helpers."""
+
+import json
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+
+from custom_components.mcp_server_http_transport.tools.categories import (
+    create_category,
+    delete_category,
+    list_categories,
+    resolve_category_id,
+    write_entity_category,
+)
+
+CR_GET = "custom_components.mcp_server_http_transport.tools.categories.cr.async_get"
+ER_GET = "custom_components.mcp_server_http_transport.tools.categories.er.async_get"
+
+
+def _make_category(category_id: str = "c1", name: str = "Lighting") -> Mock:
+    """Create a mock CategoryEntry."""
+    entry = Mock(
+        category_id=category_id,
+        icon="mdi:lightbulb",
+        created_at=datetime(2024, 1, 1),
+        modified_at=datetime(2024, 1, 1),
+    )
+    entry.name = name  # `name` is a reserved Mock constructor kwarg; set it explicitly.
+    return entry
+
+
+class TestCreateCategory:
+    """Tests for the create_category tool."""
+
+    async def test_create_category_valid(self):
+        """create_category calls async_create with the scope, name, icon."""
+        reg = Mock()
+        reg.async_create.return_value = _make_category()
+
+        with patch(CR_GET, return_value=reg):
+            result = await create_category(
+                Mock(),
+                {"scope": "automation", "name": "Lighting", "icon": "mdi:lightbulb"},
+            )
+
+        reg.async_create.assert_called_once_with(
+            scope="automation", name="Lighting", icon="mdi:lightbulb"
+        )
+        assert "c1" in result["content"][0]["text"]
+
+    async def test_create_category_bad_scope(self):
+        """create_category rejects unknown scopes and never touches the registry."""
+        reg = Mock()
+
+        with patch(CR_GET, return_value=reg):
+            result = await create_category(Mock(), {"scope": "light", "name": "X"})
+
+        assert "Unknown scope" in result["content"][0]["text"]
+        reg.async_create.assert_not_called()
+
+    async def test_create_category_duplicate(self):
+        """create_category surfaces a duplicate-name ValueError."""
+        reg = Mock()
+        reg.async_create.side_effect = ValueError("The name 'X' is already in use")
+
+        with patch(CR_GET, return_value=reg):
+            result = await create_category(Mock(), {"scope": "scene", "name": "X"})
+
+        assert "already in use" in result["content"][0]["text"]
+
+
+class TestListCategories:
+    """Tests for the list_categories tool."""
+
+    async def test_list_categories(self):
+        """list_categories returns JSON entries with ISO timestamps."""
+        reg = Mock()
+        reg.async_list_categories.return_value = [_make_category()]
+
+        with patch(CR_GET, return_value=reg):
+            result = await list_categories(Mock(), {"scope": "entity"})
+
+        reg.async_list_categories.assert_called_once_with(scope="entity")
+        body = json.loads(result["content"][0]["text"])
+        assert body[0]["category_id"] == "c1"
+        assert body[0]["name"] == "Lighting"
+        assert body[0]["icon"] == "mdi:lightbulb"
+        assert body[0]["created_at"].startswith("2024-01-01")
+
+    async def test_list_categories_bad_scope(self):
+        """list_categories rejects unknown scopes."""
+        with patch(CR_GET, return_value=Mock()):
+            result = await list_categories(Mock(), {"scope": "device"})
+
+        assert "Unknown scope" in result["content"][0]["text"]
+
+
+class TestDeleteCategory:
+    """Tests for the delete_category tool."""
+
+    async def test_delete_category(self):
+        """delete_category calls async_delete with scope and category_id."""
+        reg = Mock()
+
+        with patch(CR_GET, return_value=reg):
+            result = await delete_category(Mock(), {"scope": "script", "category_id": "c1"})
+
+        reg.async_delete.assert_called_once_with(scope="script", category_id="c1")
+        assert "Deleted category c1" in result["content"][0]["text"]
+
+
+class TestResolveCategoryId:
+    """Tests for the resolve_category_id helper."""
+
+    def test_resolve_case_insensitive(self):
+        """resolve_category_id matches names case-insensitively."""
+        reg = Mock()
+        reg.async_list_categories.return_value = [_make_category()]
+
+        with patch(CR_GET, return_value=reg):
+            assert resolve_category_id(Mock(), "entity", "lIgHtInG") == "c1"
+
+    def test_resolve_missing(self):
+        """resolve_category_id raises with a create_category hint when absent."""
+        reg = Mock()
+        reg.async_list_categories.return_value = []
+
+        with patch(CR_GET, return_value=reg):
+            with pytest.raises(ValueError, match="create_category"):
+                resolve_category_id(Mock(), "entity", "Nope")
+
+
+class TestWriteEntityCategory:
+    """Tests for the write_entity_category helper."""
+
+    def test_write_sets_scope_preserving_others(self):
+        """Setting a category keeps pre-existing other-scope keys intact."""
+        ent_reg = Mock()
+        ent_reg.async_get.return_value = Mock(categories={"automation": "x"})
+
+        with patch(ER_GET, return_value=ent_reg):
+            write_entity_category(Mock(), "input_boolean.flag", "entity", "c1")
+
+        _, kwargs = ent_reg.async_update_entity.call_args
+        assert kwargs["categories"] == {"automation": "x", "entity": "c1"}
+
+    def test_write_clears_scope(self):
+        """Passing None removes only that scope's key."""
+        ent_reg = Mock()
+        ent_reg.async_get.return_value = Mock(categories={"automation": "x", "entity": "c1"})
+
+        with patch(ER_GET, return_value=ent_reg):
+            write_entity_category(Mock(), "input_boolean.flag", "entity", None)
+
+        _, kwargs = ent_reg.async_update_entity.call_args
+        assert kwargs["categories"] == {"automation": "x"}
+
+    def test_write_entity_missing(self):
+        """Missing entity raises a clear ValueError."""
+        ent_reg = Mock()
+        ent_reg.async_get.return_value = None
+
+        with patch(ER_GET, return_value=ent_reg):
+            with pytest.raises(ValueError, match="not found"):
+                write_entity_category(Mock(), "input_boolean.gone", "entity", "c1")

--- a/tests/test_tools_config.py
+++ b/tests/test_tools_config.py
@@ -748,3 +748,88 @@ class TestToolsConfig:
         assert response.status == 200
         body = json.loads(response.body)
         assert "Error deleting script" in body["result"]["content"][0]["text"]
+
+
+CM = "custom_components.mcp_server_http_transport.config_manager"
+CR_GET = "custom_components.mcp_server_http_transport.tools.categories.cr.async_get"
+# `er` is the entity_registry module; tools.config.er and tools.categories.er are
+# the same object, so one patch of entity_registry.async_get covers both.
+ER_GET = "homeassistant.helpers.entity_registry.async_get"
+
+
+def _make_category(category_id: str = "c1", name: str = "Lighting") -> Mock:
+    """Create a mock CategoryEntry whose .name is a real string."""
+    entry = Mock(category_id=category_id)
+    entry.name = name
+    return entry
+
+
+class TestConfigCategoryAssignment:
+    """Tests for the optional category argument on config CRUD tools."""
+
+    async def test_create_automation_with_category(self):
+        """create_automation resolves the name and writes the entity category."""
+        from custom_components.mcp_server_http_transport.tools.config import create_automation
+
+        cr_reg = Mock()
+        cr_reg.async_list_categories.return_value = [_make_category()]
+
+        ent_reg = Mock()
+        ent_reg.async_get_entity_id.return_value = "automation.foo"
+        ent_reg.async_get.return_value = Mock(categories={})
+
+        with (
+            patch(
+                f"{CM}.create_list_entry",
+                new=AsyncMock(return_value="entry-id"),
+            ) as create_mock,
+            patch(CR_GET, return_value=cr_reg),
+            patch(ER_GET, return_value=ent_reg),
+        ):
+            result = await create_automation(
+                Mock(), {"config": {"alias": "X"}, "category": "Lighting"}
+            )
+
+        create_mock.assert_called_once()
+        ent_reg.async_get_entity_id.assert_called_once_with("automation", "automation", "entry-id")
+        _, kwargs = ent_reg.async_update_entity.call_args
+        assert kwargs["categories"]["automation"] == "c1"
+        assert "in category 'Lighting'" in result["content"][0]["text"]
+
+    async def test_create_automation_unknown_category_aborts_write(self):
+        """A missing category name errors out before any YAML write."""
+        from custom_components.mcp_server_http_transport.tools.config import create_automation
+
+        cr_reg = Mock()
+        cr_reg.async_list_categories.return_value = []
+
+        with (
+            patch(f"{CM}.create_list_entry", new=AsyncMock()) as create_mock,
+            patch(CR_GET, return_value=cr_reg),
+        ):
+            result = await create_automation(Mock(), {"config": {"alias": "X"}, "category": "Nope"})
+
+        assert "Error creating automation" in result["content"][0]["text"]
+        assert "No category named 'Nope'" in result["content"][0]["text"]
+        create_mock.assert_not_called()
+
+    async def test_update_automation_empty_category_clears_scope(self):
+        """Passing an empty category clears the automation scope on the entity."""
+        from custom_components.mcp_server_http_transport.tools.config import update_automation
+
+        ent_reg = Mock()
+        ent_reg.async_get_entity_id.return_value = "automation.foo"
+        ent_reg.async_get.return_value = Mock(categories={"automation": "c1"})
+
+        with (
+            patch(f"{CM}.update_list_entry", new=AsyncMock()),
+            patch(ER_GET, return_value=ent_reg),
+        ):
+            result = await update_automation(
+                Mock(),
+                {"automation_id": "entry-id", "config": {"alias": "X"}, "category": ""},
+            )
+
+        _, kwargs = ent_reg.async_update_entity.call_args
+        assert "automation" not in kwargs["categories"]
+        assert "Successfully updated automation" in result["content"][0]["text"]

--- a/tests/test_tools_helpers.py
+++ b/tests/test_tools_helpers.py
@@ -668,3 +668,48 @@ class TestHelperToolsViaHTTP:
         assert "create_helper" in tool_names
         assert "update_helper" in tool_names
         assert "delete_helper" in tool_names
+
+
+class TestHelperCategoryAssignment:
+    """Tests for the optional category argument on helper CRUD tools."""
+
+    async def test_create_helper_with_category(self):
+        """create_helper resolves the name and writes the entity category."""
+        from custom_components.mcp_server_http_transport.tools.helpers import create_helper
+
+        collection = _make_collection()
+        collection.async_create_item.return_value = {"id": "item1", "name": "Flag"}
+        mock_hass = _make_hass_with_collection("input_boolean", collection)
+
+        cat = Mock(category_id="c1")
+        cat.name = "Lighting"
+        cr_reg = Mock()
+        cr_reg.async_list_categories.return_value = [cat]
+
+        # `er` is the entity_registry module; tools.helpers.er and tools.categories.er
+        # are the same object, so one patch of entity_registry.async_get covers both.
+        ent_reg = Mock()
+        ent_reg.async_get_entity_id.return_value = "input_boolean.flag"
+        ent_reg.async_get.return_value = Mock(categories={})
+
+        with (
+            patch(
+                "custom_components.mcp_server_http_transport.tools.categories.cr.async_get",
+                return_value=cr_reg,
+            ),
+            patch(
+                "homeassistant.helpers.entity_registry.async_get",
+                return_value=ent_reg,
+            ),
+        ):
+            result = await create_helper(
+                mock_hass,
+                {"domain": "input_boolean", "config": {"name": "Flag"}, "category": "Lighting"},
+            )
+
+        ent_reg.async_get_entity_id.assert_called_once_with(
+            "input_boolean", "input_boolean", "item1"
+        )
+        _, kwargs = ent_reg.async_update_entity.call_args
+        assert kwargs["categories"] == {"entity": "c1"}
+        assert "in category 'Lighting'" in result["content"][0]["text"]


### PR DESCRIPTION
Add four category-definition CRUD tools (list/create/update/delete_category) scoped to automation, script, scene, or entity. Object-CRUD tools (create_/update_automation, _scene, _script, and create_/update_helper) now accept an optional `category` name argument that resolves to a category id and writes the entity's category map; the name is validated before any YAML write, and passing an empty/null category on update clears the assignment. Categories are applied via the in-process HA category and entity registries.