### PR TITLE
feat: partial dashboard reads and edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Home Assistant Custom Component that provides an MCP (Model Context Protocol) 
 - 🏠 Full Home Assistant API access (entities, services, areas, devices, history, statistics)
 - 🔧 Easy HACS installation
 - 📝 CRUD management of automations, scenes, scripts, and helper entities (input_boolean, counter, timer, schedule, and more)
-- 📋 Lovelace dashboard management (list, get/save/delete config, create/update/delete dashboards)
+- 📋 Lovelace dashboard management (list, get/save/delete config, create/update/delete dashboards) with outline reads and JSON Patch edits so a single card can be changed without resending the whole dashboard
 - 🩺 System administration tools (error log, config validation, restart, system status)
 - 📁 YAML config file management — read, write, delete files with automatic backup before every change and built-in config validation (opt-in)
 - 📷 Camera & image access — capture live camera frames and read saved image files for visual analysis (opt-in)
@@ -159,7 +159,8 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | Tool | Description |
 |------|-------------|
 | `list_dashboards` | List all Lovelace dashboards with metadata |
-| `get_dashboard_config` | Get full dashboard configuration (views/cards) |
+| `get_dashboard_config` | Get a dashboard configuration; `summary=true` returns an outline of views and cards, `path` returns just the part a JSON Pointer addresses |
+| `patch_dashboard_config` | Apply JSON Patch operations to a dashboard: move, add, remove, or edit individual cards without resending the whole config |
 | `save_dashboard_config` | Save (replace) full dashboard configuration |
 | `delete_dashboard_config` | Reset a dashboard configuration to empty |
 | `create_dashboard` | Create a new Lovelace dashboard (experimental) |
@@ -314,6 +315,36 @@ Use `list_dashboards` to see all dashboards, then `get_dashboard_config` and `sa
 get_dashboard_config(url_path="default")
 save_dashboard_config(url_path="default", config={"views": [{"title": "Home", "cards": [...]}]})
 ```
+
+A real dashboard can easily be over 100 KB, which is too much to read and write back for a one-card change. For anything smaller than a rewrite, work through the outline instead.
+
+`get_dashboard_config(url_path="default", summary=true)` returns each view and card as type, label, and entities, with a JSON Pointer for every entry:
+
+```json
+{
+  "view_count": 2,
+  "views": [
+    {"pointer": "/views/0", "index": 0, "title": "Living Room", "path": "living", "card_count": 2,
+     "cards": [
+       {"pointer": "/views/0/cards/0", "index": 0, "type": "tile", "entity": "light.sofa"},
+       {"pointer": "/views/0/cards/1", "index": 1, "type": "tile", "entity": "fan.air_purifier"}
+     ]}
+  ]
+}
+```
+
+Pass one of those pointers as `path` to read a single card in full, and to `patch_dashboard_config` to change it. Operations follow [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902) (`add`, `remove`, `replace`, `move`, `copy`, `test`) and apply in order, all-or-nothing, so a failing operation leaves the dashboard untouched:
+
+```json
+get_dashboard_config(url_path="default", path="/views/0/cards/1")
+
+patch_dashboard_config(url_path="default", operations=[
+  {"op": "test", "path": "/views/0/cards/1/entity", "value": "fan.air_purifier"},
+  {"op": "move", "from": "/views/0/cards/1", "path": "/views/1/cards/-"}
+])
+```
+
+A leading `test` operation makes the patch fail rather than edit the wrong card if the dashboard changed since it was read. End an array path with `/-` to append.
 
 To create or delete dashboards themselves, use the experimental `create_dashboard` and `delete_dashboard` tools. These use internal HA APIs and may break with future HA updates.
 </details>
@@ -475,7 +506,7 @@ You can also delete entries from `config/mcp_backups/` manually via SSH, the Sam
 
 Some tools use internal Home Assistant APIs that are not publicly exposed and may break with future HA updates.
 
-**Dashboard tools:** `create_dashboard`, `update_dashboard`, and `delete_dashboard` use `DashboardsCollection` and replicate side effects (panel registration, dashboards dict updates) that HA normally handles internally. The config-level tools (`list_dashboards`, `get/save/delete_dashboard_config`) use stable public APIs and are not experimental.
+**Dashboard tools:** `create_dashboard`, `update_dashboard`, and `delete_dashboard` use `DashboardsCollection` and replicate side effects (panel registration, dashboards dict updates) that HA normally handles internally. The config-level tools (`list_dashboards`, `get/save/patch/delete_dashboard_config`) use stable public APIs and are not experimental.
 
 **Helper tools:** `get_helper_config`, `create_helper`, `update_helper`, and `delete_helper` use `StorageCollection` internals to manage UI-created helpers. They only affect helpers stored in `.storage/` — helpers defined in YAML are read-only from the perspective of these tools. `list_helpers` uses public APIs and is not experimental.
 </details>

