### PR TITLE
feat: allow config file access in subdirectories (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 
 | Tool | Description |
 |------|-------------|
-| `list_config_files` | List all YAML files in the config directory (first level, secrets excluded) |
+| `list_config_files` | List YAML files in the config directory (first level by default, `recursive=true` for split configs; secrets excluded) |
 | `get_config_file` | Read the contents of a YAML config file (max 1 MB) |
 | `save_config_file` | Write or replace a YAML config file; auto-backs up all files first, then validates config |
 | `delete_config_file` | Delete a YAML config file; auto-backs up all files first |
@@ -381,10 +381,25 @@ batch_edit_config_files(
 
 Both `saves` and `deletes` are optional — you can use either or both in the same call.
 
-> **Note:** Only first-level `.yaml`/`.yml` files in the config directory are accessible. Subdirectories and non-YAML files are blocked. The following files are also blocked from direct edits — use the dedicated tools instead:
+**Split configurations.** If your `configuration.yaml` splits config across folders — `!include_dir_merge_list`, `!include_dir_named`, `packages`, and friends — pass `recursive=true` to find those files, then read or edit them by their relative path:
+
+```
+list_config_files(recursive=True)
+# → ["configuration.yaml", "includes/templates/dishwasher.yaml", "packages/hvac.yaml", ...]
+
+get_config_file(filename="includes/templates/dishwasher.yaml")
+save_config_file(filename="includes/templates/dishwasher.yaml", content="...")
+```
+
+Recursive listing skips hidden folders (`.storage`, …), `custom_components`, `deps`, `www`, `node_modules`, `tts`, and `mcp_backups`. `save_config_file` will not create missing directories — create the folder in Home Assistant first.
+
+> **Note:** Only `.yaml`/`.yml` files inside the config directory are accessible. Paths are resolved before use and must stay within the config directory — `..`, absolute paths, and symlinks pointing outside are rejected. The following are also blocked from direct edits — use the dedicated tools instead:
 >
-> - **`secrets.yaml`** — never readable, contains credentials
-> - **`automations.yaml`**, **`scenes.yaml`**, **`scripts.yaml`** — owned by Home Assistant's storage layer; use `create_automation` / `update_automation` / `delete_automation` (and the equivalents for scenes and scripts) so UI-managed entries stay consistent. These files are still included in backups, so a restore never drops them.
+> - **`secrets.yaml`** — never readable, contains credentials. Blocked at **any** depth, so `includes/secrets.yaml` is protected too.
+> - **`automations.yaml`**, **`scenes.yaml`**, **`scripts.yaml`** — owned by Home Assistant's storage layer; use `create_automation` / `update_automation` / `delete_automation` (and the equivalents for scenes and scripts) so UI-managed entries stay consistent. These files are still included in backups, so a restore never drops them. Only the **top-level** files are blocked — a split-config file that happens to be named `packages/scripts.yaml` is your own and stays editable.
+> - Anything inside **`mcp_backups/`** — use `list_config_backups` / `restore_config_backup` instead.
+
+> **Backup caveat:** the automatic snapshot taken before every save/delete covers **first-level** YAML files only. Edits to files in subdirectories are not captured by it, so there is no automatic rollback for those — keep your own copy (or use version control) before editing split config.
 </details>
 
 <details>
@@ -412,7 +427,7 @@ The image is returned directly to the model for analysis. `get_image_file` suppo
 <details>
 <summary>How does the automatic backup work?</summary>
 
-Every call to `save_config_file` and `delete_config_file` automatically creates a full snapshot of all first-level YAML files (excluding `secrets.yaml`) before making any change. When using `batch_edit_config_files`, only one backup is created for the entire batch — regardless of how many files are saved or deleted. Snapshots are stored in:
+Every call to `save_config_file` and `delete_config_file` automatically creates a full snapshot of all first-level YAML files (excluding `secrets.yaml`) before making any change. Files in subdirectories are not included in this snapshot. When using `batch_edit_config_files`, only one backup is created for the entire batch — regardless of how many files are saved or deleted. Snapshots are stored in:
 
 ```
 config/mcp_backups/2026-04-26_14-30-00-123456/

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -282,6 +282,13 @@ def _list_yaml_filenames_sync(config_dir: Path, recursive: bool = False) -> list
                 and entry.suffix.lower() in _ALLOWED_SUFFIXES
                 and entry.name.lower() not in _SECRETS_FILES
             ):
+                # A file symlink pointing outside is rejected on read, so listing it
+                # would only offer a path that always errors.
+                try:
+                    if not entry.resolve().is_relative_to(root):
+                        continue
+                except OSError:
+                    continue
                 found.append(entry.relative_to(config_dir).as_posix())
 
     _walk(config_dir, 0)

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -21,14 +21,21 @@ _ALLOWED_SUFFIXES = {".yaml", ".yml"}
 # Files blocked from direct read/write/delete via the config file tools.
 # Each entry maps the lowercase filename to the reason the AI sees in the error,
 # so when a write is rejected the AI can pick the right alternative tool instead
-# of just seeing "blocked." Two distinct blocking reasons live here:
-#   - sensitive data (secrets must never be exposed to the AI)
-#   - dedicated tool exists (raw YAML edits would bypass HA's storage layer
-#     and clobber UI-managed entries; the tool-specific CRUD goes through HA's
-#     own write path and keeps registries consistent)
-_BLOCKED_FILES = {
+# of just seeing "blocked." The two block lists differ in scope because their
+# reasons differ:
+#   - _BLOCKED_ANYWHERE: sensitive data. Secrets must never be exposed to the AI
+#     no matter where they live, so these match on basename at any depth —
+#     `includes/secrets.yaml` is just as sensitive as `secrets.yaml`.
+#   - _BLOCKED_AT_ROOT: a dedicated tool exists. Raw YAML edits would bypass HA's
+#     storage layer and clobber UI-managed entries. HA only owns these at the
+#     config root, so a split-config file that happens to be named
+#     `packages/scripts.yaml` is the user's own and stays editable.
+_BLOCKED_ANYWHERE = {
     "secrets.yaml": "contains sensitive credentials and must never be exposed",
     "secrets.yml": "contains sensitive credentials and must never be exposed",
+}
+
+_BLOCKED_AT_ROOT = {
     "automations.yaml": (
         "is owned by Home Assistant's UI and is rewritten on every change. "
         "Use create_automation / update_automation / delete_automation instead — "
@@ -72,29 +79,75 @@ def _config_dir(hass: HomeAssistant) -> Path:
 
 
 def _resolve_safe(hass: HomeAssistant, filename: str) -> Path:
-    """Return resolved Path inside config dir, or raise ValueError."""
-    if os.sep in filename or "/" in filename:
-        raise ValueError("Subdirectories are not allowed — only first-level files")
-    blocked_reason = _BLOCKED_FILES.get(filename.lower())
+    """Return resolved Path inside config dir, or raise ValueError.
+
+    `filename` may name a file in a subdirectory (e.g. 'includes/templates/x.yaml')
+    so that split configurations — `!include_dir_merge_list`, `packages`, and
+    friends — are reachable. Containment is enforced by resolving the joined path
+    and requiring it to stay under the config directory; because `resolve()`
+    follows symlinks, that single check covers '..' traversal, absolute paths, and
+    symlinks pointing outside the config root. The explicit '..'/absolute rejections
+    below are for a clearer error message, not for safety.
+    """
+    if not filename or not filename.strip():
+        raise ValueError("Filename must not be empty")
+    normalized = filename.replace(os.sep, "/")
+    candidate = Path(filename)
+    if candidate.is_absolute() or normalized.startswith("/"):
+        raise ValueError(f"Absolute paths are not allowed, got '{filename}'")
+    if ".." in normalized.split("/"):
+        raise ValueError(f"Parent directory references ('..') are not allowed, got '{filename}'")
+
+    basename = candidate.name.lower()
+    blocked_reason = _BLOCKED_ANYWHERE.get(basename)
+    if blocked_reason is None and candidate.parent == Path("."):
+        blocked_reason = _BLOCKED_AT_ROOT.get(basename)
     if blocked_reason is not None:
         raise ValueError(f"Access to '{filename}' is blocked: {blocked_reason}")
-    suffix = Path(filename).suffix.lower()
+
+    suffix = candidate.suffix.lower()
     if suffix not in _ALLOWED_SUFFIXES:
         raise ValueError(f"Only YAML files are supported (.yaml, .yml), got '{suffix or filename}'")
-    path = _config_dir(hass) / filename
+
+    config_dir = _config_dir(hass)
+    path = config_dir / filename
     # Paranoia check: resolved path must still be inside config_dir
-    if not path.resolve().is_relative_to(_config_dir(hass).resolve()):
+    if not path.resolve().is_relative_to(config_dir.resolve()):
         raise ValueError("Path traversal detected")
+    # The backup folder is managed by the backup/restore tools; editing snapshots
+    # through the generic file tools would corrupt rollback state.
+    if _BACKUP_DIR_NAME in path.resolve().relative_to(config_dir.resolve()).parts[:-1]:
+        raise ValueError(
+            f"Access to '{filename}' is blocked: it is inside the '{_BACKUP_DIR_NAME}' "
+            "folder. Use list_config_backups / restore_config_backup instead"
+        )
     return path
 
 
 _SECRETS_FILES = {"secrets.yaml", "secrets.yml"}
 
+# Directories skipped when listing recursively. These hold YAML that is not part of
+# the user's own configuration (HA internals, vendored dependencies, our own backup
+# snapshots), and walking them buries the real config in noise. Hidden directories
+# (".storage", ".git", …) are skipped by the leading-dot rule instead of by name.
+_SKIP_DIRS = {
+    _BACKUP_DIR_NAME,
+    "custom_components",
+    "deps",
+    "node_modules",
+    "tts",
+    "www",
+}
+
+# Guards against a pathological or symlink-looped tree turning a list call into an
+# unbounded walk. Real split configs nest two or three levels.
+_MAX_LIST_DEPTH = 6
+
 
 def _yaml_files_in(directory: Path) -> list[Path]:
     """Return sorted first-level YAML files for backups, excluding only secrets.
 
-    Note: this is intentionally narrower than `_BLOCKED_FILES`. The block list
+    Note: this is intentionally narrower than the block lists. Those lists
     keeps the AI from rewriting registry-owned files via the config tools, but
     those files MUST still be included in backups — otherwise a restore would
     silently drop the user's automations, scenes, or scripts. Only secrets are
@@ -136,6 +189,11 @@ def _atomic_write(path: Path, content: str) -> None:
 
     Avoids leaving the target half-written if the process dies mid-write.
     """
+    if not path.parent.is_dir():
+        raise ValueError(
+            f"Target directory '{path.parent.name}/' does not exist. "
+            "Create it in Home Assistant first, or save into an existing directory"
+        )
     tmp = path.with_name(f".{path.name}.mcp_tmp")
     try:
         tmp.write_text(content, encoding="utf-8")
@@ -153,34 +211,90 @@ def _atomic_write(path: Path, content: str) -> None:
     name="list_config_files",
     description=(
         "List YAML configuration files in the Home Assistant config directory "
-        "(first level only; secrets.yaml is excluded). "
+        "(first level only by default; secrets.yaml is excluded). "
+        "Pass recursive=true to also list files in subdirectories — use this for split "
+        "configurations that use !include_dir_merge_list, !include_dir_named, or packages. "
+        "Recursive results are paths relative to the config directory "
+        "(e.g. 'includes/templates/dishwasher.yaml') and can be passed straight to "
+        "get_config_file or save_config_file. "
         "Some listed files (automations.yaml, scenes.yaml, scripts.yaml) cannot be "
         "edited directly — use the dedicated CRUD tools for those instead"
     ),
-    input_schema={"type": "object", "properties": {}},
+    input_schema={
+        "type": "object",
+        "properties": {
+            "recursive": {
+                "type": "boolean",
+                "description": (
+                    "Include YAML files in subdirectories (default: false). "
+                    "Skips hidden folders, custom_components, deps, www, and mcp_backups"
+                ),
+            }
+        },
+    },
 )
 async def list_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
-    """List first-level YAML files in the config directory."""
+    """List YAML files in the config directory, optionally recursing into subdirectories."""
     if not _is_enabled(hass):
         return _DISABLED_RESPONSE
     config_dir = _config_dir(hass)
+    recursive = bool(arguments.get("recursive", False))
     try:
-        files = await hass.async_add_executor_job(_list_yaml_filenames_sync, config_dir)
+        files = await hass.async_add_executor_job(_list_yaml_filenames_sync, config_dir, recursive)
         return {"content": [{"type": "text", "text": json.dumps(files, indent=2)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing config files: {e}"}]}
 
 
-def _list_yaml_filenames_sync(config_dir: Path) -> list[str]:
-    """Return the first-level YAML filenames in config_dir, sorted."""
-    return [f.name for f in _yaml_files_in(config_dir)]
+def _list_yaml_filenames_sync(config_dir: Path, recursive: bool = False) -> list[str]:
+    """Return YAML filenames in config_dir, sorted.
+
+    When `recursive`, walks subdirectories and returns paths relative to the config
+    directory (e.g. 'includes/templates/dishwasher.yaml') — the same form the other
+    config file tools accept as `filename`. Secrets are excluded at every depth.
+    """
+    if not recursive:
+        return [f.name for f in _yaml_files_in(config_dir)]
+
+    root = config_dir.resolve()
+    found: list[str] = []
+
+    def _walk(directory: Path, depth: int) -> None:
+        if depth > _MAX_LIST_DEPTH:
+            return
+        try:
+            entries = sorted(directory.iterdir())
+        except OSError:
+            return
+        for entry in entries:
+            if entry.is_dir():
+                if entry.name.startswith(".") or entry.name.lower() in _SKIP_DIRS:
+                    continue
+                # Never follow a symlink out of the config directory.
+                try:
+                    if not entry.resolve().is_relative_to(root):
+                        continue
+                except OSError:
+                    continue
+                _walk(entry, depth + 1)
+            elif (
+                entry.is_file()
+                and entry.suffix.lower() in _ALLOWED_SUFFIXES
+                and entry.name.lower() not in _SECRETS_FILES
+            ):
+                found.append(entry.relative_to(config_dir).as_posix())
+
+    _walk(config_dir, 0)
+    return sorted(found)
 
 
 @register_tool(
     name="get_config_file",
     description=(
         "Read the contents of a YAML configuration file from the Home Assistant config directory. "
-        "First-level files only. secrets.yaml is blocked, and "
+        "Accepts subdirectory paths (e.g. 'includes/templates/dishwasher.yaml') so split "
+        "configurations are readable; use list_config_files with recursive=true to discover them. "
+        "secrets.yaml is blocked at any depth, and top-level "
         "automations.yaml / scenes.yaml / scripts.yaml are blocked from direct access — "
         "use list_automations / list_scenes / list_scripts (and their get_*_config variants) "
         "for those"
@@ -190,7 +304,10 @@ def _list_yaml_filenames_sync(config_dir: Path) -> list[str]:
         "properties": {
             "filename": {
                 "type": "string",
-                "description": "File name, e.g. 'automations.yaml' or 'configuration.yaml'",
+                "description": (
+                    "File path relative to the config directory, e.g. 'configuration.yaml' "
+                    "or 'includes/templates/dishwasher.yaml'"
+                ),
             }
         },
         "required": ["filename"],
@@ -224,12 +341,15 @@ def _read_config_file_sync(path: Path, filename: str) -> str:
     name="save_config_file",
     description=(
         "Write or replace a YAML configuration file in the Home Assistant config directory. "
-        "First-level files only. secrets.yaml is blocked, and "
+        "Accepts subdirectory paths (e.g. 'includes/templates/dishwasher.yaml') for split "
+        "configurations; the target directory must already exist. "
+        "secrets.yaml is blocked at any depth, and top-level "
         "automations.yaml / scenes.yaml / scripts.yaml are blocked from direct edits — "
         "use create_automation/update_automation, create_scene/update_scene, or "
         "create_script/update_script for those. "
         "Creates the file if it does not exist. "
-        "Automatically backs up all YAML files before writing and runs a config check after. "
+        "Automatically backs up all first-level YAML files before writing and runs a config "
+        "check after. Note the automatic backup does NOT cover files in subdirectories. "
         "When editing multiple files prefer batch_edit_config_files to avoid redundant backups"
     ),
     input_schema={
@@ -237,7 +357,10 @@ def _read_config_file_sync(path: Path, filename: str) -> str:
         "properties": {
             "filename": {
                 "type": "string",
-                "description": "File name, e.g. 'configuration.yaml' or 'templates.yaml'",
+                "description": (
+                    "File path relative to the config directory, e.g. 'configuration.yaml' "
+                    "or 'includes/templates/dishwasher.yaml'"
+                ),
             },
             "content": {
                 "type": "string",
@@ -288,10 +411,12 @@ async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     name="delete_config_file",
     description=(
         "Delete a YAML configuration file from the Home Assistant config directory. "
-        "First-level files only. secrets.yaml is blocked, and "
+        "Accepts subdirectory paths (e.g. 'includes/templates/dishwasher.yaml'). "
+        "secrets.yaml is blocked at any depth, and top-level "
         "automations.yaml / scenes.yaml / scripts.yaml are blocked — "
         "use delete_automation, delete_scene, or delete_script for those. "
-        "Automatically backs up all YAML files before deleting. "
+        "Automatically backs up all first-level YAML files before deleting. "
+        "Note the automatic backup does NOT cover files in subdirectories. "
         "When deleting multiple files prefer batch_edit_config_files to avoid redundant backups"
     ),
     input_schema={
@@ -299,7 +424,10 @@ async def save_config_file(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         "properties": {
             "filename": {
                 "type": "string",
-                "description": "File name to delete, e.g. 'my_custom.yaml'",
+                "description": (
+                    "File path to delete relative to the config directory, "
+                    "e.g. 'my_custom.yaml' or 'includes/templates/old.yaml'"
+                ),
             }
         },
         "required": ["filename"],
@@ -384,7 +512,9 @@ def _apply_batch_edit_sync(
     name="batch_edit_config_files",
     description=(
         "Write and/or delete multiple YAML config files in one operation. "
-        "Creates one backup before any changes and runs one config check after all changes. "
+        "Filenames may include subdirectories (e.g. 'includes/templates/dishwasher.yaml'). "
+        "Creates one backup of all first-level YAML files before any changes (subdirectory "
+        "files are not covered by it) and runs one config check after all changes. "
         "Prefer this over repeated save_config_file or delete_config_file calls "
         "when touching more than one file — avoids redundant backups"
     ),
@@ -397,7 +527,12 @@ def _apply_batch_edit_sync(
                 "items": {
                     "type": "object",
                     "properties": {
-                        "filename": {"type": "string", "description": "e.g. 'templates.yaml'"},
+                        "filename": {
+                            "type": "string",
+                            "description": (
+                                "e.g. 'templates.yaml' or 'includes/templates/dishwasher.yaml'"
+                            ),
+                        },
                         "content": {"type": "string", "description": "Full YAML content to write"},
                     },
                     "required": ["filename", "content"],
@@ -405,7 +540,7 @@ def _apply_batch_edit_sync(
             },
             "deletes": {
                 "type": "array",
-                "description": "File names to delete.",
+                "description": "File paths to delete, relative to the config directory.",
                 "items": {"type": "string"},
             },
             "run_check": {

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -199,6 +199,21 @@ class TestListConfigFilesRecursive:
 
         assert files == []
 
+    async def test_recursive_omits_file_symlink_pointing_outside(self, tmp_path):
+        """Listing and reading must agree — a path that always errors is not worth listing."""
+        outside = tmp_path.parent / "outside_file.yaml"
+        outside.write_text("secret: data")
+        nested = tmp_path / "includes"
+        nested.mkdir()
+        (nested / "escape.yaml").symlink_to(outside)
+        (nested / "real.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == ["includes/real.yaml"]
+
     async def test_recursive_respects_depth_limit(self, tmp_path):
         deep = tmp_path
         for i in range(10):

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -95,6 +95,7 @@ class TestListConfigFiles:
         assert "secrets.yml" not in files
 
     async def test_list_excludes_subdirectories(self, tmp_path):
+        """Default stays first-level-only so existing callers see no change."""
         subdir = tmp_path / "packages"
         subdir.mkdir()
         (subdir / "lights.yaml").write_text("")
@@ -104,6 +105,7 @@ class TestListConfigFiles:
         files = json.loads(result["content"][0]["text"])
 
         assert "lights.yaml" not in files
+        assert "packages/lights.yaml" not in files
 
     async def test_list_returns_sorted(self, tmp_path):
         (tmp_path / "zzz.yaml").write_text("")
@@ -126,6 +128,100 @@ class TestListConfigFiles:
         with patch.object(Path, "iterdir", side_effect=OSError("permission denied")):
             result = await list_config_files(hass, {})
         assert "Error listing config files" in result["content"][0]["text"]
+
+
+class TestListConfigFilesRecursive:
+    """Recursive listing for split configs (!include_dir_*, packages)."""
+
+    async def test_recursive_returns_relative_paths(self, tmp_path):
+        templates = tmp_path / "includes" / "templates"
+        templates.mkdir(parents=True)
+        (templates / "dishwasher.yaml").write_text("")
+        (tmp_path / "configuration.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert "includes/templates/dishwasher.yaml" in files
+        assert "configuration.yaml" in files
+
+    async def test_recursive_paths_are_accepted_by_get_config_file(self, tmp_path):
+        """The listed path must be usable verbatim as get_config_file's filename."""
+        templates = tmp_path / "includes" / "templates"
+        templates.mkdir(parents=True)
+        (templates / "dishwasher.yaml").write_text("marker: present")
+        hass = _make_hass(tmp_path)
+
+        listed = json.loads(
+            (await list_config_files(hass, {"recursive": True}))["content"][0]["text"]
+        )
+        result = await get_config_file(hass, {"filename": listed[0]})
+
+        assert "marker: present" in result["content"][0]["text"]
+
+    async def test_recursive_excludes_nested_secrets(self, tmp_path):
+        nested = tmp_path / "includes"
+        nested.mkdir()
+        (nested / "secrets.yaml").write_text("token: abc")
+        (nested / "lights.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert "includes/secrets.yaml" not in files
+        assert "includes/lights.yaml" in files
+
+    async def test_recursive_skips_noise_directories(self, tmp_path):
+        for noise in ("mcp_backups", "custom_components", "deps", "www", ".storage"):
+            d = tmp_path / noise
+            d.mkdir()
+            (d / "junk.yaml").write_text("")
+        (tmp_path / "packages").mkdir()
+        (tmp_path / "packages" / "real.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == ["packages/real.yaml"]
+
+    async def test_recursive_does_not_follow_symlink_out_of_config_dir(self, tmp_path):
+        outside = tmp_path.parent / "outside_dir"
+        outside.mkdir(exist_ok=True)
+        (outside / "leaked.yaml").write_text("secret: data")
+        (tmp_path / "escape").symlink_to(outside, target_is_directory=True)
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == []
+
+    async def test_recursive_respects_depth_limit(self, tmp_path):
+        deep = tmp_path
+        for i in range(10):
+            deep = deep / f"level{i}"
+        deep.mkdir(parents=True)
+        (deep / "too_deep.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == []
+
+    async def test_recursive_returns_sorted(self, tmp_path):
+        (tmp_path / "zzz").mkdir()
+        (tmp_path / "zzz" / "a.yaml").write_text("")
+        (tmp_path / "aaa.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+
+        result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == sorted(files)
 
 
 class TestGetConfigFile:
@@ -195,15 +291,75 @@ class TestGetConfigFile:
             "Error" in result["content"][0]["text"] or "Only YAML" in result["content"][0]["text"]
         )
 
-    async def test_read_blocks_subdirectory_path(self, tmp_path):
+    async def test_read_allows_subdirectory_path(self, tmp_path):
+        """Split configs (!include_dir_*) put real config one or more folders down."""
+        nested = tmp_path / "includes" / "templates"
+        nested.mkdir(parents=True)
+        (nested / "dishwasher.yaml").write_text("- sensor:\n    - name: Dishwasher\n")
         hass = _make_hass(tmp_path)
-        result = await get_config_file(hass, {"filename": "subdir/file.yaml"})
-        assert "Subdirectories are not allowed" in result["content"][0]["text"]
+        result = await get_config_file(hass, {"filename": "includes/templates/dishwasher.yaml"})
+        assert "name: Dishwasher" in result["content"][0]["text"]
 
     async def test_read_blocks_path_traversal(self, tmp_path):
         hass = _make_hass(tmp_path)
         result = await get_config_file(hass, {"filename": "../etc/passwd"})
-        assert "Subdirectories are not allowed" in result["content"][0]["text"]
+        assert "'..'" in result["content"][0]["text"]
+
+    async def test_read_blocks_traversal_that_lands_inside_config_dir(self, tmp_path):
+        """'..' is rejected even when the resolved path would stay inside the config dir."""
+        (tmp_path / "configuration.yaml").write_text("x: 1")
+        (tmp_path / "includes").mkdir()
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "includes/../configuration.yaml"})
+        assert "'..'" in result["content"][0]["text"]
+
+    async def test_read_blocks_absolute_path(self, tmp_path):
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "/etc/passwd.yaml"})
+        assert "Absolute paths are not allowed" in result["content"][0]["text"]
+
+    async def test_read_blocks_nested_secrets(self, tmp_path):
+        """Recursion must not open a leak the old depth-1 code structurally couldn't have."""
+        nested = tmp_path / "includes"
+        nested.mkdir()
+        (nested / "secrets.yaml").write_text("api_key: hunter2")
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "includes/secrets.yaml"})
+        text = result["content"][0]["text"]
+        assert "blocked" in text
+        assert "hunter2" not in text
+
+    async def test_read_allows_nested_file_named_like_registry_file(self, tmp_path):
+        """A subdir 'scripts.yaml' is the user's own, not HA's UI-managed one."""
+        nested = tmp_path / "packages"
+        nested.mkdir()
+        (nested / "scripts.yaml").write_text("my_package: true")
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "packages/scripts.yaml"})
+        assert "my_package: true" in result["content"][0]["text"]
+
+    async def test_read_blocks_backup_folder(self, tmp_path):
+        backup = tmp_path / "mcp_backups" / "2026-01-01_00-00-00-0"
+        backup.mkdir(parents=True)
+        (backup / "configuration.yaml").write_text("old: 1")
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(
+            hass, {"filename": "mcp_backups/2026-01-01_00-00-00-0/configuration.yaml"}
+        )
+        assert "blocked" in result["content"][0]["text"]
+
+    async def test_read_blocks_subdirectory_symlink_escape(self, tmp_path):
+        """A symlink one level down must not reach outside the config dir either."""
+        outside = tmp_path.parent / "outside_nested.yaml"
+        outside.write_text("secret: data")
+        nested = tmp_path / "includes"
+        nested.mkdir()
+        (nested / "escape.yaml").symlink_to(outside)
+        hass = _make_hass(tmp_path)
+        result = await get_config_file(hass, {"filename": "includes/escape.yaml"})
+        text = result["content"][0]["text"]
+        assert "Path traversal detected" in text
+        assert "secret: data" not in text
 
     async def test_read_blocks_symlink_escape(self, tmp_path):
         """Symlink pointing outside config_dir must be blocked by is_relative_to check."""
@@ -369,10 +525,52 @@ class TestSaveConfigFile:
         )
         assert not (tmp_path / "malicious.sh").exists()
 
-    async def test_write_blocks_subdirectory_path(self, tmp_path):
+    async def test_write_allows_subdirectory_path(self, tmp_path):
+        nested = tmp_path / "includes" / "templates"
+        nested.mkdir(parents=True)
+        (nested / "dishwasher.yaml").write_text("old: 1")
         hass = _make_hass(tmp_path)
-        result = await save_config_file(hass, {"filename": "subdir/file.yaml", "content": "x: 1"})
-        assert "Subdirectories are not allowed" in result["content"][0]["text"]
+
+        result = await save_config_file(
+            hass, {"filename": "includes/templates/dishwasher.yaml", "content": "new: 2"}
+        )
+
+        assert "Successfully saved" in result["content"][0]["text"]
+        assert (nested / "dishwasher.yaml").read_text() == "new: 2"
+
+    async def test_write_creates_new_file_in_existing_subdirectory(self, tmp_path):
+        (tmp_path / "packages").mkdir()
+        hass = _make_hass(tmp_path)
+
+        result = await save_config_file(
+            hass, {"filename": "packages/dishwasher.yaml", "content": "x: 1"}
+        )
+
+        assert "Successfully saved" in result["content"][0]["text"]
+        assert (tmp_path / "packages" / "dishwasher.yaml").read_text() == "x: 1"
+
+    async def test_write_rejects_missing_directory(self, tmp_path):
+        """Auto-creating directories would silently accept a typo'd include path."""
+        hass = _make_hass(tmp_path)
+
+        result = await save_config_file(
+            hass, {"filename": "nonexistent/file.yaml", "content": "x: 1"}
+        )
+
+        assert "does not exist" in result["content"][0]["text"]
+        assert not (tmp_path / "nonexistent").exists()
+
+    async def test_write_blocks_nested_secrets(self, tmp_path):
+        nested = tmp_path / "includes"
+        nested.mkdir()
+        hass = _make_hass(tmp_path)
+
+        result = await save_config_file(
+            hass, {"filename": "includes/secrets.yaml", "content": "x: 1"}
+        )
+
+        assert "blocked" in result["content"][0]["text"]
+        assert not (nested / "secrets.yaml").exists()
 
 
 class TestDeleteConfigFile:
@@ -435,10 +633,29 @@ class TestDeleteConfigFile:
         )
         assert (tmp_path / "script.py").exists()
 
-    async def test_delete_blocks_subdirectory_path(self, tmp_path):
+    async def test_delete_allows_subdirectory_path(self, tmp_path):
+        nested = tmp_path / "includes" / "templates"
+        nested.mkdir(parents=True)
+        (nested / "old.yaml").write_text("x: 1")
         hass = _make_hass(tmp_path)
-        result = await delete_config_file(hass, {"filename": "subdir/file.yaml"})
-        assert "Subdirectories are not allowed" in result["content"][0]["text"]
+
+        result = await delete_config_file(hass, {"filename": "includes/templates/old.yaml"})
+
+        assert "Successfully deleted" in result["content"][0]["text"]
+        assert not (nested / "old.yaml").exists()
+        # The containing directory must survive — other includes may still live there.
+        assert nested.is_dir()
+
+    async def test_delete_blocks_nested_secrets(self, tmp_path):
+        nested = tmp_path / "includes"
+        nested.mkdir()
+        (nested / "secrets.yaml").write_text("api_key: hunter2")
+        hass = _make_hass(tmp_path)
+
+        result = await delete_config_file(hass, {"filename": "includes/secrets.yaml"})
+
+        assert "blocked" in result["content"][0]["text"]
+        assert (nested / "secrets.yaml").exists()
 
 
 class TestBackupConfigFiles:
@@ -909,6 +1126,49 @@ class TestBatchEditConfigFiles:
         text = result["content"][0]["text"]
         assert "error" in text.lower()
         assert not (tmp_path / "ok.yaml").exists()
+
+    async def test_saves_and_deletes_in_subdirectories(self, tmp_path):
+        templates = tmp_path / "includes" / "templates"
+        templates.mkdir(parents=True)
+        (templates / "old.yaml").write_text("old: 1")
+        hass = _make_hass(tmp_path)
+
+        with _mock_create_backup():
+            result = await batch_edit_config_files(
+                hass,
+                {
+                    "saves": [
+                        {"filename": "includes/templates/new.yaml", "content": "new: 1"},
+                        {"filename": "configuration.yaml", "content": "root: 1"},
+                    ],
+                    "deletes": ["includes/templates/old.yaml"],
+                    "run_check": False,
+                },
+            )
+
+        text = result["content"][0]["text"]
+        assert "includes/templates/new.yaml" in text
+        assert (templates / "new.yaml").read_text() == "new: 1"
+        assert (tmp_path / "configuration.yaml").read_text() == "root: 1"
+        assert not (templates / "old.yaml").exists()
+
+    async def test_nested_secrets_in_saves_aborts_before_any_change(self, tmp_path):
+        (tmp_path / "includes").mkdir()
+        hass = _make_hass(tmp_path)
+
+        result = await batch_edit_config_files(
+            hass,
+            {
+                "saves": [
+                    {"filename": "includes/secrets.yaml", "content": "bad: true"},
+                    {"filename": "ok.yaml", "content": "ok: 1"},
+                ]
+            },
+        )
+
+        assert "error" in result["content"][0]["text"].lower()
+        assert not (tmp_path / "ok.yaml").exists()
+        assert not (tmp_path / "includes" / "secrets.yaml").exists()
 
     async def test_delete_missing_file_aborts(self, tmp_path):
         hass = _make_hass(tmp_path)

--- a/tests/test_tools_config_files.py
+++ b/tests/test_tools_config_files.py
@@ -227,6 +227,46 @@ class TestListConfigFilesRecursive:
 
         assert files == []
 
+    async def test_recursive_skips_unreadable_subdirectory(self, tmp_path):
+        """A permission-denied folder must not abort the whole listing."""
+        (tmp_path / "locked").mkdir()
+        (tmp_path / "locked" / "hidden.yaml").write_text("")
+        (tmp_path / "readable").mkdir()
+        (tmp_path / "readable" / "real.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+        original = Path.iterdir
+
+        def fail_on_locked(self):
+            if self.name == "locked":
+                raise OSError("permission denied")
+            return original(self)
+
+        with patch.object(Path, "iterdir", fail_on_locked):
+            result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == ["readable/real.yaml"]
+
+    async def test_recursive_skips_entries_that_fail_to_resolve(self, tmp_path):
+        """A broken symlink (dir or file) is skipped rather than crashing the walk."""
+        (tmp_path / "baddir").mkdir()
+        (tmp_path / "baddir" / "x.yaml").write_text("")
+        (tmp_path / "badfile.yaml").write_text("")
+        (tmp_path / "good.yaml").write_text("")
+        hass = _make_hass(tmp_path)
+        original = Path.resolve
+
+        def fail_on_bad(self, *args, **kwargs):
+            if self.name in ("baddir", "badfile.yaml"):
+                raise OSError("too many levels of symbolic links")
+            return original(self, *args, **kwargs)
+
+        with patch.object(Path, "resolve", fail_on_bad):
+            result = await list_config_files(hass, {"recursive": True})
+        files = json.loads(result["content"][0]["text"])
+
+        assert files == ["good.yaml"]
+
     async def test_recursive_returns_sorted(self, tmp_path):
         (tmp_path / "zzz").mkdir()
         (tmp_path / "zzz" / "a.yaml").write_text("")
@@ -327,6 +367,13 @@ class TestGetConfigFile:
         hass = _make_hass(tmp_path)
         result = await get_config_file(hass, {"filename": "includes/../configuration.yaml"})
         assert "'..'" in result["content"][0]["text"]
+
+    async def test_read_blocks_empty_filename(self, tmp_path):
+        """An empty path would otherwise resolve to the config directory itself."""
+        hass = _make_hass(tmp_path)
+        for empty in ("", "   "):
+            result = await get_config_file(hass, {"filename": empty})
+            assert "must not be empty" in result["content"][0]["text"]
 
     async def test_read_blocks_absolute_path(self, tmp_path):
         hass = _make_hass(tmp_path)


### PR DESCRIPTION
Closes #64.

The config file tools rejected any path containing a subdirectory, which makes split configurations — `!include_dir_merge_list`, `!include_dir_named`, `packages` — unreachable. In those setups the actual template, sensor and package definitions live one or more folders down, so the tools couldn't see the config they exist to manage.

## What changed

**Path-taking tools** (`get_config_file`, `save_config_file`, `delete_config_file`, `batch_edit_config_files`) accept a relative path that may include subdirectories. No schema change — existing callers are unaffected.

**`list_config_files`** gains an opt-in `recursive` flag (default `false`, so current behaviour is unchanged). It returns paths relative to the config directory (`includes/templates/dishwasher.yaml`) that are usable verbatim as `filename`. It skips hidden folders, `custom_components`, `deps`, `www`, `node_modules`, `tts` and `mcp_backups`, and is depth-capped so a symlink loop can't make it walk forever.

## Security

The containment boundary is unchanged. `_resolve_safe` already resolved the joined path and required it to stay under the config dir — because `resolve()` follows symlinks, that single check covers `..`, absolute paths and escaping symlinks. **Only the early depth-1 rejection was removed**; I deliberately didn't add a parallel validator. The explicit `..`/absolute rejections are for a clearer error message, not for safety.

The block list is now split by *reason*, since depth changes what each one means:

| | Scope | Why |
|---|---|---|
| `secrets.yaml` / `.yml` | **Any depth** (basename match) | Sensitive wherever it lives. `includes/secrets.yaml` is the one leak recursion could otherwise introduce — the old depth-1 code structurally couldn't have it. Explicitly tested. |
| `automations.yaml`, `scenes.yaml`, `scripts.yaml` | **Root only** | HA owns these at the config root. A split-config file that happens to be named `packages/scripts.yaml` is the user's own and stays editable. |
| `mcp_backups/**` | Any depth | Snapshots are owned by the backup/restore tools; editing them through the generic tools would corrupt rollback state. |

A file symlink escaping the config dir is also skipped when listing, so listing and reading agree rather than offering a path that always errors.

## Two deliberate limitations

**The pre-edit backup stays first-level-only.** Recursing it would sweep `.storage`, `blueprints`, `custom_components/**` and `mcp_backups` itself into a copy on every single edit. So subdirectory edits have no automatic rollback. This isn't a regression — those files weren't editable at all before — but it did mean the "backs up all YAML files" wording became misleading, so the tool descriptions and README now state the limitation explicitly. Happy to follow up with targeted backup of explicitly-touched subdir files (preserving relative paths, no recursion) if you'd like it — it drags `_restore_backup_sync` and `_list_backups_sync` along with it, so I kept it out of this PR.

**`save_config_file` does not create missing directories.** Silently creating one would turn a typo'd include path into a file HA never reads; it returns a clear error instead.

## Open questions for you

Both were raised in the issue, and I picked the minimal option rather than deciding for you:

1. **`recursive` flag vs. a `path`/`subdir` argument.** I went with the flag — backward-compatible and the least surface. Easy to swap.
2. **Toggle granularity.** This reuses the existing "Enable config file access" toggle. The issue author explicitly offered a separate "Allow subdirectory access" sub-toggle as acceptable if you'd prefer subdirectory traversal opted into on its own.

## Testing

541 passed, 4 skipped; `ruff` and `black` clean. 20 new tests covering: nested read/write/delete, recursive listing and its round-trip into `get_config_file`, nested-secrets blocking on read/write/delete/batch, root-only registry blocking, `..` (including one that resolves back inside the config dir), absolute paths, `mcp_backups` access, dir- and file-symlink escapes, the depth cap, noise-directory skipping, and missing-directory rejection. The pre-existing `test_list_excludes_subdirectories` still passes unchanged, pinning the default listing behaviour.

Also verified end-to-end against the issue's exact reproduction — a `template: !include_dir_merge_list includes/templates/` tree plus `packages` — confirming the nested file lists, reads and writes while nested/root secrets, `..` and absolute paths stay blocked with no content leaked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)