### PR TITLE
fix: return service response data from call_service

### DIFF
--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -4,7 +4,7 @@ import json
 import logging
 from typing import Any
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
@@ -110,7 +110,7 @@ async def get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str,
     annotations=ANNOTATION_DESTRUCTIVE,
 )
 async def call_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Call a Home Assistant service."""
+    """Call a Home Assistant service, returning its response data when it has any."""
     domain = arguments["domain"]
     service = arguments["service"]
     entity_id = arguments.get("entity_id")
@@ -121,18 +121,43 @@ async def call_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
         service_data["entity_id"] = entity_id
 
     try:
-        await hass.services.async_call(domain, service, service_data, blocking=True)
+        # A service declared SupportsResponse.ONLY cannot be called at all
+        # without asking for its response — Home Assistant refuses the call
+        # rather than dropping the data. That covers whole categories of reads
+        # that only exist as services: calendar.get_events, todo.get_items,
+        # weather.get_forecasts, recorder.get_statistics. OPTIONAL services do
+        # run, but withhold what they were asked for.
+        supports = hass.services.supports_response(domain, service)
+        wants_response = supports is not SupportsResponse.NONE
+
+        response = await hass.services.async_call(
+            domain,
+            service,
+            service_data,
+            blocking=True,
+            return_response=wants_response,
+        )
+    except Exception as e:
+        _LOGGER.error("Error calling service: %s", e)
+        return {"content": [{"type": "text", "text": f"Error calling service: {str(e)}"}]}
+
+    if wants_response and response is not None:
         return {
             "content": [
                 {
                     "type": "text",
-                    "text": f"Successfully called {domain}.{service}",
+                    "text": json.dumps(response, indent=2, cls=_HAJSONEncoder),
                 }
             ]
         }
-    except Exception as e:
-        _LOGGER.error("Error calling service: %s", e)
-        return {"content": [{"type": "text", "text": f"Error calling service: {str(e)}"}]}
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": f"Successfully called {domain}.{service}",
+            }
+        ]
+    }
 
 
 @register_tool(

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -122,12 +122,22 @@ async def call_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
 
     try:
         # A service declared SupportsResponse.ONLY cannot be called at all
-        # without asking for its response — Home Assistant refuses the call
+        # without asking for its response: Home Assistant refuses the call
         # rather than dropping the data. That covers whole categories of reads
-        # that only exist as services: calendar.get_events, todo.get_items,
-        # weather.get_forecasts, recorder.get_statistics. OPTIONAL services do
-        # run, but withhold what they were asked for.
-        supports = hass.services.supports_response(domain, service)
+        # that only exist as services, among them calendar.get_events,
+        # todo.get_items, weather.get_forecasts and recorder.get_statistics.
+        # OPTIONAL services do run, but withhold what they were asked for.
+        #
+        # supports_response() subscripts the service registry directly and
+        # raises KeyError for anything the registry does not hold, despite a
+        # docstring promising NONE, so has_service() guards it. An unknown
+        # service then reaches async_call and is reported as the
+        # ServiceNotFound it is.
+        supports = (
+            hass.services.supports_response(domain, service)
+            if hass.services.has_service(domain, service)
+            else SupportsResponse.NONE
+        )
         wants_response = supports is not SupportsResponse.NONE
 
         response = await hass.services.async_call(
@@ -137,27 +147,31 @@ async def call_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             blocking=True,
             return_response=wants_response,
         )
-    except Exception as e:
-        _LOGGER.error("Error calling service: %s", e)
-        return {"content": [{"type": "text", "text": f"Error calling service: {str(e)}"}]}
 
-    if wants_response and response is not None:
+        # An OPTIONAL service with nothing to say answers with an empty dict
+        # rather than None, as every script without a response variable does.
+        # That carries no more than the success message.
+        if wants_response and response:
+            return {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": json.dumps(response, indent=2, cls=_HAJSONEncoder),
+                    }
+                ]
+            }
+
         return {
             "content": [
                 {
                     "type": "text",
-                    "text": json.dumps(response, indent=2, cls=_HAJSONEncoder),
+                    "text": f"Successfully called {domain}.{service}",
                 }
             ]
         }
-    return {
-        "content": [
-            {
-                "type": "text",
-                "text": f"Successfully called {domain}.{service}",
-            }
-        ]
-    }
+    except Exception as e:
+        _LOGGER.error("Error calling service: %s", e)
+        return {"content": [{"type": "text", "text": f"Error calling service: {str(e)}"}]}
 
 
 @register_tool(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -90,6 +90,7 @@ def populated_hass():
     hass.services.async_call = AsyncMock()
     # None of the services above return data. Left as a bare Mock this would read
     # as "returns a response" and every call would ask for one.
+    hass.services.has_service = Mock(return_value=True)
     hass.services.supports_response = Mock(return_value=SupportsResponse.NONE)
 
     # --- Config ---

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from homeassistant.core import SupportsResponse
 
 from custom_components.mcp_server_http_transport.http import MCPEndpointView
 
@@ -87,6 +88,9 @@ def populated_hass():
         "homeassistant": {"restart": Mock(), "reload_all": Mock()},
     }
     hass.services.async_call = AsyncMock()
+    # None of the services above return data. Left as a bare Mock this would read
+    # as "returns a response" and every call would ask for one.
+    hass.services.supports_response = Mock(return_value=SupportsResponse.NONE)
 
     # --- Config ---
     mock_units = Mock()
@@ -453,6 +457,7 @@ class TestMCPClientSession:
             "turn_on",
             {"brightness": 128, "transition": 2, "entity_id": "light.bedroom"},
             blocking=True,
+            return_response=False,
         )
 
     async def test_get_state_for_nonexistent_entity(self, view, mock_entity_registry):

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -58,6 +58,7 @@ class TestToolsEntities:
         # Most services return nothing; the ones that do are set per test. Left
         # as a bare Mock this would read as "returns a response" and every call
         # would ask for one.
+        hass.services.has_service = Mock(return_value=True)
         hass.services.supports_response = Mock(return_value=SupportsResponse.NONE)
         return hass
 
@@ -242,6 +243,113 @@ class TestToolsEntities:
         assert response.status == 200
         body = json.loads(response.body)
         assert "Successfully called" in body["result"]["content"][0]["text"]
+
+    async def test_post_tools_call_service_empty_response_reports_success(self, view, mock_hass):
+        """A script with no response variable answers {} and still reports success.
+
+        Scripts are SupportsResponse.OPTIONAL and script/__init__.py returns
+        `response or {}`, so every ordinary script call would otherwise render
+        as an empty dict instead of a confirmation.
+        """
+        mock_hass.services.supports_response = Mock(return_value=SupportsResponse.OPTIONAL)
+        mock_hass.services.async_call = AsyncMock(return_value={})
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "call_service",
+                    "arguments": {"domain": "script", "service": "bedtime"},
+                },
+                "id": 9,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert body["result"]["content"][0]["text"] == "Successfully called script.bedtime"
+
+    async def test_post_tools_call_service_unknown_service(self, view, mock_hass):
+        """An unknown service reports itself as not found.
+
+        Core's supports_response() subscripts the service registry directly and
+        raises KeyError for anything it does not hold, which would replace the
+        ServiceNotFound message with a bare "'light'" before async_call is ever
+        reached. This is the common failure mode for a model guessing a name,
+        so the useful part of the message has to survive.
+        """
+        registry = {"light": {"turn_on": SupportsResponse.NONE}}
+        mock_hass.services.has_service = Mock(
+            side_effect=lambda domain, service: service in registry.get(domain, {})
+        )
+        mock_hass.services.supports_response = Mock(
+            side_effect=lambda domain, service: registry[domain][service]
+        )
+        # Stands in for ServiceNotFound, whose __str__ resolves a translation
+        # against a live hass and so cannot be raised from a mock.
+        mock_hass.services.async_call = AsyncMock(
+            side_effect=Exception("Action light.no_such_service not found.")
+        )
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "call_service",
+                    "arguments": {"domain": "light", "service": "no_such_service"},
+                },
+                "id": 10,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        text = json.loads(response.body)["result"]["content"][0]["text"]
+        assert "light.no_such_service" in text
+        mock_hass.services.async_call.assert_called_once_with(
+            "light",
+            "no_such_service",
+            {},
+            blocking=True,
+            return_response=False,
+        )
+
+    async def test_post_tools_call_service_unserializable_response(self, view, mock_hass):
+        """A response the encoder cannot handle degrades to the error string."""
+        mock_hass.services.supports_response = Mock(return_value=SupportsResponse.ONLY)
+        mock_hass.services.async_call = AsyncMock(return_value={"handle": object()})
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "call_service",
+                    "arguments": {"domain": "custom", "service": "read"},
+                },
+                "id": 11,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "Error calling service" in body["result"]["content"][0]["text"]
 
     async def test_post_tools_call_service_error(self, view, mock_hass):
         """Test POST with tools/call for call_service that fails."""

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from homeassistant.core import SupportsResponse
 
 from custom_components.mcp_server_http_transport.http import MCPEndpointView
 from custom_components.mcp_server_http_transport.tools import entities as entities_mod
@@ -54,6 +55,10 @@ class TestToolsEntities:
         hass = Mock()
         hass.states = Mock()
         hass.services = Mock()
+        # Most services return nothing; the ones that do are set per test. Left
+        # as a bare Mock this would read as "returns a response" and every call
+        # would ask for one.
+        hass.services.supports_response = Mock(return_value=SupportsResponse.NONE)
         return hass
 
     @pytest.fixture
@@ -165,7 +170,78 @@ class TestToolsEntities:
             "turn_on",
             {"brightness": 255, "entity_id": "light.living_room"},
             blocking=True,
+            return_response=False,
         )
+
+    async def test_post_tools_call_service_returns_response_data(self, view, mock_hass):
+        """A service that only exists to return data must return it.
+
+        Home Assistant refuses to run a SupportsResponse.ONLY service unless the
+        caller asks for the response, so without this these services could not be
+        called at all — not merely called without their answer.
+        """
+        mock_hass.services.supports_response = Mock(return_value=SupportsResponse.ONLY)
+        mock_hass.services.async_call = AsyncMock(
+            return_value={"calendar.family": {"events": [{"summary": "Dentist"}]}}
+        )
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "call_service",
+                    "arguments": {
+                        "domain": "calendar",
+                        "service": "get_events",
+                        "entity_id": "calendar.family",
+                    },
+                },
+                "id": 7,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "Dentist" in body["result"]["content"][0]["text"]
+        mock_hass.services.async_call.assert_called_once_with(
+            "calendar",
+            "get_events",
+            {"entity_id": "calendar.family"},
+            blocking=True,
+            return_response=True,
+        )
+
+    async def test_post_tools_call_service_optional_response_without_data(self, view, mock_hass):
+        """An OPTIONAL service that answers with nothing still reports success."""
+        mock_hass.services.supports_response = Mock(return_value=SupportsResponse.OPTIONAL)
+        mock_hass.services.async_call = AsyncMock(return_value=None)
+
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "call_service",
+                    "arguments": {"domain": "conversation", "service": "process"},
+                },
+                "id": 8,
+            }
+        )
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert "Successfully called" in body["result"]["content"][0]["text"]
 
     async def test_post_tools_call_service_error(self, view, mock_hass):
         """Test POST with tools/call for call_service that fails."""


### PR DESCRIPTION
`call_service` never passed `return_response` to `hass.services.async_call`. That does more than drop the data: Home Assistant **refuses outright** to run a service declared `SupportsResponse.ONLY` unless the caller asks for its response. Through this tool those services answered

```
Error calling service: The action requires responses and must be called with return_response=True
```

and there was no parameter a client could set to comply — so they were not callable at all, rather than callable without their answer.

## How much this covers

On a fairly ordinary installation I counted **40 services declaring `SupportsResponse.ONLY`**, among them:

`calendar.get_events` · `todo.get_items` · `weather.get_forecasts` · `recorder.get_statistics` · `schedule.get_schedule` · `media_player.browse_media` · `media_player.search_media` · `assist_satellite.ask_question` · `ai_task.generate_data` · `file.read_file` · `matter.get_lock_users`

A further **87 declare `SupportsResponse.OPTIONAL`**: those ran, but silently withheld what they were asked for — `conversation.process` among them.

These are whole categories of *reads* that exist only as services, with no entity state to fall back on.

## Why it reads as a bug rather than a gap

`describe_service` already relays each service's `response` contract straight from core, so a model is told:

```json
"response": { "optional": false }
```

— this service answers — and then has no way to hear the answer.

There may also be a knock-on cleanup here. `list_calendar_events` reaches past the service layer into `entity.async_get_events()`, and `get_statistics` imports `statistics_during_period` from `homeassistant.components.recorder.statistics`. Both are private APIs of other integrations, reimplemented for services that `call_service` could not reach. With this fix they could be reconsidered, which would remove two things that can break on any Home Assistant release.

## The change

Ask core what the service supports, pass it along, and serialise the response through the `_HAJSONEncoder` this module already uses for `describe_service` (needed for the `datetime` objects in, for example, `calendar.get_events`).

`supports_response()` is called **inside** the existing `try`, so a nonexistent service still surfaces as the same `ServiceNotFound` message instead of a second, different failure.

Behaviour for `SupportsResponse.NONE` services is unchanged: still `Successfully called {domain}.{service}`.

## Tests

Two added:

- a `SupportsResponse.ONLY` service returns its data and is called with `return_response=True`
- a `SupportsResponse.OPTIONAL` service that answers with nothing still reports success

Three existing assertions gain `return_response=False`, since the call signature changed. Both `hass` fixtures now stub `supports_response` — left as a bare `Mock` it reads as "returns a response", and every call would ask for one.

Full suite passes locally apart from `tests/test_server.py`, which fails identically on `main` in my environment (an `mcp` version mismatch), so unrelated to this change.

Also verified against a live Home Assistant instance: a `SupportsResponse.ONLY` service that previously errored now returns its data, `todo.get_items` returns `{"items": []}`, and `light.turn_off` is unchanged.

## One thing deliberately left out

`call_service` carries `ANNOTATION_DESTRUCTIVE`. With response services now reachable, reads like `weather.get_forecasts` and `todo.get_items` are presented as destructive to clients that honour annotations. Annotations are fixed per tool rather than per call, so addressing that would mean a separate read-only tool — a bigger discussion than this fix, and I did not want to entangle the two. Happy to open a follow-up issue if you think it is worth one.


Fixes #74