--- a/custom_components/mcp_server_http_transport/dashboard_manager.py
+++ b/custom_components/mcp_server_http_transport/dashboard_manager.py
@@ -187,10 +187,8 @@ def summarize_card(card: Any, pointer_tokens: list[str], index: int, depth: int 
     return entry
 
 
-def _summarize_card_list(cards: Any, pointer_tokens: list[str]) -> list[dict]:
-    """Summarize a `cards` / `badges` list, tolerating a non-list value."""
-    if not isinstance(cards, list):
-        return []
+def _summarize_card_list(cards: list, pointer_tokens: list[str]) -> list[dict]:
+    """Summarize a `cards` / `badges` list."""
     return [summarize_card(card, pointer_tokens + [str(i)], i) for i, card in enumerate(cards)]
 
 

--- a/custom_components/mcp_server_http_transport/dashboard_manager.py
+++ b/custom_components/mcp_server_http_transport/dashboard_manager.py
@@ -5,7 +5,20 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
+from .json_patch import apply_patch, format_pointer
+
 _LOGGER = logging.getLogger(__name__)
+
+# Keys a card may use for its human-readable label, in the order they win.
+_CARD_LABEL_KEYS = ("title", "name", "heading")
+
+# Nested cards (stacks, grids) are summarized too, but a hand-written config can
+# nest arbitrarily deep and a summary that follows it loses its point.
+_MAX_CARD_DEPTH = 6
+
+# An entities card can list dozens of rows; the first few are enough to identify
+# the card, and `entity_count` carries the rest of the information.
+_MAX_SUMMARY_ENTITIES = 10
 
 
 def _register_panel(
@@ -101,6 +114,159 @@ async def save_dashboard_config(hass: HomeAssistant, url_path: str, config: dict
         await dashboard.async_save(config)
     except Exception as exc:
         raise ValueError(f"Failed to save config for dashboard '{url_path}': {exc}") from exc
+
+
+async def patch_dashboard_config(
+    hass: HomeAssistant, url_path: str, operations: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Apply JSON Patch operations to a dashboard config and save the result.
+
+    The patch runs against a copy of the loaded config, so a failing operation
+    leaves the stored dashboard untouched.
+    """
+    config = await get_dashboard_config(hass, url_path)
+    patched = apply_patch(config, operations)
+
+    if not isinstance(patched, dict):
+        raise ValueError(
+            "The patched config must be an object with a 'views' list, "
+            f"but the operations produced a {type(patched).__name__}"
+        )
+
+    await save_dashboard_config(hass, url_path, patched)
+    return patched
+
+
+def _extract_entity_ids(value: Any) -> list[str]:
+    """Pull entity ids out of a card's `entities` value (strings or row objects)."""
+    if not isinstance(value, list):
+        return []
+    entities: list[str] = []
+    for row in value:
+        if isinstance(row, str):
+            entities.append(row)
+        elif isinstance(row, dict) and isinstance(row.get("entity"), str):
+            entities.append(row["entity"])
+    return entities
+
+
+def summarize_card(card: Any, pointer_tokens: list[str], index: int, depth: int = 0) -> dict:
+    """Return an identifying outline of a card: what it is, not how it is configured."""
+    entry: dict[str, Any] = {"pointer": format_pointer(pointer_tokens), "index": index}
+
+    if not isinstance(card, dict):
+        entry["value"] = card
+        return entry
+
+    if isinstance(card.get("type"), str):
+        entry["type"] = card["type"]
+    for key in _CARD_LABEL_KEYS:
+        label = card.get(key)
+        if isinstance(label, str) and label:
+            entry["label"] = label
+            break
+    if isinstance(card.get("entity"), str):
+        entry["entity"] = card["entity"]
+
+    entities = _extract_entity_ids(card.get("entities"))
+    if entities:
+        entry["entity_count"] = len(entities)
+        entry["entities"] = entities[:_MAX_SUMMARY_ENTITIES]
+
+    nested = card.get("cards")
+    if isinstance(nested, list) and nested:
+        entry["card_count"] = len(nested)
+        if depth >= _MAX_CARD_DEPTH:
+            entry["truncated"] = True
+        else:
+            entry["cards"] = [
+                summarize_card(child, pointer_tokens + ["cards", str(i)], i, depth + 1)
+                for i, child in enumerate(nested)
+            ]
+
+    return entry
+
+
+def _summarize_card_list(cards: Any, pointer_tokens: list[str]) -> list[dict]:
+    """Summarize a `cards` / `badges` list, tolerating a non-list value."""
+    if not isinstance(cards, list):
+        return []
+    return [summarize_card(card, pointer_tokens + [str(i)], i) for i, card in enumerate(cards)]
+
+
+def summarize_view(view: Any, pointer_tokens: list[str], index: int) -> dict:
+    """Return an outline of a single view and the cards it holds."""
+    entry: dict[str, Any] = {"pointer": format_pointer(pointer_tokens), "index": index}
+
+    if not isinstance(view, dict):
+        entry["value"] = view
+        return entry
+
+    for key in ("title", "path", "icon", "type"):
+        value = view.get(key)
+        if isinstance(value, str) and value:
+            entry[key] = value
+
+    badges = view.get("badges")
+    if isinstance(badges, list) and badges:
+        entry["badge_count"] = len(badges)
+        entry["badges"] = _summarize_card_list(badges, pointer_tokens + ["badges"])
+
+    cards = view.get("cards")
+    if isinstance(cards, list):
+        entry["card_count"] = len(cards)
+        entry["cards"] = _summarize_card_list(cards, pointer_tokens + ["cards"])
+
+    sections = view.get("sections")
+    if isinstance(sections, list):
+        entry["section_count"] = len(sections)
+        entry["sections"] = [
+            _summarize_section(section, pointer_tokens + ["sections", str(i)], i)
+            for i, section in enumerate(sections)
+        ]
+
+    return entry
+
+
+def _summarize_section(section: Any, pointer_tokens: list[str], index: int) -> dict:
+    """Return an outline of one section of a sections-type view."""
+    entry: dict[str, Any] = {"pointer": format_pointer(pointer_tokens), "index": index}
+
+    if not isinstance(section, dict):
+        entry["value"] = section
+        return entry
+
+    for key in ("type", "title"):
+        value = section.get(key)
+        if isinstance(value, str) and value:
+            entry[key] = value
+
+    cards = section.get("cards")
+    if isinstance(cards, list):
+        entry["card_count"] = len(cards)
+        entry["cards"] = _summarize_card_list(cards, pointer_tokens + ["cards"])
+
+    return entry
+
+
+def summarize_dashboard_config(config: Any) -> dict[str, Any]:
+    """Return an outline of every view in a dashboard config.
+
+    Each entry carries the JSON Pointer of the thing it describes, so a caller
+    can read one card with get_dashboard_config(path=...) or edit it with
+    patch_dashboard_config without ever loading the whole config.
+    """
+    if not isinstance(config, dict):
+        raise ValueError(f"Dashboard config must be an object, got {type(config).__name__}")
+
+    views = config.get("views")
+    if not isinstance(views, list):
+        return {"views": [], "view_count": 0}
+
+    return {
+        "view_count": len(views),
+        "views": [summarize_view(view, ["views", str(i)], i) for i, view in enumerate(views)],
+    }
 
 
 async def delete_dashboard_config(hass: HomeAssistant, url_path: str) -> None:

--- a/custom_components/mcp_server_http_transport/dashboard_manager.py
+++ b/custom_components/mcp_server_http_transport/dashboard_manager.py
@@ -127,10 +127,19 @@ async def patch_dashboard_config(
     config = await get_dashboard_config(hass, url_path)
     patched = apply_patch(config, operations)
 
+    # A dashboard config is an object, and its `views` — when it has any — is a
+    # list. Anything else renders as a broken dashboard, so it is caught here
+    # rather than stored. `views` may legitimately be absent: that is what an
+    # empty dashboard looks like before its first view is added.
     if not isinstance(patched, dict):
         raise ValueError(
             "The patched config must be an object with a 'views' list, "
             f"but the operations produced a {type(patched).__name__}"
+        )
+    if "views" in patched and not isinstance(patched["views"], list):
+        raise ValueError(
+            "The patched config's 'views' must be a list, but the operations "
+            f"produced a {type(patched['views']).__name__}"
         )
 
     await save_dashboard_config(hass, url_path, patched)

--- a/custom_components/mcp_server_http_transport/json_patch.py
+++ b/custom_components/mcp_server_http_transport/json_patch.py
@@ -55,7 +55,9 @@ def _list_index(token: str, length: int, tokens: list[str], allow_end: bool = Fa
         if not allow_end:
             raise JsonPatchError(f"'{where}': '-' only addresses the end of an array when adding")
         return length
-    if not token.isdigit():
+    # isdecimal rather than isdigit: the latter also accepts superscripts such as
+    # '²', which int() then rejects with a bare ValueError.
+    if not token.isdecimal():
         raise JsonPatchError(f"'{where}': '{token}' is not a valid array index")
     index = int(token)
     limit = length if allow_end else length - 1

--- a/custom_components/mcp_server_http_transport/json_patch.py
+++ b/custom_components/mcp_server_http_transport/json_patch.py
@@ -1,0 +1,207 @@
+"""JSON Pointer (RFC 6901) and JSON Patch (RFC 6902) support.
+
+Used by the dashboard tools so a single card can be edited without sending the
+whole Lovelace config back and forth.
+"""
+
+import copy
+import json
+from typing import Any
+
+# Operations that address a second location in the document.
+_OPS_WITH_FROM = {"move", "copy"}
+# Operations that carry a value.
+_OPS_WITH_VALUE = {"add", "replace", "test"}
+_VALID_OPS = _OPS_WITH_FROM | _OPS_WITH_VALUE | {"remove"}
+
+
+class JsonPatchError(ValueError):
+    """Raised when a pointer cannot be resolved or a patch operation fails."""
+
+
+def parse_pointer(pointer: str) -> list[str]:
+    """Split a JSON Pointer into its unescaped reference tokens.
+
+    A leading slash is optional: 'views/0' is accepted as '/views/0' so a
+    caller that drops it still gets the location it meant.
+    """
+    if not isinstance(pointer, str):
+        raise JsonPatchError(f"Pointer must be a string, got {type(pointer).__name__}")
+    if pointer == "":
+        return []
+    if not pointer.startswith("/"):
+        pointer = "/" + pointer
+    return [token.replace("~1", "/").replace("~0", "~") for token in pointer[1:].split("/")]
+
+
+def format_pointer(tokens: list[str]) -> str:
+    """Join reference tokens back into a JSON Pointer string."""
+    return "".join("/" + token.replace("~", "~0").replace("/", "~1") for token in tokens)
+
+
+def _describe(value: Any, limit: int = 120) -> str:
+    """Render a value for an error message, truncated so errors stay readable."""
+    try:
+        text = json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        text = repr(value)
+    return text if len(text) <= limit else text[:limit] + "…"
+
+
+def _list_index(token: str, length: int, tokens: list[str], allow_end: bool = False) -> int:
+    """Convert a reference token to a list index, or raise JsonPatchError."""
+    where = format_pointer(tokens)
+    if token == "-":
+        if not allow_end:
+            raise JsonPatchError(f"'{where}': '-' only addresses the end of an array when adding")
+        return length
+    if not token.isdigit():
+        raise JsonPatchError(f"'{where}': '{token}' is not a valid array index")
+    index = int(token)
+    limit = length if allow_end else length - 1
+    if index > limit:
+        raise JsonPatchError(
+            f"'{where}': index {index} is out of range (array has {length} item(s))"
+        )
+    return index
+
+
+def resolve_pointer(doc: Any, pointer: str) -> Any:
+    """Return the value a JSON Pointer addresses.
+
+    Raises JsonPatchError if any step of the pointer does not exist.
+    """
+    node = doc
+    walked: list[str] = []
+    for token in parse_pointer(pointer):
+        walked.append(token)
+        if isinstance(node, list):
+            node = node[_list_index(token, len(node), walked)]
+        elif isinstance(node, dict):
+            if token not in node:
+                available = ", ".join(sorted(node)[:10]) or "none"
+                raise JsonPatchError(
+                    f"'{format_pointer(walked)}': key '{token}' not found (available: {available})"
+                )
+            node = node[token]
+        else:
+            raise JsonPatchError(
+                f"'{format_pointer(walked)}': cannot look up '{token}' "
+                f"inside a {type(node).__name__}"
+            )
+    return node
+
+
+def _parent_of(doc: Any, tokens: list[str]) -> Any:
+    """Return the container holding the location `tokens` addresses."""
+    return resolve_pointer(doc, format_pointer(tokens[:-1]))
+
+
+def _add(doc: Any, tokens: list[str], value: Any) -> Any:
+    """Insert or set `value` at the location, returning the (possibly new) document."""
+    if not tokens:
+        return value
+    parent = _parent_of(doc, tokens)
+    if isinstance(parent, list):
+        parent.insert(_list_index(tokens[-1], len(parent), tokens, allow_end=True), value)
+    elif isinstance(parent, dict):
+        parent[tokens[-1]] = value
+    else:
+        raise JsonPatchError(f"'{format_pointer(tokens)}': cannot add to a {type(parent).__name__}")
+    return doc
+
+
+def _remove(doc: Any, tokens: list[str]) -> Any:
+    """Delete the value at the location, returning the (possibly new) document."""
+    if not tokens:
+        raise JsonPatchError("Cannot remove the whole document; use replace with path ''")
+    parent = _parent_of(doc, tokens)
+    if isinstance(parent, list):
+        parent.pop(_list_index(tokens[-1], len(parent), tokens))
+    elif isinstance(parent, dict):
+        if tokens[-1] not in parent:
+            raise JsonPatchError(f"'{format_pointer(tokens)}': key '{tokens[-1]}' not found")
+        del parent[tokens[-1]]
+    else:
+        raise JsonPatchError(
+            f"'{format_pointer(tokens)}': cannot remove from a {type(parent).__name__}"
+        )
+    return doc
+
+
+def _apply_operation(doc: Any, operation: Any) -> Any:
+    """Apply one patch operation and return the resulting document."""
+    if not isinstance(operation, dict):
+        raise JsonPatchError(f"Operation must be an object, got {type(operation).__name__}")
+
+    op = operation.get("op")
+    if op not in _VALID_OPS:
+        raise JsonPatchError(
+            f"Unknown op '{op}' (expected one of: {', '.join(sorted(_VALID_OPS))})"
+        )
+    if "path" not in operation:
+        raise JsonPatchError(f"'{op}' requires a 'path'")
+    if op in _OPS_WITH_VALUE and "value" not in operation:
+        raise JsonPatchError(f"'{op}' requires a 'value'")
+    if op in _OPS_WITH_FROM and "from" not in operation:
+        raise JsonPatchError(f"'{op}' requires a 'from'")
+
+    tokens = parse_pointer(operation["path"])
+
+    if op == "add":
+        return _add(doc, tokens, copy.deepcopy(operation["value"]))
+
+    if op == "remove":
+        return _remove(doc, tokens)
+
+    if op == "replace":
+        # Resolve first so replacing a location that does not exist is an error
+        # rather than a silent insert.
+        resolve_pointer(doc, operation["path"])
+        if not tokens:
+            return copy.deepcopy(operation["value"])
+        return _add(_remove(doc, tokens), tokens, copy.deepcopy(operation["value"]))
+
+    if op == "test":
+        actual = resolve_pointer(doc, operation["path"])
+        if actual != operation["value"]:
+            raise JsonPatchError(
+                f"test failed at '{operation['path']}': expected "
+                f"{_describe(operation['value'])}, found {_describe(actual)}"
+            )
+        return doc
+
+    from_tokens = parse_pointer(operation["from"])
+    value = resolve_pointer(doc, operation["from"])
+
+    if op == "copy":
+        return _add(doc, tokens, copy.deepcopy(value))
+
+    # move: refuse to relocate a container into itself, which would otherwise
+    # detach the moved subtree from the document.
+    if tokens[: len(from_tokens)] == from_tokens and len(tokens) > len(from_tokens):
+        raise JsonPatchError(
+            f"Cannot move '{operation['from']}' into its own child '{operation['path']}'"
+        )
+    return _add(_remove(doc, from_tokens), tokens, value)
+
+
+def apply_patch(doc: Any, operations: Any) -> Any:
+    """Apply a list of JSON Patch operations to a copy of `doc`.
+
+    Operations are applied in order to a deep copy, so `doc` is left untouched
+    and a failure part way through leaves nothing half-written.
+    """
+    if not isinstance(operations, list):
+        raise JsonPatchError(f"Operations must be a list, got {type(operations).__name__}")
+    if not operations:
+        raise JsonPatchError("Provide at least one operation")
+
+    result = copy.deepcopy(doc)
+    for index, operation in enumerate(operations):
+        try:
+            result = _apply_operation(result, operation)
+        except JsonPatchError as err:
+            op_name = operation.get("op") if isinstance(operation, dict) else operation
+            raise JsonPatchError(f"Operation {index} ({op_name}): {err}") from err
+    return result

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.12.0"
+  "version": "1.13.0"
 }

--- a/custom_components/mcp_server_http_transport/tools/dashboards.py
+++ b/custom_components/mcp_server_http_transport/tools/dashboards.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_IDEMPOTENT,
+    ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
     _HAJSONEncoder,
     register_tool,
@@ -44,8 +45,12 @@ async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -
 @register_tool(
     name="get_dashboard_config",
     description=(
-        "Get the full configuration (views and cards) of a Lovelace dashboard. "
-        'Use url_path="default" for the main Overview dashboard.'
+        "Get the configuration (views and cards) of a Lovelace dashboard. "
+        'Use url_path="default" for the main Overview dashboard. '
+        "Returns the whole config by default, which can be very large on a busy dashboard. "
+        "For a large dashboard, start with summary=true to get an outline of the views and "
+        "cards with a JSON Pointer for each, then pass one of those pointers as 'path' to read "
+        "just that card or view. The same pointers are what patch_dashboard_config edits"
     ),
     input_schema={
         "type": "object",
@@ -56,7 +61,23 @@ async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -
                     'Dashboard URL path (e.g., "energy", "map"). '
                     'Use "default" for the main Overview dashboard.'
                 ),
-            }
+            },
+            "path": {
+                "type": "string",
+                "description": (
+                    "JSON Pointer to the part of the config to return, e.g. '/views/2' or "
+                    "'/views/2/cards/5'. Omit to return the whole config."
+                ),
+            },
+            "summary": {
+                "type": "boolean",
+                "description": (
+                    "Return an outline instead of the full config (default: false): view "
+                    "titles plus each card's type, label, and entities, with a JSON Pointer "
+                    "for every entry but without the cards' full options. "
+                    "Can be combined with path='/views/<n>' to outline a single view"
+                ),
+            },
         },
         "required": ["url_path"],
     },
@@ -65,13 +86,44 @@ async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -
 async def get_dashboard_config_tool(
     hass: HomeAssistant, arguments: dict[str, Any]
 ) -> dict[str, Any]:
-    """Get dashboard configuration."""
-    from ..dashboard_manager import get_dashboard_config
+    """Get a dashboard configuration, optionally scoped to a pointer or summarized."""
+    from ..dashboard_manager import (
+        get_dashboard_config,
+        summarize_dashboard_config,
+        summarize_view,
+    )
+    from ..json_patch import parse_pointer, resolve_pointer
+
+    pointer = arguments.get("path") or ""
 
     try:
         config = await get_dashboard_config(hass, arguments["url_path"])
+
+        if arguments.get("summary", False):
+            tokens = parse_pointer(pointer)
+            if not tokens:
+                result: Any = summarize_dashboard_config(config)
+            elif len(tokens) == 2 and tokens[0] == "views" and tokens[1].isdigit():
+                view = resolve_pointer(config, pointer)
+                result = summarize_view(view, tokens, int(tokens[1]))
+            else:
+                return {
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": (
+                                f"summary=true supports the whole config (omit path) or a "
+                                f"single view (path='/views/0'), not '{pointer}'. "
+                                f"Call again without summary to read '{pointer}' in full."
+                            ),
+                        }
+                    ]
+                }
+        else:
+            result = resolve_pointer(config, pointer) if pointer else config
+
         return {
-            "content": [{"type": "text", "text": json.dumps(config, indent=2, cls=_HAJSONEncoder)}]
+            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
         }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting dashboard config: {str(e)}"}]}
