### PR TITLE
fix: answer unauthenticated GET /api/mcp with the RFC 9728 challenge

### DIFF
--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -163,6 +163,54 @@ class MCPEndpointView(HomeAssistantView):
 
         return None
 
+    def _unauthorized(self, request: web.Request) -> web.Response:
+        """Build the 401 that points a client at this resource's metadata.
+
+        The resource_metadata URL is the RFC 9728 path-suffixed form. HA Core
+        serves its own metadata at the bare /.well-known/oauth-protected-resource
+        and wins that route by registering first, so a client that falls back to
+        the root path is told the authorization server is HA itself.
+        """
+        base_url = _get_issuer(request)
+        if base_url is not None:
+            resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource/api/mcp"
+            www_authenticate = (
+                f'Bearer realm="MCP Server",' f' resource_metadata="{resource_metadata_url}"'
+            )
+        else:
+            www_authenticate = 'Bearer realm="Home Assistant MCP Server"'
+
+        return web.json_response(
+            {
+                "error": "invalid_token",
+                "error_description": "Invalid or missing token",
+            },
+            status=401,
+            headers={"WWW-Authenticate": www_authenticate},
+        )
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Answer GET probes, which clients use to discover how to authenticate.
+
+        This endpoint carries no SSE stream, so an authenticated GET is Method
+        Not Allowed. An unauthenticated one still gets the challenge, because a
+        bare 405 leaves the client with no pointer to the resource metadata.
+        """
+        if not _integration_loaded(self.hass):
+            return _service_unavailable()
+
+        if not await self._validate_token(request):
+            return self._unauthorized(request)
+
+        return web.json_response(
+            {
+                "error": "method_not_allowed",
+                "error_description": "This endpoint accepts POST and serves no SSE stream",
+            },
+            status=405,
+            headers={"Allow": "OPTIONS, POST"},
+        )
+
     async def post(self, request: web.Request) -> web.Response:
         """Handle POST requests for MCP messages."""
         if not _integration_loaded(self.hass):
@@ -171,24 +219,7 @@ class MCPEndpointView(HomeAssistantView):
         # Validate token
         token_payload = await self._validate_token(request)
         if not token_payload:
-            # Build WWW-Authenticate header
-            base_url = _get_issuer(request)
-            if base_url is not None:
-                resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource/api/mcp"
-                www_authenticate = (
-                    f'Bearer realm="MCP Server",' f' resource_metadata="{resource_metadata_url}"'
-                )
-            else:
-                www_authenticate = 'Bearer realm="Home Assistant MCP Server"'
-
-            return web.json_response(
-                {
-                    "error": "invalid_token",
-                    "error_description": "Invalid or missing token",
-                },
-                status=401,
-                headers={"WWW-Authenticate": www_authenticate},
-            )
+            return self._unauthorized(request)
 
         body = None
         try:

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0"],
-  "version": "1.13.0"
+  "version": "1.13.1"
 }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -103,3 +103,22 @@ async def test_unauthenticated_request_is_rejected(
     assert resp.status == 401
     assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")
     assert (await resp.json())["error"] == "invalid_token"
+
+
+async def test_unauthenticated_get_carries_the_challenge(
+    loaded_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """A GET probe reaches the view instead of aiohttp's own method-not-allowed.
+
+    aiohttp answers an unrouted method itself, and that response carries no
+    WWW-Authenticate, so this asserts the route exists rather than that the
+    handler body is correct.
+    """
+    client = await hass_client_no_auth()
+
+    resp = await client.get("/api/mcp")
+
+    assert resp.status == 401
+    assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")
+    assert (await resp.json())["error"] == "invalid_token"

--- a/tests/test_e2e_oidc.py
+++ b/tests/test_e2e_oidc.py
@@ -157,3 +157,24 @@ async def test_expired_token_is_rejected(
     resp = await _post_initialize(client, token)
 
     assert resp.status == 401
+
+
+async def test_unauthenticated_get_advertises_resource_metadata(
+    oidc_ready: rsa.RSAPrivateKey, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """A GET probe is told where this resource's metadata lives.
+
+    The advertised path is the RFC 9728 suffixed form. Home Assistant serves its
+    own metadata at the bare /.well-known/oauth-protected-resource and wins that
+    route by registering first, so pointing at the root would send the client to
+    HA's own authorization server.
+    """
+    client = await hass_client_no_auth()
+
+    resp = await client.get("/api/mcp", headers=FORWARDED)
+
+    assert resp.status == 401
+    assert resp.headers["WWW-Authenticate"] == (
+        'Bearer realm="MCP Server",'
+        f' resource_metadata="{ISSUER_BASE}/.well-known/oauth-protected-resource/api/mcp"'
+    )

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -299,6 +299,52 @@ class TestMCPEndpointView:
 
         assert response.status == 202
 
+    async def test_get_without_token_returns_401_with_challenge(self, view):
+        """Test GET without a token returns 401 carrying the metadata pointer."""
+        request = Mock()
+        request.headers = {}
+        request.url.origin.return_value = "https://homeassistant.local"
+
+        with patch(
+            "custom_components.mcp_server_http_transport.http._get_issuer",
+            return_value="https://homeassistant.local:8123",
+        ):
+            response = await view.get(request)
+
+        assert response.status == 401
+        body = json.loads(response.body)
+        assert body["error"] == "invalid_token"
+        assert (
+            'resource_metadata="https://homeassistant.local:8123'
+            '/.well-known/oauth-protected-resource/api/mcp"' in response.headers["WWW-Authenticate"]
+        )
+
+    async def test_get_with_valid_token_returns_405(self, view):
+        """Test GET with a valid token is Method Not Allowed; there is no SSE stream."""
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.get(request)
+
+        assert response.status == 405
+        assert response.headers["Allow"] == "OPTIONS, POST"
+        assert "WWW-Authenticate" not in response.headers
+
+    async def test_get_returns_503_when_unloaded(self, mock_server):
+        """Test GET is gated on the integration being loaded, like POST."""
+        hass = Mock()
+        hass.data = {}
+        view = MCPEndpointView(hass, mock_server)
+
+        request = Mock()
+        request.headers = {}
+
+        response = await view.get(request)
+
+        assert response.status == 503
+        assert json.loads(response.body)["error"] == "service_unavailable"
+
     async def test_validate_token_without_bearer_prefix(self, view):
         """Test _validate_token without Bearer prefix returns None."""
         request = Mock()


### PR DESCRIPTION
`MCPEndpointView` only defined `post`, and Home Assistant registers routes solely for the methods a view implements, so `GET /api/mcp` fell through to aiohttp's own 405. That response carries no `WWW-Authenticate` header, so a client that probes with GET before POST gets no pointer to this resource's metadata at all.

From there it falls back to the bare `/.well-known/oauth-protected-resource`, which HA Core has served natively since home-assistant/core#166213 (HA 2026.4+) and wins by registering first during bootstrap. Core's metadata points `authorization_servers` at the HA root, RFC 8414 discovery from there lands on core's own authorization server metadata, and that has no `registration_endpoint`. A DCR-based client has no path to an authorization screen from that point.

GET now returns the same 401 and challenge the POST path already built, and 405 once the token validates, since this endpoint serves no SSE stream. `Allow` is set explicitly because aiohttp stops generating it once GET is a real route. The challenge construction moves into `_unauthorized` so the two methods cannot drift apart.

Reported in #69, where the reporter confirmed they configured the connector as `https://<ha>:8123/api/mcp`, the correct URL, and still failed. Their probe:

```
curl -sk -X GET https://<ha>:8123/api/mcp -D -

HTTP/1.1 405 Method Not Allowed
Allow: OPTIONS,POST
```

No `WWW-Authenticate`, which is the gap this closes.

### Scope

Worth being precise about what is and is not established. The missing challenge is confirmed as a real defect and is wrong on its own terms: a protected resource should tell an unauthenticated caller how to authenticate. What is not confirmed is that Claude.ai actually probes with GET before POST, since a client that POSTs first already receives the correct challenge today. So this is the leading explanation for #69 rather than a proven one, and #69 should stay open until the reporter retests.

Two things from #69 are deliberately left out. The root `MCPProtectedResourceMetadataView` is still dead code on HA 2026.4 and later, with tests asserting behavior production never reaches, and it still needs a drop-or-document decision. The issue title also frames the shadowing as the cause, which the reporter's answer rules out; that is worth retitling separately.
