### PR TITLE
Advertise the openid scope in protected resource metadata

### DIFF
--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -57,6 +57,7 @@ def _get_protected_resource_metadata(base_url: str) -> dict[str, Any]:
     return {
         "resource": f"{base_url}/api/mcp",
         "authorization_servers": [f"{base_url}/oidc"],
+        "scopes_supported": ["openid"],
         "bearer_methods_supported": ["header"],
         "resource_signing_alg_values_supported": ["RS256"],
         "resource_documentation": f"{base_url}/api/mcp",

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -82,6 +82,7 @@ def test_get_protected_resource_metadata():
 
     assert metadata["resource"] == f"{base_url}/api/mcp"
     assert metadata["authorization_servers"] == [f"{base_url}/oidc"]
+    assert metadata["scopes_supported"] == ["openid"]
     assert metadata["bearer_methods_supported"] == ["header"]
     assert metadata["resource_signing_alg_values_supported"] == ["RS256"]
     assert metadata["resource_documentation"] == f"{base_url}/api/mcp"


### PR DESCRIPTION
Fixes #83.

The short version: the protected resource metadata doesn't advertise `scopes_supported`, so a client that builds its authorization request from that document asks for no scope at all — and `hass-oidc-server`, correctly, turns it away with "The openid scope is required for OIDC requests." One line fixes it.

I ran into this connecting Claude Code (HA 2026.8.2, `mcp_server_http_transport` 1.15.0, `oidc_provider` 1.5.2, public HTTPS via Nabu Casa). Everything up to that point is right: the 401 carries the `resource_metadata` pointer, and that document names `/oidc` as the authorization server. It just never says which scopes to ask for. RFC 9728 §2 is where that belongs, and the MCP authorization spec has clients populate the request from it. Claude Code offers no flag for setting scopes by hand — I checked — so there's nothing to work around on the client side.

I went with `openid` on its own. As far as I can tell the bearer path only ever reads `sub`, so `profile`, `email`, and `groups` would add claims that nothing looks at; if you'd rather advertise everything the OIDC server supports, say the word and I'll change it.

I added the matching assertion to `test_get_protected_resource_metadata`. The full suite comes out the same before and after — 692 passed, 1 failed, 5 skipped, 8 errors — with the failures all in `test_server.py` and unrelated to this as far as I can see, though I didn't dig into them. `ruff` and `black` are clean.

Verified on my own instance: with this applied and Home Assistant restarted, Claude Code finishes the flow and the server reports connected.

Thanks for both of these, by the way. Making Home Assistant its own OIDC provider is a genuinely nice piece of work, and it saved me from parking a long-lived token in a config file.
