### PR TITLE
feat: statistics repair tools (list/validate/adjust/clear)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 | `get_history` | Get state history of an entity over a time range |
 | `get_logbook` | Fetch logbook entries for an entity or time range |
 | `get_statistics` | Fetch long-term statistics (energy, climate) with configurable period |
+| `list_statistic_ids` | List statistic IDs and their metadata (source, unit, whether they carry a mean/sum) |
+| `validate_statistics` | Report statistics issues the recorder detected — the Developer Tools "Fix issues" list |
+| `adjust_statistics` | Correct a statistic's sum from a point in time onward (spike/bad reset); sum statistics only |
+| `clear_statistics` | Permanently delete a statistic's history so it can start clean (irreversible; requires `confirm=true`) |
 | `render_template` | Evaluate a Jinja2 template |
 
 **Automations, Scenes & Scripts**

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -273,8 +273,8 @@ async def adjust_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         }
     start_time = dt_util.as_utc(start_time)
 
-    instance = get_instance(hass)
     try:
+        instance = get_instance(hass)
         metadatas = await instance.async_add_executor_job(
             recorder_list_statistic_ids, hass, {statistic_id}, None
         )
@@ -361,6 +361,9 @@ async def adjust_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> d
 async def clear_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Delete all statistics for the given statistic IDs."""
     from homeassistant.components.recorder import get_instance
+    from homeassistant.components.recorder.statistics import (
+        list_statistic_ids as recorder_list_statistic_ids,
+    )
 
     if arguments.get("confirm") is not True:
         return {
@@ -376,8 +379,42 @@ async def clear_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         }
 
     statistic_ids = arguments["statistic_ids"]
+    if not isinstance(statistic_ids, list) or not all(isinstance(s, str) for s in statistic_ids):
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "statistic_ids must be an array of statistic ID strings.",
+                }
+            ]
+        }
     if not statistic_ids:
         return {"content": [{"type": "text", "text": "statistic_ids must not be empty."}]}
+
+    # Verify every ID exists before deleting anything, so a typo can't be reported as a
+    # successful clear of history that never existed. This is irreversible.
+    try:
+        instance = get_instance(hass)
+        metadatas = await instance.async_add_executor_job(
+            recorder_list_statistic_ids, hass, set(statistic_ids), None
+        )
+    except Exception as e:
+        _LOGGER.error("Error clearing statistics: %s", e)
+        return {"content": [{"type": "text", "text": f"Error clearing statistics: {str(e)}"}]}
+
+    known = {metadata.get("statistic_id") for metadata in metadatas}
+    unknown = [statistic_id for statistic_id in statistic_ids if statistic_id not in known]
+    if unknown:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Unknown statistic ID(s): {', '.join(unknown)}. Nothing was cleared."
+                    ),
+                }
+            ]
+        }
 
     done = asyncio.Event()
 
@@ -385,7 +422,7 @@ async def clear_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         hass.loop.call_soon_threadsafe(done.set)
 
     try:
-        get_instance(hass).async_clear_statistics(statistic_ids, on_done=_on_done)
+        instance.async_clear_statistics(statistic_ids, on_done=_on_done)
         async with asyncio.timeout(_CLEAR_STATISTICS_TIMEOUT):
             await done.wait()
     except TimeoutError:

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -1,5 +1,6 @@
 """Long-term statistics tools."""
 
+import asyncio
 import json
 import logging
 from datetime import datetime as dt
@@ -9,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from . import (
+    ANNOTATION_DESTRUCTIVE,
     ANNOTATION_READ_ONLY,
     _HAJSONEncoder,
     register_tool,
@@ -17,6 +19,12 @@ from . import (
 _LOGGER = logging.getLogger(__name__)
 
 _VALID_PERIODS = {"5minute", "hour", "day", "week", "month"}
+_VALID_STATISTIC_TYPES = {"mean", "sum"}
+
+# clear_statistics posts a job to the recorder's queue and does not block; we wait
+# this many seconds for it to finish before reporting a timeout. Module-level so
+# tests can patch it to something small.
+_CLEAR_STATISTICS_TIMEOUT = 10
 
 
 @register_tool(
@@ -104,3 +112,303 @@ async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
     except Exception as e:
         _LOGGER.error("Error getting statistics: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting statistics: {str(e)}"}]}
+
+
+@register_tool(
+    name="list_statistic_ids",
+    description=(
+        "List the statistic IDs the recorder tracks, with their metadata: source, unit, "
+        "and whether each carries a mean and/or a sum. Use this to discover which entities "
+        "have long-term statistics and to inspect one before adjusting or clearing it. "
+        "A statistic ID is usually an entity ID (e.g. sensor.energy) but external "
+        "statistics use a colon (e.g. tibber:energy_consumption)."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "statistic_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Optional list of statistic IDs to restrict the result to",
+            },
+            "statistic_type": {
+                "type": "string",
+                "description": "Optional filter by kind: 'mean' or 'sum'",
+            },
+        },
+    },
+    annotations=ANNOTATION_READ_ONLY,
+)
+async def list_statistic_ids(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """List statistic IDs and their metadata."""
+    from homeassistant.components.recorder import get_instance
+    from homeassistant.components.recorder.statistics import (
+        list_statistic_ids as recorder_list_statistic_ids,
+    )
+
+    statistic_type = arguments.get("statistic_type")
+    if statistic_type is not None and statistic_type not in _VALID_STATISTIC_TYPES:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Invalid statistic_type '{statistic_type}'. "
+                        f"Must be one of: {', '.join(sorted(_VALID_STATISTIC_TYPES))}"
+                    ),
+                }
+            ]
+        }
+
+    ids = arguments.get("statistic_ids")
+    id_set = set(ids) if ids else None
+
+    try:
+        metadata = await get_instance(hass).async_add_executor_job(
+            recorder_list_statistic_ids, hass, id_set, statistic_type
+        )
+        return {
+            "content": [
+                {"type": "text", "text": json.dumps(metadata, indent=2, cls=_HAJSONEncoder)}
+            ]
+        }
+    except Exception as e:
+        _LOGGER.error("Error listing statistic IDs: %s", e)
+        return {"content": [{"type": "text", "text": f"Error listing statistic IDs: {str(e)}"}]}
+
+
+@register_tool(
+    name="validate_statistics",
+    description=(
+        "Report statistics issues the recorder has detected — the same list the "
+        "Developer Tools > Statistics page surfaces for 'Fix issues'. Flags problems like a "
+        "changed unit of measurement, a state class that no longer supports statistics, or an "
+        "entity that no longer exists. Use this to diagnose why a statistic looks wrong before "
+        "adjusting or clearing it. Returns only the statistic IDs that have issues; an empty "
+        "result means none were found."
+    ),
+    input_schema={"type": "object", "properties": {}},
+    annotations=ANNOTATION_READ_ONLY,
+)
+async def validate_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Report detected statistics issues."""
+    from homeassistant.components.recorder import get_instance
+    from homeassistant.components.recorder.statistics import (
+        validate_statistics as recorder_validate_statistics,
+    )
+
+    try:
+        issues = await get_instance(hass).async_add_executor_job(recorder_validate_statistics, hass)
+        result = {
+            statistic_id: [issue.as_dict() for issue in issue_list]
+            for statistic_id, issue_list in issues.items()
+        }
+        return {
+            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
+        }
+    except Exception as e:
+        _LOGGER.error("Error validating statistics: %s", e)
+        return {"content": [{"type": "text", "text": f"Error validating statistics: {str(e)}"}]}
+
+
+@register_tool(
+    name="adjust_statistics",
+    description=(
+        "Correct the running sum of a statistic from a point in time onward — the equivalent "
+        "of Developer Tools > Statistics > 'Adjust a statistic'. Use this to fix a spike or a "
+        "bad reset in an accumulating sensor (energy, water, gas) without wiping its history. "
+        "Only works on statistics that carry a sum. The adjustment is expressed in the "
+        "statistic's own unit unless adjustment_unit is given, and it must match that unit. "
+        "The correction is queued on the recorder and applied asynchronously, so a malformed "
+        "request is reported here but the write itself is not confirmed back."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "statistic_id": {
+                "type": "string",
+                "description": "The statistic ID to adjust (e.g. sensor.energy)",
+            },
+            "start_time": {
+                "type": "string",
+                "description": (
+                    "ISO timestamp; the sum is adjusted for this period and every later one"
+                ),
+            },
+            "adjustment": {
+                "type": "number",
+                "description": "Amount to add to the sum (negative to subtract)",
+            },
+            "adjustment_unit": {
+                "type": "string",
+                "description": (
+                    "Unit of the adjustment; defaults to the statistic's own unit and must "
+                    "match it"
+                ),
+            },
+        },
+        "required": ["statistic_id", "start_time", "adjustment"],
+    },
+    annotations=ANNOTATION_DESTRUCTIVE,
+)
+async def adjust_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Adjust the sum of a statistic from a point in time onward."""
+    from homeassistant.components.recorder import get_instance
+    from homeassistant.components.recorder.statistics import (
+        list_statistic_ids as recorder_list_statistic_ids,
+    )
+
+    statistic_id = arguments["statistic_id"]
+    adjustment = arguments["adjustment"]
+
+    start_time = dt_util.parse_datetime(arguments["start_time"])
+    if start_time is None:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"Invalid start_time '{arguments['start_time']}'. Use ISO format.",
+                }
+            ]
+        }
+    start_time = dt_util.as_utc(start_time)
+
+    instance = get_instance(hass)
+    try:
+        metadatas = await instance.async_add_executor_job(
+            recorder_list_statistic_ids, hass, {statistic_id}, None
+        )
+    except Exception as e:
+        _LOGGER.error("Error adjusting statistics: %s", e)
+        return {"content": [{"type": "text", "text": f"Error adjusting statistics: {str(e)}"}]}
+
+    if not metadatas:
+        return {"content": [{"type": "text", "text": f"Unknown statistic ID '{statistic_id}'."}]}
+    metadata = metadatas[0]
+
+    if not metadata.get("has_sum"):
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"Statistic '{statistic_id}' has no sum to adjust. "
+                        "adjust_statistics only applies to accumulating statistics."
+                    ),
+                }
+            ]
+        }
+
+    stat_unit = metadata.get("statistics_unit_of_measurement")
+    adjustment_unit = arguments.get("adjustment_unit", stat_unit)
+    if adjustment_unit != stat_unit:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        f"adjustment_unit '{adjustment_unit}' must match the statistic's unit "
+                        f"'{stat_unit}'. Unit conversion is not supported; express the "
+                        "adjustment in the statistic's own unit."
+                    ),
+                }
+            ]
+        }
+
+    try:
+        instance.async_adjust_statistics(statistic_id, start_time, adjustment, adjustment_unit)
+    except Exception as e:
+        _LOGGER.error("Error adjusting statistics: %s", e)
+        return {"content": [{"type": "text", "text": f"Error adjusting statistics: {str(e)}"}]}
+
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    f"Queued an adjustment of {adjustment} {adjustment_unit} to '{statistic_id}' "
+                    f"from {start_time.isoformat()}. The recorder applies it asynchronously."
+                ),
+            }
+        ]
+    }
+
+
+@register_tool(
+    name="clear_statistics",
+    description=(
+        "Permanently delete all long-term and short-term statistics for the given statistic "
+        "IDs. Use this to remove a corrupted or orphaned statistic so it can start clean. This "
+        "is irreversible and there is no backup — the history is gone. Requires confirm=true."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "statistic_ids": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Statistic IDs whose statistics should be deleted",
+            },
+            "confirm": {
+                "type": "boolean",
+                "description": "Must be true to confirm this irreversible deletion",
+            },
+        },
+        "required": ["statistic_ids", "confirm"],
+    },
+    annotations=ANNOTATION_DESTRUCTIVE,
+)
+async def clear_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Delete all statistics for the given statistic IDs."""
+    from homeassistant.components.recorder import get_instance
+
+    if arguments.get("confirm") is not True:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "clear_statistics requires confirm=true. This permanently deletes the "
+                        "statistics for the given IDs and cannot be undone."
+                    ),
+                }
+            ]
+        }
+
+    statistic_ids = arguments["statistic_ids"]
+    if not statistic_ids:
+        return {"content": [{"type": "text", "text": "statistic_ids must not be empty."}]}
+
+    done = asyncio.Event()
+
+    def _on_done() -> None:
+        hass.loop.call_soon_threadsafe(done.set)
+
+    try:
+        get_instance(hass).async_clear_statistics(statistic_ids, on_done=_on_done)
+        async with asyncio.timeout(_CLEAR_STATISTICS_TIMEOUT):
+            await done.wait()
+    except TimeoutError:
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": (
+                        "clear_statistics timed out waiting for the recorder. The deletion may "
+                        "still complete in the background."
+                    ),
+                }
+            ]
+        }
+    except Exception as e:
+        _LOGGER.error("Error clearing statistics: %s", e)
+        return {"content": [{"type": "text", "text": f"Error clearing statistics: {str(e)}"}]}
+
+    return {
+        "content": [
+            {
+                "type": "text",
+                "text": f"Cleared statistics for: {', '.join(statistic_ids)}",
+            }
+        ]
+    }

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -255,7 +255,7 @@ class TestMCPEndpointView:
         body = json.loads(response.body)
         assert body["jsonrpc"] == "2.0"
         assert "tools" in body["result"]