@@ -81,7 +133,9 @@ async def get_dashboard_config_tool(
     name="save_dashboard_config",
     description=(
         "Save (replace) the full configuration of a Lovelace dashboard. "
-        'Use url_path="default" for the main Overview dashboard.'
+        'Use url_path="default" for the main Overview dashboard. '
+        "This requires sending every view and card, so for anything short of a rewrite "
+        "use patch_dashboard_config instead"
     ),
     input_schema={
         "type": "object",
@@ -120,6 +174,120 @@ async def save_dashboard_config_tool(
         }
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error saving dashboard config: {str(e)}"}]}
+
+
+def _count(value: Any) -> int:
+    """Length of a list-valued config key, 0 for anything else."""
+    return len(value) if isinstance(value, list) else 0
+
+
+def _view_overview(config: dict[str, Any]) -> list[str]:
+    """One compact line per view: index, title, and how many cards it now holds."""
+    lines: list[str] = []
+    for index, view in enumerate(config.get("views") or []):
+        if not isinstance(view, dict):
+            lines.append(f"  [{index}] (not an object)")
+            continue
+        sections = [s for s in (view.get("sections") or []) if isinstance(s, dict)]
+        cards = _count(view.get("cards")) + sum(_count(s.get("cards")) for s in sections)
+        title = view.get("title") or view.get("path") or ""
+        parts = [f"{cards} card(s)"]
+        if sections:
+            parts.append(f"{len(sections)} section(s)")
+        lines.append(f"  [{index}] {title}: " + ", ".join(parts))
+    return lines
+
+
+@register_tool(
+    name="patch_dashboard_config",
+    description=(
+        "Edit parts of a Lovelace dashboard without resending the whole config. "
+        "Takes RFC 6902 JSON Patch operations addressing locations by JSON Pointer, "
+        "e.g. move one card between views or change a single card's entity. "
+        'Use url_path="default" for the main Overview dashboard. '
+        "Discover pointers with get_dashboard_config(summary=true). "
+        "Operations apply in order and all-or-nothing: if one fails the dashboard is "
+        "left untouched. Because each operation sees the result of the previous one, "
+        "removing several cards from the same view is safest done highest index first. "
+        "Guard against a stale read by leading with a 'test' operation"
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "url_path": {
+                "type": "string",
+                "description": (
+                    'Dashboard URL path (e.g., "energy", "map"). '
+                    'Use "default" for the main Overview dashboard.'
+                ),
+            },
+            "operations": {
+                "type": "array",
+                "description": (
+                    "JSON Patch operations to apply in order. Example: "
+                    '[{"op": "test", "path": "/views/1/cards/3/entity", '
+                    '"value": "fan.air_purifier"}, '
+                    '{"op": "move", "from": "/views/1/cards/3", "path": "/views/2/cards/-"}]'
+                ),
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "op": {
+                            "type": "string",
+                            "enum": ["add", "remove", "replace", "move", "copy", "test"],
+                            "description": (
+                                "add: insert a value (into an array at the given index, "
+                                "or set an object key). remove: delete the value. "
+                                "replace: overwrite an existing value. "
+                                "move/copy: relocate or duplicate the value at 'from'. "
+                                "test: fail the whole patch unless the value matches"
+                            ),
+                        },
+                        "path": {
+                            "type": "string",
+                            "description": (
+                                "JSON Pointer to the target, e.g. '/views/2/cards/5' or "
+                                "'/views/0/sections/1/cards/0/entity'. For 'add' and 'move', "
+                                "end an array path with '/-' to append, or with an index to "
+                                "insert before that position"
+                            ),
+                        },
+                        "value": {
+                            "description": (
+                                "The value for add, replace, and test. "
+                                "For a card this is the full card object"
+                            ),
+                        },
+                        "from": {
+                            "type": "string",
+                            "description": "Source JSON Pointer, required for move and copy",
+                        },
+                    },
+                    "required": ["op", "path"],
+                },
+            },
+        },
+        "required": ["url_path", "operations"],
+    },
+    annotations=ANNOTATION_NON_IDEMPOTENT,
+)
+async def patch_dashboard_config_tool(
+    hass: HomeAssistant, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Apply JSON Patch operations to a dashboard configuration."""
+    from ..dashboard_manager import patch_dashboard_config
+
+    url_path = arguments["url_path"]
+    operations = arguments.get("operations")
+
+    try:
+        config = await patch_dashboard_config(hass, url_path, operations)
+        count = len(operations) if isinstance(operations, list) else 0
+        lines = [f"Applied {count} operation(s) to dashboard '{url_path}'"]
+        lines.extend(_view_overview(config))
+        return {"content": [{"type": "text", "text": "\n".join(lines)}]}
+    except Exception as e:
+        return {"content": [{"type": "text", "text": f"Error patching dashboard config: {str(e)}"}]}
 
 
 @register_tool(

--- a/custom_components/mcp_server_http_transport/tools/dashboards.py
+++ b/custom_components/mcp_server_http_transport/tools/dashboards.py
@@ -103,7 +103,7 @@ async def get_dashboard_config_tool(
             tokens = parse_pointer(pointer)
             if not tokens:
                 result: Any = summarize_dashboard_config(config)
-            elif len(tokens) == 2 and tokens[0] == "views" and tokens[1].isdigit():
+            elif len(tokens) == 2 and tokens[0] == "views" and tokens[1].isdecimal():
                 view = resolve_pointer(config, pointer)
                 result = summarize_view(view, tokens, int(tokens[1]))
             else:
@@ -282,8 +282,7 @@ async def patch_dashboard_config_tool(
 
     try:
         config = await patch_dashboard_config(hass, url_path, operations)
-        count = len(operations) if isinstance(operations, list) else 0
-        lines = [f"Applied {count} operation(s) to dashboard '{url_path}'"]
+        lines = [f"Applied {len(operations)} operation(s) to dashboard '{url_path}'"]
         lines.extend(_view_overview(config))
         return {"content": [{"type": "text", "text": "\n".join(lines)}]}
     except Exception as e:

--- a/tests/test_dashboard_manager.py
+++ b/tests/test_dashboard_manager.py
@@ -297,6 +297,28 @@ class TestPatchDashboardConfig:
 
         dashboard.async_save.assert_not_called()
 
+    async def test_rejects_a_patch_that_breaks_the_views_list(self):
+        dashboard = self._dashboard_with({"views": [{"title": "Home"}]})
+        hass = _make_hass({"energy": dashboard})
+
+        with pytest.raises(ValueError, match="'views' must be a list"):
+            await patch_dashboard_config(
+                hass, "energy", [{"op": "replace", "path": "/views", "value": {"0": {}}}]
+            )
+
+        dashboard.async_save.assert_not_called()
+
+    async def test_allows_a_config_without_views(self):
+        dashboard = self._dashboard_with({})
+        hass = _make_hass({"energy": dashboard})
+
+        result = await patch_dashboard_config(
+            hass, "energy", [{"op": "add", "path": "/title", "value": "Home"}]
+        )
+
+        assert result == {"title": "Home"}
+        dashboard.async_save.assert_called_once_with(result)
+
     async def test_raises_for_nonexistent_dashboard(self):
         hass = _make_hass({})
         with pytest.raises(ValueError, match="not found"):

--- a/tests/test_dashboard_manager.py
+++ b/tests/test_dashboard_manager.py
@@ -12,7 +12,10 @@ from custom_components.mcp_server_http_transport.dashboard_manager import (
     delete_dashboard_config,
     get_dashboard_config,
     list_dashboards,
+    patch_dashboard_config,
     save_dashboard_config,
+    summarize_dashboard_config,
+    summarize_view,
     update_dashboard,
 )
 
@@ -215,6 +218,268 @@ class TestSaveDashboardConfig:
         hass = _make_hass({"energy": dashboard})
         with pytest.raises(ValueError, match="Failed to save config"):
             await save_dashboard_config(hass, "energy", {})
+
+
+class TestPatchDashboardConfig:
+    """Tests for patch_dashboard_config."""
+
+    @staticmethod
+    def _dashboard_with(config: dict) -> AsyncMock:
+        dashboard = AsyncMock()
+        dashboard.async_load.return_value = config
+        return dashboard
+
+    async def test_saves_only_the_patched_result(self):
+        dashboard = self._dashboard_with(
+            {"views": [{"title": "Home", "cards": [{"type": "tile", "entity": "light.a"}]}]}
+        )
+        hass = _make_hass({"energy": dashboard})
+
+        result = await patch_dashboard_config(
+            hass,
+            "energy",
+            [{"op": "replace", "path": "/views/0/cards/0/entity", "value": "light.b"}],
+        )
+
+        assert result["views"][0]["cards"][0]["entity"] == "light.b"
+        dashboard.async_save.assert_called_once_with(result)
+
+    async def test_moves_a_card_between_views(self):
+        dashboard = self._dashboard_with(
+            {
+                "views": [
+                    {"title": "Living", "cards": [{"type": "tile", "entity": "fan.purifier"}]},
+                    {"title": "Bedroom", "cards": []},
+                ]
+            }
+        )
+        hass = _make_hass({None: dashboard})
+
+        result = await patch_dashboard_config(
+            hass,
+            "default",
+            [{"op": "move", "from": "/views/0/cards/0", "path": "/views/1/cards/-"}],
+        )
+
+        assert result["views"][0]["cards"] == []
+        assert result["views"][1]["cards"][0]["entity"] == "fan.purifier"
+
+    async def test_does_not_save_when_an_operation_fails(self):
+        dashboard = self._dashboard_with({"views": [{"title": "Home", "cards": []}]})
+        hass = _make_hass({"energy": dashboard})
+
+        with pytest.raises(ValueError, match="test failed"):
+            await patch_dashboard_config(
+                hass,
+                "energy",
+                [{"op": "test", "path": "/views/0/title", "value": "Away"}],
+            )
+
+        dashboard.async_save.assert_not_called()
+
+    async def test_does_not_mutate_the_loaded_config(self):
+        loaded = {"views": [{"title": "Home", "cards": [{"type": "tile"}]}]}
+        dashboard = self._dashboard_with(loaded)
+        hass = _make_hass({"energy": dashboard})
+
+        await patch_dashboard_config(hass, "energy", [{"op": "remove", "path": "/views/0/cards/0"}])
+
+        assert loaded["views"][0]["cards"] == [{"type": "tile"}]
+
+    async def test_rejects_a_patch_that_produces_a_non_object(self):
+        dashboard = self._dashboard_with({"views": []})
+        hass = _make_hass({"energy": dashboard})
+
+        with pytest.raises(ValueError, match="must be an object"):
+            await patch_dashboard_config(
+                hass, "energy", [{"op": "replace", "path": "", "value": []}]
+            )
+
+        dashboard.async_save.assert_not_called()
+
+    async def test_raises_for_nonexistent_dashboard(self):
+        hass = _make_hass({})
+        with pytest.raises(ValueError, match="not found"):
+            await patch_dashboard_config(
+                hass, "nonexistent", [{"op": "remove", "path": "/views/0"}]
+            )
+
+
+class TestSummarizeDashboardConfig:
+    """Tests for summarize_dashboard_config and its helpers."""
+
+    def test_summarizes_views_and_cards_with_pointers(self):
+        config = {
+            "views": [
+                {
+                    "title": "Living Room",
+                    "path": "living",
+                    "icon": "mdi:sofa",
+                    "cards": [
+                        {"type": "tile", "entity": "light.sofa", "name": "Sofa"},
+                        {"type": "tile", "entity": "fan.air_purifier"},
+                    ],
+                }
+            ]
+        }
+
+        result = summarize_dashboard_config(config)
+
+        assert result["view_count"] == 1
+        view = result["views"][0]
+        assert view["pointer"] == "/views/0"
+        assert view["title"] == "Living Room"
+        assert view["path"] == "living"
+        assert view["card_count"] == 2
+        assert view["cards"][1]["pointer"] == "/views/0/cards/1"
+        assert view["cards"][1]["entity"] == "fan.air_purifier"
+        assert view["cards"][0]["label"] == "Sofa"
+
+    def test_omits_card_options(self):
+        config = {
+            "views": [
+                {
+                    "title": "Home",
+                    "cards": [
+                        {
+                            "type": "tile",
+                            "entity": "light.a",
+                            "features": [{"type": "light-brightness"}],
+                            "vertical": True,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        card = summarize_dashboard_config(config)["views"][0]["cards"][0]
+
+        assert card["type"] == "tile"
+        assert "features" not in card
+        assert "vertical" not in card
+
+    def test_summarizes_sections_view(self):
+        config = {
+            "views": [
+                {
+                    "title": "Home",
+                    "type": "sections",
+                    "sections": [
+                        {
+                            "type": "grid",
+                            "title": "Lights",
+                            "cards": [{"type": "tile", "entity": "light.a"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        view = summarize_dashboard_config(config)["views"][0]
+
+        assert view["section_count"] == 1
+        section = view["sections"][0]
+        assert section["pointer"] == "/views/0/sections/0"
+        assert section["title"] == "Lights"
+        assert section["cards"][0]["pointer"] == "/views/0/sections/0/cards/0"
+
+    def test_summarizes_nested_stack_cards(self):
+        config = {
+            "views": [
+                {
+                    "title": "Home",
+                    "cards": [
+                        {
+                            "type": "vertical-stack",
+                            "cards": [
+                                {"type": "tile", "entity": "light.a"},
+                                {"type": "tile", "entity": "light.b"},
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        stack = summarize_dashboard_config(config)["views"][0]["cards"][0]
+
+        assert stack["card_count"] == 2
+        assert stack["cards"][1]["pointer"] == "/views/0/cards/0/cards/1"
+        assert stack["cards"][1]["entity"] == "light.b"
+
+    def test_truncates_beyond_the_nesting_limit(self):
+        card: dict = {"type": "tile", "entity": "light.deep"}
+        for _ in range(8):
+            card = {"type": "vertical-stack", "cards": [card]}
+
+        result = summarize_dashboard_config({"views": [{"title": "Home", "cards": [card]}]})
+
+        node = result["views"][0]["cards"][0]
+        depth = 0
+        while "cards" in node:
+            node = node["cards"][0]
+            depth += 1
+        assert node["truncated"] is True
+        assert depth == 6
+
+    def test_caps_the_entities_it_lists(self):
+        entities = [f"light.l{i}" for i in range(14)]
+        config = {
+            "views": [{"title": "Home", "cards": [{"type": "entities", "entities": entities}]}]
+        }
+
+        card = summarize_dashboard_config(config)["views"][0]["cards"][0]
+
+        assert card["entity_count"] == 14
+        assert len(card["entities"]) == 10
+
+    def test_reads_entity_ids_from_row_objects(self):
+        config = {
+            "views": [
+                {
+                    "title": "Home",
+                    "cards": [
+                        {
+                            "type": "entities",
+                            "entities": [{"entity": "light.a", "name": "A"}, "light.b"],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        card = summarize_dashboard_config(config)["views"][0]["cards"][0]
+        assert card["entities"] == ["light.a", "light.b"]
+
+    def test_summarizes_badges(self):
+        config = {
+            "views": [{"title": "Home", "badges": [{"type": "entity", "entity": "person.me"}]}]
+        }
+
+        view = summarize_dashboard_config(config)["views"][0]
+
+        assert view["badge_count"] == 1
+        assert view["badges"][0]["pointer"] == "/views/0/badges/0"
+
+    def test_handles_config_without_views(self):
+        assert summarize_dashboard_config({}) == {"views": [], "view_count": 0}
+
+    def test_handles_malformed_entries(self):
+        result = summarize_dashboard_config({"views": ["not-a-view"]})
+        assert result["views"][0]["value"] == "not-a-view"
+
+    def test_rejects_non_object_config(self):
+        with pytest.raises(ValueError, match="must be an object"):
+            summarize_dashboard_config([])
+
+    def test_summarize_view_uses_the_given_pointer(self):
+        view = {"title": "Bedroom", "cards": [{"type": "tile", "entity": "light.bed"}]}
+
+        result = summarize_view(view, ["views", "3"], 3)
+
+        assert result["pointer"] == "/views/3"
+        assert result["index"] == 3
+        assert result["cards"][0]["pointer"] == "/views/3/cards/0"
 
 
 class TestDeleteDashboardConfig:

--- a/tests/test_dashboard_manager.py
+++ b/tests/test_dashboard_manager.py
@@ -465,8 +465,18 @@ class TestSummarizeDashboardConfig:
         assert summarize_dashboard_config({}) == {"views": [], "view_count": 0}
 
     def test_handles_malformed_entries(self):
-        result = summarize_dashboard_config({"views": ["not-a-view"]})
+        config = {
+            "views": [
+                "not-a-view",
+                {"title": "Home", "cards": ["not-a-card"], "sections": ["not-a-section"]},
+            ]
+        }
+
+        result = summarize_dashboard_config(config)
+
         assert result["views"][0]["value"] == "not-a-view"
+        assert result["views"][1]["cards"][0]["value"] == "not-a-card"
+        assert result["views"][1]["sections"][0]["value"] == "not-a-section"
 
     def test_rejects_non_object_config(self):
         with pytest.raises(ValueError, match="must be an object"):

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 67
+        assert len(body["result"]["tools"]) == 68
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 67
+        assert len(tool_names) == 68
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_json_patch.py
+++ b/tests/test_json_patch.py
@@ -4,6 +4,7 @@ import pytest
 
 from custom_components.mcp_server_http_transport.json_patch import (
     JsonPatchError,
+    _describe,
     apply_patch,
     format_pointer,
     parse_pointer,
@@ -61,6 +62,23 @@ class TestFormatPointer:
     def test_roundtrips_escaped_tokens(self):
         pointer = "/a~1b/c~0d"
         assert format_pointer(parse_pointer(pointer)) == pointer
+
+
+class TestDescribe:
+    """Tests for _describe, which renders values into error messages."""
+
+    def test_renders_json(self):
+        assert _describe({"entity": "light.a"}) == '{"entity": "light.a"}'
+
+    def test_truncates_long_values(self):
+        text = _describe(["light.a"] * 50)
+        assert len(text) == 121
+        assert text.endswith("…")
+
+    def test_falls_back_to_repr_when_json_fails(self):
+        circular: dict = {}
+        circular["self"] = circular
+        assert _describe(circular) == "{'self': {...}}"
 
 
 class TestResolvePointer:
@@ -159,6 +177,14 @@ class TestApplyPatch:
                 _dashboard(), [{"op": "replace", "path": "/views/0/icon", "value": "mdi:x"}]
             )
 
+    def test_add_into_a_scalar_is_rejected(self):
+        with pytest.raises(JsonPatchError, match="cannot add to a str"):
+            apply_patch(_dashboard(), [{"op": "add", "path": "/views/0/title/x", "value": 1}])
+
+    def test_remove_from_a_scalar_is_rejected(self):
+        with pytest.raises(JsonPatchError, match="cannot remove from a str"):
+            apply_patch(_dashboard(), [{"op": "remove", "path": "/views/0/title/x"}])
+
     def test_replace_whole_document(self):
         result = apply_patch(_dashboard(), [{"op": "replace", "path": "", "value": {"views": []}}])
         assert result == {"views": []}
@@ -192,6 +218,11 @@ class TestApplyPatch:
                 _dashboard(),
                 [{"op": "move", "from": "/views/0", "path": "/views/0/cards/-"}],
             )
+
+    def test_move_to_the_root_replaces_the_document(self):
+        result = apply_patch(_dashboard(), [{"op": "move", "from": "/views/1", "path": ""}])
+
+        assert result["title"] == "Bedroom"
 
     def test_copy_duplicates_a_card(self):
         result = apply_patch(

--- a/tests/test_json_patch.py
+++ b/tests/test_json_patch.py
@@ -103,6 +103,10 @@ class TestResolvePointer:
         with pytest.raises(JsonPatchError, match="not a valid array index"):
             resolve_pointer(_dashboard(), "/views/first")
 
+    def test_superscript_is_not_an_array_index(self):
+        with pytest.raises(JsonPatchError, match="not a valid array index"):
+            resolve_pointer(_dashboard(), "/views/²")
+
     def test_dash_does_not_resolve(self):
         with pytest.raises(JsonPatchError, match="end of an array"):
             resolve_pointer(_dashboard(), "/views/-")

--- a/tests/test_json_patch.py
+++ b/tests/test_json_patch.py
@@ -1,0 +1,291 @@
+"""Tests for the JSON Pointer / JSON Patch helpers."""
+
+import pytest
+
+from custom_components.mcp_server_http_transport.json_patch import (
+    JsonPatchError,
+    apply_patch,
+    format_pointer,
+    parse_pointer,
+    resolve_pointer,
+)
+
+
+def _dashboard() -> dict:
+    """A small dashboard config shaped like a real Lovelace storage config."""
+    return {
+        "views": [
+            {
+                "title": "Living Room",
+                "path": "living",
+                "cards": [
+                    {"type": "tile", "entity": "light.sofa"},
+                    {"type": "tile", "entity": "fan.air_purifier"},
+                ],
+            },
+            {
+                "title": "Bedroom",
+                "path": "bedroom",
+                "cards": [{"type": "tile", "entity": "light.bed"}],
+            },
+        ]
+    }
+
+
+class TestParsePointer:
+    """Tests for parse_pointer."""
+
+    def test_empty_pointer_is_the_whole_document(self):
+        assert parse_pointer("") == []
+
+    def test_splits_tokens(self):
+        assert parse_pointer("/views/0/cards/1") == ["views", "0", "cards", "1"]
+
+    def test_leading_slash_is_optional(self):
+        assert parse_pointer("views/0") == ["views", "0"]
+
+    def test_unescapes_tokens(self):
+        assert parse_pointer("/a~1b/c~0d") == ["a/b", "c~d"]
+
+    def test_rejects_non_string(self):
+        with pytest.raises(JsonPatchError, match="must be a string"):
+            parse_pointer(5)
+
+
+class TestFormatPointer:
+    """Tests for format_pointer."""
+
+    def test_empty_tokens(self):
+        assert format_pointer([]) == ""
+
+    def test_roundtrips_escaped_tokens(self):
+        pointer = "/a~1b/c~0d"
+        assert format_pointer(parse_pointer(pointer)) == pointer
+
+
+class TestResolvePointer:
+    """Tests for resolve_pointer."""
+
+    def test_empty_pointer_returns_document(self):
+        doc = _dashboard()
+        assert resolve_pointer(doc, "") is doc
+
+    def test_resolves_nested_value(self):
+        assert resolve_pointer(_dashboard(), "/views/1/cards/0/entity") == "light.bed"
+
+    def test_missing_key_lists_available_keys(self):
+        with pytest.raises(JsonPatchError, match="available: cards, path, title"):
+            resolve_pointer(_dashboard(), "/views/0/nope")
+
+    def test_index_out_of_range(self):
+        with pytest.raises(JsonPatchError, match="out of range"):
+            resolve_pointer(_dashboard(), "/views/7")
+
+    def test_non_numeric_array_index(self):
+        with pytest.raises(JsonPatchError, match="not a valid array index"):
+            resolve_pointer(_dashboard(), "/views/first")
+
+    def test_dash_does_not_resolve(self):
+        with pytest.raises(JsonPatchError, match="end of an array"):
+            resolve_pointer(_dashboard(), "/views/-")
+
+    def test_descending_into_scalar(self):
+        with pytest.raises(JsonPatchError, match="inside a str"):
+            resolve_pointer(_dashboard(), "/views/0/title/0")
+
+
+class TestApplyPatch:
+    """Tests for apply_patch."""
+
+    def test_replace_leaves_rest_untouched(self):
+        result = apply_patch(
+            _dashboard(),
+            [{"op": "replace", "path": "/views/0/cards/1/entity", "value": "fan.new"}],
+        )
+
+        assert result["views"][0]["cards"][1]["entity"] == "fan.new"
+        assert result["views"][0]["cards"][0]["entity"] == "light.sofa"
+        assert result["views"][1] == _dashboard()["views"][1]
+
+    def test_does_not_mutate_the_input(self):
+        doc = _dashboard()
+        apply_patch(doc, [{"op": "remove", "path": "/views/0/cards/0"}])
+        assert len(doc["views"][0]["cards"]) == 2
+
+    def test_add_appends_with_dash(self):
+        card = {"type": "tile", "entity": "light.lamp"}
+        result = apply_patch(
+            _dashboard(), [{"op": "add", "path": "/views/1/cards/-", "value": card}]
+        )
+
+        assert result["views"][1]["cards"][-1] == card
+
+    def test_add_inserts_at_index(self):
+        card = {"type": "tile", "entity": "light.lamp"}
+        result = apply_patch(
+            _dashboard(), [{"op": "add", "path": "/views/0/cards/0", "value": card}]
+        )
+
+        assert result["views"][0]["cards"][0] == card
+        assert len(result["views"][0]["cards"]) == 3
+
+    def test_add_sets_object_key(self):
+        result = apply_patch(
+            _dashboard(), [{"op": "add", "path": "/views/0/icon", "value": "mdi:sofa"}]
+        )
+        assert result["views"][0]["icon"] == "mdi:sofa"
+
+    def test_add_index_out_of_range(self):
+        with pytest.raises(JsonPatchError, match="out of range"):
+            apply_patch(_dashboard(), [{"op": "add", "path": "/views/0/cards/9", "value": {}}])
+
+    def test_remove_card(self):
+        result = apply_patch(_dashboard(), [{"op": "remove", "path": "/views/0/cards/0"}])
+
+        assert len(result["views"][0]["cards"]) == 1
+        assert result["views"][0]["cards"][0]["entity"] == "fan.air_purifier"
+
+    def test_remove_missing_key(self):
+        with pytest.raises(JsonPatchError, match="not found"):
+            apply_patch(_dashboard(), [{"op": "remove", "path": "/views/0/icon"}])
+
+    def test_remove_whole_document_is_rejected(self):
+        with pytest.raises(JsonPatchError, match="Cannot remove the whole document"):
+            apply_patch(_dashboard(), [{"op": "remove", "path": ""}])
+
+    def test_replace_requires_existing_location(self):
+        with pytest.raises(JsonPatchError, match="not found"):
+            apply_patch(
+                _dashboard(), [{"op": "replace", "path": "/views/0/icon", "value": "mdi:x"}]
+            )
+
+    def test_replace_whole_document(self):
+        result = apply_patch(_dashboard(), [{"op": "replace", "path": "", "value": {"views": []}}])
+        assert result == {"views": []}
+
+    def test_move_card_between_views(self):
+        result = apply_patch(
+            _dashboard(),
+            [{"op": "move", "from": "/views/0/cards/1", "path": "/views/1/cards/-"}],
+        )
+
+        assert [c["entity"] for c in result["views"][0]["cards"]] == ["light.sofa"]
+        assert [c["entity"] for c in result["views"][1]["cards"]] == [
+            "light.bed",
+            "fan.air_purifier",
+        ]
+
+    def test_move_reorders_within_a_view(self):
+        result = apply_patch(
+            _dashboard(),
+            [{"op": "move", "from": "/views/0/cards/1", "path": "/views/0/cards/0"}],
+        )
+
+        assert [c["entity"] for c in result["views"][0]["cards"]] == [
+            "fan.air_purifier",
+            "light.sofa",
+        ]
+
+    def test_move_into_own_child_is_rejected(self):
+        with pytest.raises(JsonPatchError, match="into its own child"):
+            apply_patch(
+                _dashboard(),
+                [{"op": "move", "from": "/views/0", "path": "/views/0/cards/-"}],
+            )
+
+    def test_copy_duplicates_a_card(self):
+        result = apply_patch(
+            _dashboard(),
+            [{"op": "copy", "from": "/views/0/cards/0", "path": "/views/1/cards/-"}],
+        )
+
+        assert result["views"][0]["cards"][0]["entity"] == "light.sofa"
+        assert result["views"][1]["cards"][-1]["entity"] == "light.sofa"
+
+    def test_copy_is_deep(self):
+        result = apply_patch(
+            _dashboard(),
+            [
+                {"op": "copy", "from": "/views/0/cards/0", "path": "/views/1/cards/-"},
+                {"op": "replace", "path": "/views/1/cards/1/entity", "value": "light.other"},
+            ],
+        )
+
+        assert result["views"][0]["cards"][0]["entity"] == "light.sofa"
+
+    def test_test_passes_and_continues(self):
+        result = apply_patch(
+            _dashboard(),
+            [
+                {"op": "test", "path": "/views/0/cards/1/entity", "value": "fan.air_purifier"},
+                {"op": "remove", "path": "/views/0/cards/1"},
+            ],
+        )
+
+        assert len(result["views"][0]["cards"]) == 1
+
+    def test_test_failure_reports_both_values(self):
+        with pytest.raises(JsonPatchError) as excinfo:
+            apply_patch(
+                _dashboard(),
+                [{"op": "test", "path": "/views/0/cards/1/entity", "value": "fan.other"}],
+            )
+
+        message = str(excinfo.value)
+        assert "fan.other" in message
+        assert "fan.air_purifier" in message
+
+    def test_failure_part_way_through_discards_earlier_operations(self):
+        doc = _dashboard()
+
+        with pytest.raises(JsonPatchError, match="Operation 1"):
+            apply_patch(
+                doc,
+                [
+                    {"op": "remove", "path": "/views/0/cards/0"},
+                    {"op": "remove", "path": "/views/0/cards/5"},
+                ],
+            )
+
+        assert len(doc["views"][0]["cards"]) == 2
+
+    def test_error_names_the_failing_operation(self):
+        with pytest.raises(JsonPatchError, match=r"Operation 0 \(replace\)"):
+            apply_patch(_dashboard(), [{"op": "replace", "path": "/nope", "value": 1}])
+
+    def test_unknown_op(self):
+        with pytest.raises(JsonPatchError, match="Unknown op"):
+            apply_patch(_dashboard(), [{"op": "upsert", "path": "/views", "value": []}])
+
+    def test_operation_must_be_an_object(self):
+        with pytest.raises(JsonPatchError, match="must be an object"):
+            apply_patch(_dashboard(), ["remove /views/0"])
+
+    def test_missing_path(self):
+        with pytest.raises(JsonPatchError, match="requires a 'path'"):
+            apply_patch(_dashboard(), [{"op": "remove"}])
+
+    def test_missing_value(self):
+        with pytest.raises(JsonPatchError, match="requires a 'value'"):
+            apply_patch(_dashboard(), [{"op": "add", "path": "/views/0/icon"}])
+
+    def test_missing_from(self):
+        with pytest.raises(JsonPatchError, match="requires a 'from'"):
+            apply_patch(_dashboard(), [{"op": "move", "path": "/views/0/cards/-"}])
+
+    def test_operations_must_be_a_list(self):
+        with pytest.raises(JsonPatchError, match="must be a list"):
+            apply_patch(_dashboard(), {"op": "remove", "path": "/views/0"})
+
+    def test_empty_operations(self):
+        with pytest.raises(JsonPatchError, match="at least one operation"):
+            apply_patch(_dashboard(), [])
+
+    def test_added_value_is_copied_from_the_caller(self):
+        card = {"type": "tile", "entity": "light.lamp"}
+        result = apply_patch(
+            _dashboard(), [{"op": "add", "path": "/views/0/cards/-", "value": card}]
+        )
+
+        card["entity"] = "light.changed"
+        assert result["views"][0]["cards"][-1]["entity"] == "light.lamp"

--- a/tests/test_tools_dashboards.py
+++ b/tests/test_tools_dashboards.py
@@ -471,3 +471,308 @@ class TestToolsDashboards:
         assert response.status == 200
         body = json.loads(response.body)
         assert "Error deleting dashboard" in body["result"]["content"][0]["text"]
+
+    async def test_post_tools_call_get_dashboard_config_with_path(self, view, mock_hass):
+        """Test get_dashboard_config returning only the part a JSON Pointer addresses."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_dashboard_config",
+                    "arguments": {"url_path": "default", "path": "/views/0/cards/1"},
+                },
+                "id": 74,
+            }
+        )
+
+        mock_config = {
+            "views": [
+                {
+                    "title": "Home",
+                    "cards": [
+                        {"type": "tile", "entity": "light.sofa"},
+                        {"type": "tile", "entity": "fan.air_purifier"},
+                    ],
+                }
+            ]
+        }
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.get_dashboard_config",
+                new_callable=AsyncMock,
+                return_value=mock_config,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        result = json.loads(body["result"]["content"][0]["text"])
+        assert result == {"type": "tile", "entity": "fan.air_purifier"}
+
+    async def test_post_tools_call_get_dashboard_config_with_unknown_path(self, view, mock_hass):
+        """Test get_dashboard_config when the JSON Pointer does not resolve."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_dashboard_config",
+                    "arguments": {"url_path": "default", "path": "/views/9"},
+                },
+                "id": 75,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.get_dashboard_config",
+                new_callable=AsyncMock,
+                return_value={"views": [{"title": "Home"}]},
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        text = body["result"]["content"][0]["text"]
+        assert "Error getting dashboard config" in text
+        assert "out of range" in text
+
+    async def test_post_tools_call_get_dashboard_config_summary(self, view, mock_hass):
+        """Test get_dashboard_config summary mode outlining the whole dashboard."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_dashboard_config",
+                    "arguments": {"url_path": "default", "summary": True},
+                },
+                "id": 76,
+            }
+        )
+
+        mock_config = {
+            "views": [
+                {
+                    "title": "Home",
+                    "cards": [
+                        {"type": "tile", "entity": "light.sofa", "features": [{"type": "x"}]}
+                    ],
+                }
+            ]
+        }
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.get_dashboard_config",
+                new_callable=AsyncMock,
+                return_value=mock_config,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        result = json.loads(body["result"]["content"][0]["text"])
+        assert result["view_count"] == 1
+        card = result["views"][0]["cards"][0]
+        assert card["pointer"] == "/views/0/cards/0"
+        assert "features" not in card
+
+    async def test_post_tools_call_get_dashboard_config_summary_for_one_view(self, view, mock_hass):
+        """Test get_dashboard_config summary mode scoped to a single view."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_dashboard_config",
+                    "arguments": {"url_path": "default", "summary": True, "path": "/views/1"},
+                },
+                "id": 77,
+            }
+        )
+
+        mock_config = {
+            "views": [
+                {"title": "Home", "cards": []},
+                {"title": "Bedroom", "cards": [{"type": "tile", "entity": "light.bed"}]},
+            ]
+        }
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.get_dashboard_config",
+                new_callable=AsyncMock,
+                return_value=mock_config,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        result = json.loads(body["result"]["content"][0]["text"])
+        assert result["pointer"] == "/views/1"
+        assert result["title"] == "Bedroom"
+        assert result["cards"][0]["pointer"] == "/views/1/cards/0"
+
+    async def test_post_tools_call_get_dashboard_config_summary_unsupported_path(
+        self, view, mock_hass
+    ):
+        """Test get_dashboard_config summary mode with a path it cannot outline."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "get_dashboard_config",
+                    "arguments": {
+                        "url_path": "default",
+                        "summary": True,
+                        "path": "/views/0/cards/1",
+                    },
+                },
+                "id": 78,
+            }
+        )
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.get_dashboard_config",
+                new_callable=AsyncMock,
+                return_value={"views": [{"title": "Home", "cards": []}]},
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        text = body["result"]["content"][0]["text"]
+        assert "summary=true supports" in text
+        assert "/views/0/cards/1" in text
+
+    async def test_post_tools_call_patch_dashboard_config(self, view, mock_hass):
+        """Test POST with tools/call for patch_dashboard_config."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "patch_dashboard_config",
+                    "arguments": {
+                        "url_path": "default",
+                        "operations": [
+                            {
+                                "op": "test",
+                                "path": "/views/0/cards/0/entity",
+                                "value": "fan.air_purifier",
+                            },
+                            {
+                                "op": "move",
+                                "from": "/views/0/cards/0",
+                                "path": "/views/1/cards/-",
+                            },
+                        ],
+                    },
+                },
+                "id": 79,
+            }
+        )
+
+        mock_config = {
+            "views": [
+                {"title": "Living Room", "cards": [{"type": "tile", "entity": "fan.air_purifier"}]},
+                {"title": "Bedroom", "cards": []},
+            ]
+        }
+        mock_save = AsyncMock()
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.get_dashboard_config",
+                new_callable=AsyncMock,
+                return_value=mock_config,
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.save_dashboard_config",
+                mock_save,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        text = body["result"]["content"][0]["text"]
+        assert "Applied 2 operation(s)" in text
+        assert "[0] Living Room: 0 card(s)" in text
+        assert "[1] Bedroom: 1 card(s)" in text
+
+        saved = mock_save.await_args.args[2]
+        assert saved["views"][0]["cards"] == []
+        assert saved["views"][1]["cards"][0]["entity"] == "fan.air_purifier"
+
+    async def test_post_tools_call_patch_dashboard_config_error(self, view, mock_hass):
+        """Test patch_dashboard_config leaving the dashboard alone when an operation fails."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "patch_dashboard_config",
+                    "arguments": {
+                        "url_path": "default",
+                        "operations": [
+                            {"op": "test", "path": "/views/0/title", "value": "Away"},
+                        ],
+                    },
+                },
+                "id": 80,
+            }
+        )
+
+        mock_save = AsyncMock()
+
+        with (
+            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.get_dashboard_config",
+                new_callable=AsyncMock,
+                return_value={"views": [{"title": "Home", "cards": []}]},
+            ),
+            patch(
+                "custom_components.mcp_server_http_transport.dashboard_manager.save_dashboard_config",
+                mock_save,
+            ),
+        ):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        text = body["result"]["content"][0]["text"]
+        assert "Error patching dashboard config" in text
+        assert "test failed" in text
+        mock_save.assert_not_awaited()

