### PR TITLE
feat: device-centric and service-introspection tools (#58, #59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `batch_get_state` | Get state for multiple entities in one call (max 50) |
 | `list_entities` | List all entities, with optional `domain`, `detailed`, and `fields` parameters |
 | `search_entities` | Search entities by friendly name, device class, domain, or area |
+| `get_device_details` | Get a device and every entity registered to it (all domains), with optional states |
 | `call_service` | Call any Home Assistant service |
 | `fire_event` | Fire a custom event on the Home Assistant event bus |
 | `get_history` | Get state history of an entity over a time range |
@@ -178,6 +179,7 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `list_areas` | List all areas |
 | `list_devices` | List devices, optionally filtered by area |
 | `list_services` | List available services, optionally filtered by domain |
+| `describe_service` | Get a service's full parameter schema: fields, selectors, examples, and targets |
 | `list_integrations` | List installed integrations and their status |
 | `list_labels` | List all labels for cross-domain grouping |
 

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.11.0"
+  "version": "1.12.0"
 }

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import label_registry as lr
+from homeassistant.helpers.service import async_get_all_descriptions
 
 from . import _HAJSONEncoder, register_tool
 
@@ -267,6 +268,91 @@ async def list_devices(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
 
 
 @register_tool(
+    name="get_device_details",
+    description=(
+        "Get a device together with every entity registered to it, across all domains. "
+        "Use this after list_devices when a request is about a physical device "
+        "(e.g. 'where is the vacuum', 'what can my washing machine do'): it returns all "
+        "related entities so you do not have to guess entity IDs or naming conventions. "
+        "Includes each entity's current state and attributes by default"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "device_id": {
+                "type": "string",
+                "description": "The device ID, as returned by list_devices",
+            },
+            "include_entities": {
+                "type": "boolean",
+                "description": "Include entities registered to the device (default true)",
+            },
+            "include_states": {
+                "type": "boolean",
+                "description": (
+                    "Include each entity's current state and attributes (default true). "
+                    "Ignored when include_entities is false"
+                ),
+            },
+            "include_disabled": {
+                "type": "boolean",
+                "description": "Include disabled entities (default false)",
+            },
+        },
+        "required": ["device_id"],
+    },
+)
+async def get_device_details(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Get a device and the entities registered to it."""
+    device_id = arguments["device_id"]
+    include_entities = arguments.get("include_entities", True)
+    include_states = arguments.get("include_states", True)
+    include_disabled = arguments.get("include_disabled", False)
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get(device_id)
+    if device is None:
+        return {"content": [{"type": "text", "text": f"Device {device_id} not found"}]}
+
+    result: dict[str, Any] = {
+        "device": {
+            "id": device.id,
+            "name": device.name,
+            "manufacturer": device.manufacturer,
+            "model": device.model,
+            "area_id": device.area_id,
+            "name_by_user": device.name_by_user,
+        }
+    }
+
+    if include_entities:
+        entity_registry = er.async_get(hass)
+        entries = er.async_entries_for_device(
+            entity_registry, device_id, include_disabled_entities=include_disabled
+        )
+        entities = []
+        for entry in entries:
+            entity: dict[str, Any] = {
+                "entity_id": entry.entity_id,
+                "domain": entry.entity_id.split(".")[0],
+                "name": entry.name or entry.original_name or entry.entity_id,
+                "disabled": entry.disabled_by is not None,
+            }
+            if include_states:
+                state = hass.states.get(entry.entity_id)
+                if state is not None:
+                    entity["state"] = state.state
+                    entity["attributes"] = dict(state.attributes)
+                    entity["name"] = state.attributes.get("friendly_name", entity["name"])
+                else:
+                    entity["state"] = None
+            entities.append(entity)
+        result["entities"] = entities
+
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+
+
+@register_tool(
     name="list_services",
     description="List available services in Home Assistant, optionally filtered by domain",
     input_schema={
@@ -291,6 +377,55 @@ async def list_services(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
     result = {}
     for domain, domain_services in services.items():
         result[domain] = list(domain_services.keys())
+
+    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+
+
+@register_tool(
+    name="describe_service",
+    description=(
+        "Get the full parameter schema for a service: each field's description, whether it "
+        "is required, example values, selectors, and target constraints. Use this after "
+        "list_services when you need to know how to call a service, instead of guessing the "
+        "payload. Note: selectors describe a parameter's type and constraints; for dynamic "
+        "per-entity options (such as a specific vacuum's mapped rooms) read the target "
+        "entity's attributes via get_state"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "domain": {
+                "type": "string",
+                "description": "The service domain (e.g., vacuum, light)",
+            },
+            "service": {
+                "type": "string",
+                "description": (
+                    "The service name (e.g., clean_area). "
+                    "Omit to describe every service in the domain"
+                ),
+            },
+        },
+        "required": ["domain"],
+    },
+)
+async def describe_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Describe a service's parameters, selectors, and targets."""
+    domain = arguments["domain"]
+    service = arguments.get("service")
+
+    descriptions = await async_get_all_descriptions(hass)
+    domain_services = descriptions.get(domain)
+    if not domain_services:
+        return {"content": [{"type": "text", "text": f"No services found for domain {domain}"}]}
+
+    if service is not None:
+        description = domain_services.get(service)
+        if description is None:
+            return {"content": [{"type": "text", "text": f"Service {domain}.{service} not found"}]}
+        result = {service: description}
+    else:
+        result = dict(domain_services)
 
     return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
 

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 65
+        assert len(body["result"]["tools"]) == 67
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 65
+        assert len(tool_names) == 67
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -587,6 +587,64 @@ class TestToolsEntities:
         assert "state" not in data["entities"][0]
         assert data["entities"][0]["name"] == "Dispense"
 
+    async def test_post_tools_call_get_device_details_entity_without_state(self, view, mock_hass):
+        """Test get_device_details reports state=None for an entity with no current state."""
+        mock_device = Mock()
+        mock_device.id = "device1"
+        mock_device.name = "Pet Feeder"
+        mock_device.manufacturer = "Acme"
+        mock_device.model = "PF1"
+        mock_device.area_id = None
+        mock_device.name_by_user = None
+        mock_dr = Mock()
+        mock_dr.async_get.return_value = mock_device
+
+        entry = Mock()
+        entry.entity_id = "switch.pet_feeder_dispense"
+        entry.name = None
+        entry.original_name = "Dispense"
+        entry.disabled_by = None
+
+        # The registered entity has no state in the machine (e.g. unavailable or not loaded).
+        mock_hass.states.get.return_value = None
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "get_device_details", "arguments": {"device_id": "device1"}},
+                "id": 104,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.dr.async_get",
+                return_value=mock_dr,
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.er.async_get",
+                return_value=Mock(),
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities."
+                "er.async_entries_for_device",
+                return_value=[entry],
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert data["entities"][0]["entity_id"] == "switch.pet_feeder_dispense"
+        assert data["entities"][0]["state"] is None
+        # With no state to override it, the name falls back to the registry original_name.
+        assert data["entities"][0]["name"] == "Dispense"
+
     async def test_post_tools_call_list_services(self, view, mock_hass):
         """Test POST with tools/call for list_services."""
         mock_hass.services.async_services.return_value = {

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -421,6 +421,172 @@ class TestToolsEntities:
         assert len(devices) == 1
         assert devices[0]["name"] == "Living Room Lamp"
 
+    async def test_post_tools_call_get_device_details_multi_domain(self, view, mock_hass):
+        """Test get_device_details returns entities across domains with states."""
+        mock_device = Mock()
+        mock_device.id = "device1"
+        mock_device.name = "Xiaomi Robot Vacuum X10"
+        mock_device.manufacturer = "Xiaomi"
+        mock_device.model = "X10"
+        mock_device.area_id = "living_room"
+        mock_device.name_by_user = None
+        mock_dr = Mock()
+        mock_dr.async_get.return_value = mock_device
+
+        vacuum_entry = Mock()
+        vacuum_entry.entity_id = "vacuum.xiaomi_robot_vacuum_x10"
+        vacuum_entry.name = None
+        vacuum_entry.original_name = "Xiaomi Robot Vacuum X10"
+        vacuum_entry.disabled_by = None
+
+        sensor_entry = Mock()
+        sensor_entry.entity_id = "sensor.xiaomi_robot_vacuum_x10_current_room"
+        sensor_entry.name = None
+        sensor_entry.original_name = "Current Room"
+        sensor_entry.disabled_by = None
+
+        mock_er = Mock()
+
+        vacuum_state = Mock()
+        vacuum_state.state = "docked"
+        vacuum_state.attributes = {"friendly_name": "Xiaomi Robot Vacuum X10"}
+        sensor_state = Mock()
+        sensor_state.state = "Dining Room"
+        sensor_state.attributes = {"friendly_name": "Current Room"}
+        mock_hass.states.get.side_effect = lambda eid: {
+            "vacuum.xiaomi_robot_vacuum_x10": vacuum_state,
+            "sensor.xiaomi_robot_vacuum_x10_current_room": sensor_state,
+        }.get(eid)
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "get_device_details", "arguments": {"device_id": "device1"}},
+                "id": 101,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.dr.async_get",
+                return_value=mock_dr,
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.er.async_get",
+                return_value=mock_er,
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities."
+                "er.async_entries_for_device",
+                return_value=[vacuum_entry, sensor_entry],
+            ) as mock_entries,
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert data["device"]["name"] == "Xiaomi Robot Vacuum X10"
+        assert data["device"]["manufacturer"] == "Xiaomi"
+        domains = sorted(e["domain"] for e in data["entities"])
+        assert domains == ["sensor", "vacuum"]
+        current_room = next(e for e in data["entities"] if e["entity_id"].endswith("current_room"))
+        assert current_room["state"] == "Dining Room"
+        assert current_room["name"] == "Current Room"
+        # Disabled entities excluded by default
+        _, kwargs = mock_entries.call_args
+        assert kwargs["include_disabled_entities"] is False
+
+    async def test_post_tools_call_get_device_details_not_found(self, view, mock_hass):
+        """Test get_device_details returns an error for an unknown device."""
+        mock_dr = Mock()
+        mock_dr.async_get.return_value = None
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "get_device_details", "arguments": {"device_id": "nope"}},
+                "id": 102,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.dr.async_get",
+                return_value=mock_dr,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "not found" in body["result"]["content"][0]["text"]
+
+    async def test_post_tools_call_get_device_details_no_states(self, view, mock_hass):
+        """Test get_device_details omits states when include_states is false."""
+        mock_device = Mock()
+        mock_device.id = "device1"
+        mock_device.name = "Pet Feeder"
+        mock_device.manufacturer = "Acme"
+        mock_device.model = "PF1"
+        mock_device.area_id = None
+        mock_device.name_by_user = None
+        mock_dr = Mock()
+        mock_dr.async_get.return_value = mock_device
+
+        entry = Mock()
+        entry.entity_id = "switch.pet_feeder_dispense"
+        entry.name = "Dispense"
+        entry.original_name = "Dispense"
+        entry.disabled_by = None
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_device_details",
+                    "arguments": {"device_id": "device1", "include_states": False},
+                },
+                "id": 103,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.dr.async_get",
+                return_value=mock_dr,
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities.er.async_get",
+                return_value=Mock(),
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities."
+                "er.async_entries_for_device",
+                return_value=[entry],
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert data["entities"][0]["entity_id"] == "switch.pet_feeder_dispense"
+        assert "state" not in data["entities"][0]
+        assert data["entities"][0]["name"] == "Dispense"
+
     async def test_post_tools_call_list_services(self, view, mock_hass):
         """Test POST with tools/call for list_services."""
         mock_hass.services.async_services.return_value = {
@@ -476,6 +642,147 @@ class TestToolsEntities:
         services = json.loads(body["result"]["content"][0]["text"])
         assert "light" in services
         assert "switch" not in services
+
+    async def test_post_tools_call_describe_service_single(self, view, mock_hass):
+        """Test describe_service returns one service's field schema."""
+        descriptions = {
+            "vacuum": {
+                "clean_area": {
+                    "name": "Clean area",
+                    "description": "Clean selected mapped areas.",
+                    "fields": {
+                        "cleaning_area_id": {
+                            "required": True,
+                            "selector": {"text": {"multiple": True}},
+                        }
+                    },
+                },
+                "start": {"name": "Start", "fields": {}},
+            }
+        }
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "describe_service",
+                    "arguments": {"domain": "vacuum", "service": "clean_area"},
+                },
+                "id": 110,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities."
+                "async_get_all_descriptions",
+                AsyncMock(return_value=descriptions),
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert list(data.keys()) == ["clean_area"]
+        assert "cleaning_area_id" in data["clean_area"]["fields"]
+        assert data["clean_area"]["fields"]["cleaning_area_id"]["required"] is True
+
+    async def test_post_tools_call_describe_service_whole_domain(self, view, mock_hass):
+        """Test describe_service returns every service in a domain when service is omitted."""
+        descriptions = {
+            "vacuum": {
+                "clean_area": {"name": "Clean area", "fields": {}},
+                "start": {"name": "Start", "fields": {}},
+            }
+        }
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "describe_service", "arguments": {"domain": "vacuum"}},
+                "id": 111,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities."
+                "async_get_all_descriptions",
+                AsyncMock(return_value=descriptions),
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert sorted(data.keys()) == ["clean_area", "start"]
+
+    async def test_post_tools_call_describe_service_unknown_domain(self, view, mock_hass):
+        """Test describe_service reports when a domain has no services."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "describe_service", "arguments": {"domain": "nope"}},
+                "id": 112,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities."
+                "async_get_all_descriptions",
+                AsyncMock(return_value={"vacuum": {"start": {}}}),
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "No services found" in body["result"]["content"][0]["text"]
+
+    async def test_post_tools_call_describe_service_unknown_service(self, view, mock_hass):
+        """Test describe_service reports when a service does not exist in the domain."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "describe_service",
+                    "arguments": {"domain": "vacuum", "service": "nope"},
+                },
+                "id": 113,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.tools.entities."
+                "async_get_all_descriptions",
+                AsyncMock(return_value={"vacuum": {"start": {}}}),
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "not found" in body["result"]["content"][0]["text"]
 
     async def test_post_tools_call_search_entities_by_query(self, view, mock_hass):
         """Test search_entities matches by friendly name."""