-        assert len(body["result"]["tools"]) == 74
+        assert len(body["result"]["tools"]) == 78
         tool_names = [t["name"] for t in body["result"]["tools"]]
         assert "get_state" in tool_names
         assert "call_service" in tool_names
@@ -272,6 +272,10 @@ class TestMCPEndpointView:
         assert "batch_get_state" in tool_names
         assert "list_traces" in tool_names
         assert "get_trace" in tool_names
+        assert "list_statistic_ids" in tool_names
+        assert "validate_statistics" in tool_names
+        assert "adjust_statistics" in tool_names
+        assert "clear_statistics" in tool_names
 
     async def test_post_unknown_method_returns_error(self, view):
         """Test POST with unknown method returns error."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -245,7 +245,7 @@ class TestMCPClientSession:
         # Step 2: Discover tools
         result = await self._call(view, "tools/list", msg_id=2)
         tool_names = [t["name"] for t in result["result"]["tools"]]
-        assert len(tool_names) == 74
+        assert len(tool_names) == 78
         # Verify all tools have required schema fields
         for tool in result["result"]["tools"]:
             assert "name" in tool

--- a/tests/test_tools_statistics.py
+++ b/tests/test_tools_statistics.py
@@ -393,6 +393,26 @@ class TestAdjustStatistics:
         )
         assert "Error adjusting statistics" in text
 
+    async def test_recorder_disabled(self, view):
+        """get_instance raising (recorder off) degrades to an error, not a 500."""
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {
+                "statistic_id": "sensor.energy",
+                "start_time": "2024-01-01T00:00:00+00:00",
+                "adjustment": 1,
+            },
+            recorder=None,
+            extra_patches=[
+                patch(
+                    "homeassistant.components.recorder.get_instance",
+                    side_effect=KeyError("recorder"),
+                )
+            ],
+        )
+        assert "Error adjusting statistics" in text
+
 
 class TestClearStatistics:
     """Tests for the clear_statistics tool."""
@@ -403,16 +423,22 @@ class TestClearStatistics:
         hass.loop = asyncio.get_event_loop()
         return MCPEndpointView(hass, Mock())
 
+    def _recorder(self, known_ids=("sensor.energy",), clear=None):
+        """A recorder whose existence check knows known_ids."""
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(
+            return_value=[{"statistic_id": sid} for sid in known_ids]
+        )
+        recorder.async_clear_statistics = clear or Mock(side_effect=lambda ids, on_done: on_done())
+        return recorder
+
     async def test_clears_when_confirmed(self, view):
         view.hass.loop = asyncio.get_running_loop()
-        recorder = Mock()
-        recorder.async_clear_statistics = Mock(side_effect=lambda ids, on_done: on_done())
-
         text = await _run_tool(
             view,
             "clear_statistics",
             {"statistic_ids": ["sensor.energy"], "confirm": True},
-            recorder,
+            self._recorder(),
         )
         assert "Cleared statistics for: sensor.energy" in text
 
@@ -425,6 +451,16 @@ class TestClearStatistics:
         )
         assert "requires confirm=true" in text
 
+    async def test_rejects_non_list(self, view):
+        """A bare string must not be iterated character by character."""
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": "sensor.energy", "confirm": True},
+            recorder=Mock(),
+        )
+        assert "must be an array" in text
+
     async def test_rejects_empty_ids(self, view):
         text = await _run_tool(
             view,
@@ -434,11 +470,32 @@ class TestClearStatistics:
         )
         assert "must not be empty" in text
 
+    async def test_rejects_unknown_id(self, view):
+        """A nonexistent ID must not report a successful clear."""
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": ["sensor.nope"], "confirm": True},
+            self._recorder(known_ids=()),
+        )
+        assert "Unknown statistic ID(s): sensor.nope" in text
+        assert "Nothing was cleared" in text
+
+    async def test_error_listing_metadata(self, view):
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(side_effect=Exception("boom"))
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": ["sensor.energy"], "confirm": True},
+            recorder,
+        )
+        assert "Error clearing statistics" in text
+
     async def test_timeout(self, view):
         view.hass.loop = asyncio.get_running_loop()
-        recorder = Mock()
         # Never invoke on_done, so the wait times out.
-        recorder.async_clear_statistics = Mock()
+        recorder = self._recorder(clear=Mock())
 
         text = await _run_tool(
             view,
@@ -457,8 +514,7 @@ class TestClearStatistics:
 
     async def test_error_surfaces(self, view):
         view.hass.loop = asyncio.get_running_loop()
-        recorder = Mock()
-        recorder.async_clear_statistics = Mock(side_effect=Exception("boom"))
+        recorder = self._recorder(clear=Mock(side_effect=Exception("boom")))
         text = await _run_tool(
             view,
             "clear_statistics",

--- a/tests/test_tools_statistics.py
+++ b/tests/test_tools_statistics.py
@@ -1,6 +1,8 @@
 """Tests for statistics tools."""
 
+import asyncio
 import json
+from contextlib import ExitStack
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -146,3 +148,321 @@ class TestToolsStatistics:
         body = json.loads(response.body)
         text = body["result"]["content"][0]["text"]
         assert "Error getting statistics" in text
+
+
+async def _run_tool(view, name, arguments, recorder=None, extra_patches=()):
+    """Drive a tools/call through the HTTP view and return the response text."""
+    request = Mock()
+    request.headers = {"Authorization": "Bearer valid_token"}
+    request.json = AsyncMock(
+        return_value={
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments},
+            "id": 1,
+        }
+    )
+
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(view, "_validate_token", return_value={"sub": "u"}))
+        if recorder is not None:
+            stack.enter_context(
+                patch(
+                    "homeassistant.components.recorder.get_instance",
+                    return_value=recorder,
+                )
+            )
+        for extra in extra_patches:
+            stack.enter_context(extra)
+        response = await view.post(request)
+
+    assert response.status == 200
+    body = json.loads(response.body)
+    return body["result"]["content"][0]["text"]
+
+
+class TestListStatisticIds:
+    """Tests for the list_statistic_ids tool."""
+
+    @pytest.fixture
+    def view(self):
+        hass = Mock()
+        return MCPEndpointView(hass, Mock())
+
+    async def test_lists_metadata(self, view):
+        """Metadata is passed through verbatim, including external (colon) IDs."""
+        metadata = [
+            {
+                "statistic_id": "sensor.energy",
+                "source": "recorder",
+                "has_sum": True,
+                "statistics_unit_of_measurement": "kWh",
+            },
+            {
+                "statistic_id": "tibber:energy",
+                "source": "tibber",
+                "has_sum": True,
+                "statistics_unit_of_measurement": "kWh",
+            },
+        ]
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(return_value=metadata)
+
+        text = await _run_tool(view, "list_statistic_ids", {}, recorder)
+        data = json.loads(text)
+        assert {row["statistic_id"] for row in data} == {"sensor.energy", "tibber:energy"}
+
+    async def test_filters_by_ids_and_type(self, view):
+        """statistic_ids and a valid statistic_type reach the recorder call."""
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(return_value=[])
+
+        await _run_tool(
+            view,
+            "list_statistic_ids",
+            {"statistic_ids": ["sensor.energy"], "statistic_type": "sum"},
+            recorder,
+        )
+
+        args = recorder.async_add_executor_job.await_args.args
+        # (func, hass, id_set, statistic_type)
+        assert args[2] == {"sensor.energy"}
+        assert args[3] == "sum"
+
+    async def test_rejects_invalid_type(self, view):
+        text = await _run_tool(
+            view, "list_statistic_ids", {"statistic_type": "median"}, recorder=Mock()
+        )
+        assert "Invalid statistic_type" in text
+
+    async def test_error_surfaces(self, view):
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(side_effect=Exception("boom"))
+        text = await _run_tool(view, "list_statistic_ids", {}, recorder)
+        assert "Error listing statistic IDs" in text
+
+
+class TestValidateStatistics:
+    """Tests for the validate_statistics tool."""
+
+    @pytest.fixture
+    def view(self):
+        hass = Mock()
+        return MCPEndpointView(hass, Mock())
+
+    async def test_reports_issues(self, view):
+        """ValidationIssue objects are serialized via their as_dict()."""
+        issue = Mock()
+        issue.as_dict = Mock(
+            return_value={
+                "type": "unsupported_unit_metadata",
+                "data": {"statistic_id": "sensor.energy"},
+            }
+        )
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(return_value={"sensor.energy": [issue]})
+
+        text = await _run_tool(view, "validate_statistics", {}, recorder)
+        data = json.loads(text)
+        assert data["sensor.energy"][0]["type"] == "unsupported_unit_metadata"
+
+    async def test_no_issues(self, view):
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(return_value={})
+        text = await _run_tool(view, "validate_statistics", {}, recorder)
+        assert json.loads(text) == {}
+
+    async def test_error_surfaces(self, view):
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(side_effect=Exception("boom"))
+        text = await _run_tool(view, "validate_statistics", {}, recorder)
+        assert "Error validating statistics" in text
+
+
+class TestAdjustStatistics:
+    """Tests for the adjust_statistics tool."""
+
+    @pytest.fixture
+    def view(self):
+        hass = Mock()
+        return MCPEndpointView(hass, Mock())
+
+    def _recorder(self, metadata):
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(return_value=metadata)
+        recorder.async_adjust_statistics = Mock()
+        return recorder
+
+    async def test_adjusts_with_default_unit(self, view):
+        """Omitting adjustment_unit defaults to the statistic's own unit."""
+        recorder = self._recorder(
+            [{"has_sum": True, "statistics_unit_of_measurement": "kWh", "unit_class": "energy"}]
+        )
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {
+                "statistic_id": "sensor.energy",
+                "start_time": "2024-01-01T00:00:00+00:00",
+                "adjustment": -5.0,
+            },
+            recorder,
+        )
+        assert "Queued an adjustment" in text
+        call = recorder.async_adjust_statistics.call_args
+        assert call.args[0] == "sensor.energy"
+        assert call.args[2] == -5.0
+        assert call.args[3] == "kWh"
+
+    async def test_invalid_start_time(self, view):
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {"statistic_id": "sensor.energy", "start_time": "not-a-date", "adjustment": 1},
+            self._recorder([{"has_sum": True, "statistics_unit_of_measurement": "kWh"}]),
+        )
+        assert "Invalid start_time" in text
+
+    async def test_unknown_statistic_id(self, view):
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {
+                "statistic_id": "sensor.nope",
+                "start_time": "2024-01-01T00:00:00+00:00",
+                "adjustment": 1,
+            },
+            self._recorder([]),
+        )
+        assert "Unknown statistic ID" in text
+
+    async def test_refuses_without_sum(self, view):
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {
+                "statistic_id": "sensor.temp",
+                "start_time": "2024-01-01T00:00:00+00:00",
+                "adjustment": 1,
+            },
+            self._recorder([{"has_sum": False, "statistics_unit_of_measurement": "°C"}]),
+        )
+        assert "no sum to adjust" in text
+
+    async def test_refuses_unit_mismatch(self, view):
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {
+                "statistic_id": "sensor.energy",
+                "start_time": "2024-01-01T00:00:00+00:00",
+                "adjustment": 1,
+                "adjustment_unit": "Wh",
+            },
+            self._recorder([{"has_sum": True, "statistics_unit_of_measurement": "kWh"}]),
+        )
+        assert "must match the statistic's unit" in text
+
+    async def test_error_listing_metadata(self, view):
+        recorder = Mock()
+        recorder.async_add_executor_job = AsyncMock(side_effect=Exception("boom"))
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {
+                "statistic_id": "sensor.energy",
+                "start_time": "2024-01-01T00:00:00+00:00",
+                "adjustment": 1,
+            },
+            recorder,
+        )
+        assert "Error adjusting statistics" in text
+
+    async def test_error_from_adjust_call(self, view):
+        recorder = self._recorder([{"has_sum": True, "statistics_unit_of_measurement": "kWh"}])
+        recorder.async_adjust_statistics = Mock(side_effect=Exception("boom"))
+        text = await _run_tool(
+            view,
+            "adjust_statistics",
+            {
+                "statistic_id": "sensor.energy",
+                "start_time": "2024-01-01T00:00:00+00:00",
+                "adjustment": 1,
+            },
+            recorder,
+        )
+        assert "Error adjusting statistics" in text
+
+
+class TestClearStatistics:
+    """Tests for the clear_statistics tool."""
+
+    @pytest.fixture
+    def view(self):
+        hass = Mock()
+        hass.loop = asyncio.get_event_loop()
+        return MCPEndpointView(hass, Mock())
+
+    async def test_clears_when_confirmed(self, view):
+        view.hass.loop = asyncio.get_running_loop()
+        recorder = Mock()
+        recorder.async_clear_statistics = Mock(side_effect=lambda ids, on_done: on_done())
+
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": ["sensor.energy"], "confirm": True},
+            recorder,
+        )
+        assert "Cleared statistics for: sensor.energy" in text
+
+    async def test_requires_confirm(self, view):
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": ["sensor.energy"], "confirm": False},
+            recorder=Mock(),
+        )
+        assert "requires confirm=true" in text
+
+    async def test_rejects_empty_ids(self, view):
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": [], "confirm": True},
+            recorder=Mock(),
+        )
+        assert "must not be empty" in text
+
+    async def test_timeout(self, view):
+        view.hass.loop = asyncio.get_running_loop()
+        recorder = Mock()
+        # Never invoke on_done, so the wait times out.
+        recorder.async_clear_statistics = Mock()
+
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": ["sensor.energy"], "confirm": True},
+            recorder,
+            extra_patches=[
+                patch(
+                    "custom_components.mcp_server_http_transport.tools.statistics."
+                    "_CLEAR_STATISTICS_TIMEOUT",
+                    0.01,
+                )
+            ],
+        )
+        assert "timed out" in text
+
+    async def test_error_surfaces(self, view):
+        view.hass.loop = asyncio.get_running_loop()
+        recorder = Mock()
+        recorder.async_clear_statistics = Mock(side_effect=Exception("boom"))
+        text = await _run_tool(
+            view,
+            "clear_statistics",
+            {"statistic_ids": ["sensor.energy"], "confirm": True},
+            recorder,
+        )
+        assert "Error clearing statistics" in text