--- a/tests/test_tools_dashboards.py
+++ b/tests/test_tools_dashboards.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from custom_components.mcp_server_http_transport.http import MCPEndpointView
+from custom_components.mcp_server_http_transport.tools.dashboards import _view_overview
 
 
 class TestToolsDashboards:
@@ -776,3 +777,43 @@ class TestToolsDashboards:
         assert "Error patching dashboard config" in text
         assert "test failed" in text
         mock_save.assert_not_awaited()
+
+
+class TestViewOverview:
+    """Tests for _view_overview, the confirmation line patch_dashboard_config returns."""
+
+    def test_counts_cards_per_view(self):
+        config = {
+            "views": [
+                {"title": "Living Room", "cards": [{"type": "tile"}, {"type": "tile"}]},
+                {"path": "bedroom", "cards": []},
+            ]
+        }
+
+        assert _view_overview(config) == [
+            "  [0] Living Room: 2 card(s)",
+            "  [1] bedroom: 0 card(s)",
+        ]
+
+    def test_counts_cards_inside_sections(self):
+        config = {
+            "views": [
+                {
+                    "title": "Home",
+                    "type": "sections",
+                    "cards": [{"type": "tile"}],
+                    "sections": [
+                        {"type": "grid", "cards": [{"type": "tile"}, {"type": "tile"}]},
+                        {"type": "grid", "cards": []},
+                    ],
+                }
+            ]
+        }
+
+        assert _view_overview(config) == ["  [0] Home: 3 card(s), 2 section(s)"]
+
+    def test_reports_a_view_that_is_not_an_object(self):
+        assert _view_overview({"views": ["broken"]}) == ["  [0] (not an object)"]
+
+    def test_handles_a_config_without_views(self):
+        assert _view_overview({}) == []


