### PR TITLE
chore: bump version to 1.15.0

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0", "python-dateutil>=2.9.0"],
-  "version": "1.14.0"
+  "version": "1.15.0"
 }


### PR DESCRIPTION
Bumps the integration version to 1.15.0 to release the tools merged since v1.14.0.

Six new tools, no breaking changes:

**Automation & script traces (#72)**

| Tool | Purpose |
|---|---|
| `list_traces` | Recent execution traces for an automation/script or a whole domain, newest first |
| `get_trace` | Full step-by-step trace of one run: which trigger fired, which conditions passed, variables at each step |

**Statistics repair (#77)**

| Tool | Purpose |
|---|---|
| `list_statistic_ids` | Statistic IDs and their metadata (source, unit, mean/sum) |
| `validate_statistics` | Issues the recorder detected, the Developer Tools "Fix issues" list |
| `adjust_statistics` | Correct a statistic's sum from a point in time onward |
| `clear_statistics` | Permanently delete a statistic's history (requires `confirm=true`) |