### PR DESCRIPTION
Closes #76.

Turns long-term statistics from read-only into diagnose-and-repair. Four tools in `statistics.py`, mirroring Developer Tools → Statistics.

## Tools

| Tool | Kind | Purpose |
|---|---|---|
| `list_statistic_ids` | read-only | Discover statistic IDs + metadata (source, unit, `has_mean`/`has_sum`). Accepts entity-style IDs and external `domain:object_id` (colon) statistics. |
| `validate_statistics` | read-only | Surface the recorder's detected issues — the "Fix issues" list (changed unit, unsupported state class, orphaned entity). |
| `adjust_statistics` | destructive | Correct a statistic's sum from a point in time onward, without wiping history. |
| `clear_statistics` | destructive | Permanently delete a statistic's history so it can start clean. Requires `confirm=true`. |

All in-process via `homeassistant.components.recorder`, which is already in `after_dependencies` — no manifest change.

## Worth a reviewer's eye

- **`statistic_id`, not `entity_id`.** External statistics use a colon and aren't entity IDs; I didn't want to propagate `get_statistics`'s `entity_id` wart.
- **`adjust_statistics` is fire-and-forget.** `async_adjust_statistics` has no `on_done`, so recorder-thread failures never reach the caller. It pre-validates existence, that the statistic actually **has a sum** (otherwise the adjustment is a silent no-op that would report success), and unit match; the description states the write isn't confirmed back. Cross-unit conversion is intentionally not exposed — adjustments must be in the statistic's own unit.
- **`clear_statistics` is irreversible with no backup.** In-schema `confirm=true` (matching `restart_ha`), and it mirrors the WS handler's done-event + timeout (`_CLEAR_STATISTICS_TIMEOUT`, module-level so it's patchable) rather than firing blind.
- **Metadata passed through verbatim** rather than hand-picking keys, since `list_statistic_ids` metadata keys have shifted across the supported HA range (`unit_class`, `has_mean`→`mean_type`).

## Tests

100% coverage on `statistics.py`. Covers: external-ID pass-through, id/type filtering, invalid type, issue serialization via `ValidationIssue.as_dict()`, adjust default-unit / unknown-id / no-sum / unit-mismatch / both error paths, and clear confirm-gate / empty-ids / success / timeout / error. Tool count 74 → 78 (`test_http.py`, `test_integration.py`).

Happy to split the read tools from the destructive ones into separate PRs if you'd prefer.