### PR DESCRIPTION
Closes #65.

Editing a Lovelace dashboard was all-or-nothing: `get_dashboard_config` returned the entire config and `save_dashboard_config` demanded the entire config back. On the ~135 KB dashboard in the issue, moving a single card meant reading 135 KB and writing 135 KB in one turn, which blows past the output limit before the edit lands.

Both ends of that round trip are now scopeable.

### Reading

`get_dashboard_config` keeps its current behaviour when called with just `url_path`, and gains two optional arguments:

- `path` — a JSON Pointer (`/views/2/cards/5`) returning only that part of the config.
- `summary` — an outline instead of the full config: every view and card as type, label, and entities, each carrying the JSON Pointer that addresses it, with the cards' options left out. Combine with `path="/views/<n>"` to outline a single view.

```json
{
  "view_count": 2,
  "views": [
    {"pointer": "/views/0", "index": 0, "title": "Living Room", "path": "living", "card_count": 2,
     "cards": [
       {"pointer": "/views/0/cards/0", "index": 0, "type": "tile", "entity": "light.sofa"},
       {"pointer": "/views/0/cards/1", "index": 1, "type": "tile", "entity": "fan.air_purifier"}
     ]}
  ]
}
```

Sections views, nested stack cards, and badges are all summarized, with nesting truncated at six levels and long `entities` lists capped at ten ids plus an `entity_count`.