### PR DESCRIPTION
Adds two introspection tools that close gaps reported in #58 and #59, where AI clients could discover devices and service names but had no reliable way to go from a physical device to its entities, or from a service name to the parameters it expects.

## `get_device_details` (closes #58)

Today there is no device-centric path: `list_entities` neither accepts a `device_id` filter nor emits `device_id`, so a client that knows a `device_id` from `list_devices` has to dump every entity and guess by name prefix. That is exactly how the assistant in #58 read the main `vacuum.*` entity but missed the separate `sensor.*_current_room` entity.

`get_device_details(device_id, include_entities=true, include_states=true, include_disabled=false)` returns the device plus every entity registered to it (across all domains) using Home Assistant's `entity_registry.async_entries_for_device`. Each entity reports its `entity_id`, `domain`, resolved `name`, and a `disabled` flag, and by default includes the current `state` and `attributes`. The tool description points clients to use it after `list_devices`.

## `describe_service` (closes part of #59)

`list_services` returns only `{domain: [service_names]}`. `describe_service(domain, service?)` returns the full parameter schema via `homeassistant.helpers.service.async_get_all_descriptions`: each field's description, required flag, example, selector, and target constraints. Omitting `service` describes every service in the domain. This is the same `services.yaml`-derived metadata the HA frontend uses, so a client can learn that `vacuum.clean_area` takes a `cleaning_area_id` list instead of guessing field names and payloads.

This deliberately does not attempt to resolve dynamic, per-entity option values (for example one specific vacuum's mapped room IDs). Those are not part of the service description; they come from integration-specific data and, where exposed at all, live on the entity's attributes. The tool description directs clients to read those via `get_state`. See the issue replies for the fuller rationale on what was intentionally left out.

## Notes

Version bumped to 1.12.0. Tool count is now 67 (count assertions updated in the integration and HTTP tests). New unit tests cover a multi-domain device, the not-found and `include_states=false` paths, and single-service / whole-domain / unknown-domain / unknown-service cases for `describe_service`. Full suite (517 tests), ruff, and black all pass.