### Writing

`patch_dashboard_config` applies [RFC 6902](https://datatracker.ietf.org/doc/html/rfc6902) operations to those same pointers, so the issue's example becomes:

```json
patch_dashboard_config(url_path="default", operations=[
  {"op": "test", "path": "/views/0/cards/1/entity", "value": "fan.air_purifier"},
  {"op": "move", "from": "/views/0/cards/1", "path": "/views/1/cards/-"}
])
```

All six operations are supported (`add`, `remove`, `replace`, `move`, `copy`, `test`). The patch is applied to a deep copy of the loaded config and only saved once every operation succeeds, so a failure leaves the stored dashboard untouched rather than half-edited. A leading `test` operation turns a stale read into a clean failure instead of an edit to the wrong card. The tool returns a one-line-per-view confirmation with the resulting card counts, not the patched config.

`save_dashboard_config` is unchanged apart from its description, which now points at `patch_dashboard_config` for anything short of a full rewrite.

### Implementation

JSON Pointer (RFC 6901) and JSON Patch (RFC 6902) live in a new dependency-free `json_patch.py`. Error messages name the failing operation index and, for a missing key, list the keys that are available, since the model consuming them has no other way to see where its pointer went wrong. A missing leading slash on a pointer is tolerated.

68 tools total now, up from 67. Manifest version bumped to 1.13.0.
