### PR TITLE
refactor: fetch statistics through recorder.get_statistics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,11 @@ jobs:
             ha-version: "2025.10.1"
             ha-test-helper: "0.13.286"
             extra-deps: "pycares<5"
+          # The declared minimum in hacs.json. recorder.get_statistics, which
+          # tools/statistics.py reads through, landed in this release.
+          - python-version: "3.13"
+            ha-version: "2025.6.0"
+            ha-test-helper: "0.13.251"
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,9 +77,6 @@ jobs:
             ha-version: "2025.10.1"
             ha-test-helper: "0.13.286"
             extra-deps: "pycares<5"
-          - python-version: "3.13"
-            ha-version: "2025.4.4"
-            ha-test-helper: "0.13.236"
 
     steps:
     - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,7 @@ jobs:
           - python-version: "3.13"
             ha-version: "2025.6.0"
             ha-test-helper: "0.13.251"
+            extra-deps: "pycares<5"
 
     steps:
     - uses: actions/checkout@v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,20 +18,35 @@ they are easy to confuse because they all look like `homeassistant.components.*`
 
 ## Before replacing a private call with a service
 
-Confirm the service response carries every field the code reads. Home Assistant
-services routinely return less than the method they wrap: `calendar.get_events`
-filters events through `LIST_EVENT_FIELDS` and drops `uid`, `rrule` and
-`recurrence_id`, which the calendar tools need, so it is not a substitute for
-`async_get_events`. Check the field filter in core before assuming a swap is
-possible.
+Read the handler in core to the end. Three things have to hold, and each has bitten
+this repo:
 
-Entity services key their response by entity ID; plain services do not.
+**The fields.** Services routinely return less than the method they wrap.
+`calendar.get_events` filters events through `LIST_EVENT_FIELDS` and drops `uid`,
+`rrule` and `recurrence_id`, which the calendar tools need, so it is not a
+substitute for `async_get_events`.
+
+**The response shape.** A plain service returns whatever its handler returns, which
+is often an envelope rather than the payload. `recorder.get_statistics` returns
+`{"statistics": {statistic_id: [rows]}}`, not rows keyed by ID. Entity services are
+the ones keyed by entity ID, and that keying is added by the helper, not the
+handler. Getting this wrong fails silently: the lookup misses and the tool reports
+no data rather than an error.
+
+**The version it landed in.** A service is only supported API on versions that have
+it. `recorder.get_statistics` arrived in 2025.6 and raises `ServiceNotFound` on
+anything older. Check the oldest HA in the CI matrix in `.github/workflows/main.yml`
+before assuming a service is reachable.
 
 ## Anything left in category 2 or 3
 
 Give it a contract test in `tests/test_ha_api_contracts.py` pinning the signature or
 fields relied on. An HA release that changes it then fails CI here instead of
 silently on a user's upgrade.
+
+Pin service responses the same way, by driving the real handler. Mocking a service
+in a tool test only asserts the shape the tool already assumes, so it stays green
+when core changes underneath it.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Working on this integration
+
+## Calling into Home Assistant
+
+Tools live in `custom_components/mcp_server_http_transport/tools/`. Most reach into
+Home Assistant, and not every reach carries the same risk. Three categories, and
+they are easy to confuse because they all look like `homeassistant.components.*`:
+
+1. **Entity platform contracts.** Methods declared on an entity base class that
+   every integration on that platform implements: `CalendarEntity.async_get_events`,
+   `async_turn_on`, and so on. Safe to call. Home Assistant's own services and REST
+   views are thin wrappers over them.
+2. **Cross-integration internals.** Module-level functions imported out of another
+   integration, such as `recorder.statistics.statistics_during_period`. No
+   compatibility promise, no deprecation cycle. Prefer a service call.
+3. **`hass.data[DATA_*]` lookups.** Unsupported, and usually the only way to resolve
+   an entity object. Guard for the component being absent.
+
+## Before replacing a private call with a service
+
+Confirm the service response carries every field the code reads. Home Assistant
+services routinely return less than the method they wrap: `calendar.get_events`
+filters events through `LIST_EVENT_FIELDS` and drops `uid`, `rrule` and
+`recurrence_id`, which the calendar tools need, so it is not a substitute for
+`async_get_events`. Check the field filter in core before assuming a swap is
+possible.
+
+Entity services key their response by entity ID; plain services do not.
+
+## Anything left in category 2 or 3
+
+Give it a contract test in `tests/test_ha_api_contracts.py` pinning the signature or
+fields relied on. An HA release that changes it then fails CI here instead of
+silently on a user's upgrade.
+
+## Conventions
+
+Black and Ruff at line length 100, both enforced in CI. Tools register through
+`@register_tool` and return `{"content": [{"type": "text", ...}]}`; errors come back
+as text in that same shape rather than as raised exceptions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -88,9 +88,9 @@ async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
 
     try:
         # recorder.get_statistics is the supported way in. It is declared
-        # SupportsResponse.ONLY and keys its response by statistic ID, the same
-        # shape statistics_during_period returns, with start and end already
-        # rendered as ISO strings rather than epoch floats.
+        # SupportsResponse.ONLY and wraps its payload in a "statistics" key,
+        # under which rows are keyed by statistic ID. start and end arrive as
+        # ISO strings where statistics_during_period returned epoch floats.
         stats = await hass.services.async_call(
             "recorder",
             "get_statistics",
@@ -105,7 +105,7 @@ async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
             return_response=True,
         )
 
-        entity_stats = (stats or {}).get(entity_id, [])
+        entity_stats = (stats or {}).get("statistics", {}).get(entity_id, [])
         result = []
         for stat in entity_stats:
             entry = {}

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -19,6 +19,10 @@ from . import (
 _LOGGER = logging.getLogger(__name__)
 
 _VALID_PERIODS = {"5minute", "hour", "day", "week", "month"}
+
+# Row keys asked of recorder.get_statistics. The service requires the list
+# explicitly; get_statistics shapes the rows down to these plus start and end.
+_STATISTIC_TYPES = ["mean", "min", "max", "sum", "state"]
 _VALID_STATISTIC_TYPES = {"mean", "sum"}
 
 # clear_statistics posts a job to the recorder's queue and does not block; we wait
@@ -63,9 +67,6 @@ _CLEAR_STATISTICS_TIMEOUT = 10
 )
 async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any]:
     """Fetch long-term statistics for an entity."""
-    from homeassistant.components.recorder import get_instance
-    from homeassistant.components.recorder.statistics import statistics_during_period
-
     entity_id = arguments["entity_id"]
     start_time = dt.fromisoformat(arguments["start_time"])
     end_time_str = arguments.get("end_time")
@@ -86,18 +87,25 @@ async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
         }
 
     try:
-        stats = await get_instance(hass).async_add_executor_job(
-            statistics_during_period,
-            hass,
-            start_time,
-            end_time,
-            {entity_id},
-            period,
-            None,
-            {"mean", "min", "max", "sum", "state"},
+        # recorder.get_statistics is the supported way in. It is declared
+        # SupportsResponse.ONLY and keys its response by statistic ID, the same
+        # shape statistics_during_period returns, with start and end already
+        # rendered as ISO strings rather than epoch floats.
+        stats = await hass.services.async_call(
+            "recorder",
+            "get_statistics",
+            {
+                "start_time": start_time,
+                "end_time": end_time,
+                "statistic_ids": [entity_id],
+                "period": period,
+                "types": _STATISTIC_TYPES,
+            },
+            blocking=True,
+            return_response=True,
         )
 
-        entity_stats = stats.get(entity_id, [])
+        entity_stats = (stats or {}).get(entity_id, [])
         result = []
         for stat in entity_stats:
             entry = {}

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "MCP Server (HTTP Transport)",
+  "homeassistant": "2025.6.0",
   "render_readme": true,
   "zip_release": true,
   "filename": "mcp_server_http_transport.zip"

--- a/tests/test_ha_api_contracts.py
+++ b/tests/test_ha_api_contracts.py
@@ -12,15 +12,22 @@ alternative; the docstrings say which, and what to do when one breaks.
 
 import dataclasses
 import inspect
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.components.calendar.const import DATA_COMPONENT, LIST_EVENT_FIELDS
 from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.services import (
+    SERVICE_GET_STATISTICS,
+    _async_handle_get_statistics_service,
+)
 from homeassistant.components.recorder.statistics import (
     list_statistic_ids,
     validate_statistics,
 )
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.recorder import DATA_INSTANCE
 
 
 def _params(func) -> list[str]:
@@ -78,12 +85,73 @@ class TestCalendarContracts:
         assert not {"uid", "rrule", "recurrence_id"} & LIST_EVENT_FIELDS
 
 
+class TestRecorderGetStatisticsService:
+    """Contracts for the public service get_statistics reads through.
+
+    A service is supported API, but its response shape is still an assumption
+    this repo makes, and mocking the service in a tool test only asserts the
+    shape the tool already believes in. These drive the real handler.
+    """
+
+    def test_service_exists(self):
+        """The service get_statistics calls.
+
+        Added in HA 2025.6, which is why hacs.json declares that as the minimum
+        and the CI matrix starts there. On anything older this import fails and
+        the tool would answer ServiceNotFound for every query.
+        """
+        assert SERVICE_GET_STATISTICS == "get_statistics"
+
+    async def test_response_wraps_rows_under_a_statistics_key(self):
+        """The response is {"statistics": {statistic_id: [rows]}}.
+
+        get_statistics reads through that envelope. Without it the lookup
+        misses silently and the tool reports no data rather than failing.
+        """
+        rows = {"sensor.energy": [{"start": 1704067200.0, "end": 1704070800.0, "mean": 1.5}]}
+        hass = Mock()
+        hass.data = {DATA_INSTANCE: Mock(async_add_executor_job=AsyncMock(return_value=rows))}
+        call = Mock(
+            hass=hass,
+            data={
+                "start_time": datetime(2024, 1, 1, tzinfo=UTC),
+                "statistic_ids": ["sensor.energy"],
+                "period": "hour",
+                "types": ["mean"],
+            },
+        )
+
+        response = await _async_handle_get_statistics_service(call)
+
+        assert set(response) == {"statistics"}
+        assert list(response["statistics"]) == ["sensor.energy"]
+        assert response["statistics"]["sensor.energy"][0]["mean"] == 1.5
+
+    async def test_response_renders_start_and_end_as_iso_strings(self):
+        """get_statistics passes start and end through to the caller verbatim."""
+        rows = {"sensor.energy": [{"start": 1704067200.0, "end": 1704070800.0, "mean": 1.5}]}
+        hass = Mock()
+        hass.data = {DATA_INSTANCE: Mock(async_add_executor_job=AsyncMock(return_value=rows))}
+        call = Mock(
+            hass=hass,
+            data={
+                "start_time": datetime(2024, 1, 1, tzinfo=UTC),
+                "statistic_ids": ["sensor.energy"],
+                "period": "hour",
+                "types": ["mean"],
+            },
+        )
+
+        row = (await _async_handle_get_statistics_service(call))["statistics"]["sensor.energy"][0]
+
+        assert row["start"] == "2024-01-01T00:00:00+00:00"
+        assert row["end"] == "2024-01-01T01:00:00+00:00"
+
+
 class TestRecorderContracts:
     """Contracts for tools/statistics.py.
 
-    get_statistics needs nothing here: it goes through the public
-    recorder.get_statistics service. The recorder exposes no service
-    equivalent for the four below.
+    The recorder exposes no service equivalent for the four below.
     """
 
     def test_list_statistic_ids_signature(self):

--- a/tests/test_ha_api_contracts.py
+++ b/tests/test_ha_api_contracts.py
@@ -1,0 +1,105 @@
+"""Contracts against Home Assistant internals the tools still depend on.
+
+Home Assistant's supported boundary between integrations is the service layer
+and the state machine. Where a tool reaches past it, the call carries no
+compatibility promise and can change without a deprecation cycle, which would
+break on a user's HA upgrade rather than here. These tests pin each remaining
+assumption so that upgrade fails CI instead.
+
+Every contract below is either unavoidable or cheaper than its public
+alternative; the docstrings say which, and what to do when one breaks.
+"""
+
+import dataclasses
+import inspect
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.components.calendar.const import DATA_COMPONENT, LIST_EVENT_FIELDS
+from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder.statistics import (
+    list_statistic_ids,
+    validate_statistics,
+)
+from homeassistant.helpers.entity_component import EntityComponent
+
+
+def _params(func) -> list[str]:
+    return list(inspect.signature(func).parameters)
+
+
+class TestCalendarContracts:
+    """Contracts for tools/calendar.py."""
+
+    def test_async_get_events_signature(self):
+        """The calendar tools call entity.async_get_events(hass, start, end).
+
+        This is the CalendarEntity platform contract, not another integration's
+        internals: the base class declares it and every calendar integration
+        implements it. Home Assistant's own REST view and its own
+        calendar.get_events service both call it exactly this way.
+        """
+        assert _params(CalendarEntity.async_get_events) == [
+            "self",
+            "hass",
+            "start_date",
+            "end_date",
+        ]
+
+    def test_calendar_event_carries_serialized_fields(self):
+        """_serialize_event reads these off CalendarEvent."""
+        fields = {f.name for f in dataclasses.fields(CalendarEvent)}
+        assert {"start", "end", "summary", "description", "uid", "recurrence_id", "rrule"} <= fields
+        for prop in ("start_datetime_local", "end_datetime_local", "all_day"):
+            assert isinstance(getattr(CalendarEvent, prop), property)
+
+    def test_entity_lookup_surface(self):
+        """_get_calendar_entity resolves the entity via hass.data[DATA_COMPONENT].
+
+        The genuinely unsupported step, and the one to replace first if a
+        supported entity lookup ever appears. Home Assistant's own
+        CalendarEventView resolves entities the same way.
+        """
+        assert DATA_COMPONENT is not None
+        assert hasattr(EntityComponent, "get_entity")
+
+    def test_get_events_service_still_drops_the_fields_we_need(self):
+        """calendar.get_events is not a substitute for async_get_events.
+
+        The service filters every event through LIST_EVENT_FIELDS, which drops
+        uid, rrule and recurrence_id. list_calendar_events dedupes on uid and
+        reports rrule/recurrence_id; delete_calendar_events matches on uid and
+        passes it to async_delete_event, so it cannot work without one.
+
+        If this test fails because the set grew, the swap in issue #78 has
+        become possible: move both tools onto the service and delete the
+        DATA_COMPONENT lookup above.
+        """
+        assert LIST_EVENT_FIELDS == {"start", "end", "summary", "description", "location"}
+        assert not {"uid", "rrule", "recurrence_id"} & LIST_EVENT_FIELDS
+
+
+class TestRecorderContracts:
+    """Contracts for tools/statistics.py.
+
+    get_statistics needs nothing here: it goes through the public
+    recorder.get_statistics service. The recorder exposes no service
+    equivalent for the four below.
+    """
+
+    def test_list_statistic_ids_signature(self):
+        assert _params(list_statistic_ids) == ["hass", "statistic_ids", "statistic_type"]
+
+    def test_validate_statistics_signature(self):
+        assert _params(validate_statistics) == ["hass"]
+
+    def test_async_adjust_statistics_signature(self):
+        assert _params(Recorder.async_adjust_statistics) == [
+            "self",
+            "statistic_id",
+            "start_time",
+            "sum_adjustment",
+            "adjustment_unit",
+        ]
+
+    def test_async_clear_statistics_signature(self):
+        assert _params(Recorder.async_clear_statistics) == ["self", "statistic_ids", "on_done"]

--- a/tests/test_supported_versions.py
+++ b/tests/test_supported_versions.py
@@ -1,0 +1,39 @@
+"""The declared minimum Home Assistant version has to be one CI actually builds.
+
+A floor in hacs.json is a promise to users on that release. Nothing enforces it at
+install time beyond HACS refusing older versions, so if the matrix stops covering
+it the promise is untested and breaks on someone's instance rather than here.
+"""
+
+import json
+import pathlib
+
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+
+def _version(value: str) -> tuple[int, ...]:
+    return tuple(int(part) for part in value.split("."))
+
+
+def _matrix_ha_versions() -> list[str]:
+    workflow = yaml.safe_load((REPO_ROOT / ".github/workflows/main.yml").read_text())
+    legs = workflow["jobs"]["integration-test"]["strategy"]["matrix"]["include"]
+    return [leg["ha-version"] for leg in legs]
+
+
+def test_declared_minimum_is_the_oldest_version_tested():
+    """hacs.json's floor and the oldest integration leg must be the same release.
+
+    Raise both together, or add a matrix leg for the older one. The current floor
+    is 2025.6.0 because recorder.get_statistics, which tools/statistics.py reads
+    through, landed in that release and raises ServiceNotFound before it.
+    """
+    declared = json.loads((REPO_ROOT / "hacs.json").read_text())["homeassistant"]
+    oldest = min(_matrix_ha_versions(), key=_version)
+
+    assert _version(declared) == _version(oldest), (
+        f"hacs.json declares {declared} as the minimum but the oldest tested "
+        f"version is {oldest}, so nothing verifies the version we claim to support"
+    )

--- a/tests/test_tools_statistics.py
+++ b/tests/test_tools_statistics.py
@@ -36,22 +36,22 @@ class TestToolsStatistics:
         mock_stats = {
             "sensor.energy": [
                 {
-                    "start": "2024-01-01T00:00:00",
+                    "start": "2024-01-01T00:00:00+00:00",
+                    "end": "2024-01-01T01:00:00+00:00",
                     "mean": 100.5,
                     "min": 90.0,
                     "max": 110.0,
                 },
                 {
-                    "start": "2024-01-01T01:00:00",
+                    "start": "2024-01-01T01:00:00+00:00",
+                    "end": "2024-01-01T02:00:00+00:00",
                     "mean": 105.0,
                     "min": 95.0,
                     "max": 115.0,
                 },
             ]
         }
-
-        mock_recorder = Mock()
-        mock_recorder.async_add_executor_job = AsyncMock(return_value=mock_stats)
+        mock_hass.services.async_call = AsyncMock(return_value=mock_stats)
 
         request = Mock()
         request.headers = {"Authorization": "Bearer valid_token"}
@@ -70,13 +70,7 @@ class TestToolsStatistics:
             }
         )
 
-        with (
-            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
-            patch(
-                "homeassistant.components.recorder.get_instance",
-                return_value=mock_recorder,
-            ),
-        ):
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
             response = await view.post(request)
 
         assert response.status == 200
@@ -84,6 +78,15 @@ class TestToolsStatistics:
         data = json.loads(body["result"]["content"][0]["text"])
         assert len(data) == 2
         assert data[0]["mean"] == 100.5
+        assert data[0]["start"] == "2024-01-01T00:00:00+00:00"
+
+        domain, service, service_data = mock_hass.services.async_call.call_args.args
+        kwargs = mock_hass.services.async_call.call_args.kwargs
+        assert (domain, service) == ("recorder", "get_statistics")
+        assert service_data["statistic_ids"] == ["sensor.energy"]
+        assert service_data["period"] == "hour"
+        assert set(service_data["types"]) == {"mean", "min", "max", "sum", "state"}
+        assert kwargs == {"blocking": True, "return_response": True}
 
     async def test_post_tools_call_get_statistics_invalid_period(self, view, mock_hass):
         """Test POST with tools/call for get_statistics with invalid period."""
@@ -114,9 +117,12 @@ class TestToolsStatistics:
         assert "Invalid period" in text
 
     async def test_post_tools_call_get_statistics_error(self, view, mock_hass):
-        """Test get_statistics when recorder raises."""
-        mock_recorder = Mock()
-        mock_recorder.async_add_executor_job = AsyncMock(side_effect=Exception("Recorder error"))
+        """Test get_statistics when the recorder service raises.
+
+        Covers the recorder not being loaded at all, which surfaces as
+        ServiceNotFound from async_call rather than a KeyError on the instance.
+        """
+        mock_hass.services.async_call = AsyncMock(side_effect=Exception("Recorder error"))
 
         request = Mock()
         request.headers = {"Authorization": "Bearer valid_token"}
@@ -135,13 +141,7 @@ class TestToolsStatistics:
             }
         )
 
-        with (
-            patch.object(view, "_validate_token", return_value={"sub": "user123"}),
-            patch(
-                "homeassistant.components.recorder.get_instance",
-                return_value=mock_recorder,
-            ),
-        ):
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
             response = await view.post(request)
 
         assert response.status == 200

--- a/tests/test_tools_statistics.py
+++ b/tests/test_tools_statistics.py
@@ -51,7 +51,8 @@ class TestToolsStatistics:
                 },
             ]
         }
-        mock_hass.services.async_call = AsyncMock(return_value=mock_stats)
+        # recorder.get_statistics wraps its payload under a "statistics" key.
+        mock_hass.services.async_call = AsyncMock(return_value={"statistics": mock_stats})
 
         request = Mock()
         request.headers = {"Authorization": "Bearer valid_token"}


### PR DESCRIPTION
Closes #78.

`get_statistics` now goes through the public `recorder.get_statistics` service instead of importing `statistics_during_period` out of the recorder. That removes the seven-positional-argument call the issue singled out, which would have broken silently on a user's HA upgrade rather than failing in CI here. The service wraps its payload as `{"statistics": {statistic_id: [rows]}}` rather than keying rows by ID directly, so the tool reads through that envelope; the row filtering on the other side of it is unchanged.

Two things a reviewer should weigh. The service renders `start` and `end` as ISO strings where the private call returned epoch floats, so the tool's output changes shape. And the service arrived in HA 2025.6, so this raises the supported minimum: `hacs.json` now declares `"homeassistant": "2025.6.0"` and the CI matrix drops its 2025.4.4 leg. On older versions the call raises `ServiceNotFound` where the private import worked, so that floor is load-bearing rather than cosmetic.

### The calendar half is deliberately not done

The issue grouped `entity.async_get_events()` with the recorder import as two instances of the same problem. They are not the same thing, and this is the part worth a close look.

`async_get_events` is declared on the `CalendarEntity` base class as `raise NotImplementedError`. It is the entity platform contract every calendar integration implements, in the same category as `async_turn_on` on a light. Home Assistant's own REST view and its own `calendar.get_events` service are both thin wrappers that call `entity.async_get_events(hass, start, end)` the way these tools do.

The service is also strictly less capable than the method it wraps. `async_get_events_service` filters every event through `LIST_EVENT_FIELDS`, which is `{start, end, summary, description, location}`, so `uid`, `rrule` and `recurrence_id` never reach the caller. `list_calendar_events` dedupes on `uid` and reports the other two; `delete_calendar_events` matches on `uid` and passes it to `async_delete_event`, so it cannot work at all without one. Swapping would regress both tools to get a worse compatibility story.

The one genuinely unsupported step in `calendar.py` is the `hass.data[DATA_COMPONENT]` entity lookup, and Home Assistant's own `CalendarEventView` resolves entities the same way. There is no supported alternative to move to.

### What replaces it

`tests/test_ha_api_contracts.py` pins every remaining reach past the integration boundary: the calendar entity method and the `CalendarEvent` fields `_serialize_event` reads, the `DATA_COMPONENT` lookup, and the four recorder functions with no service equivalent (`list_statistic_ids`, `validate_statistics`, `async_adjust_statistics`, `async_clear_statistics`). An HA release that changes any of them now fails CI here instead of silently on someone's upgrade, which was the actual risk in the issue and one that applies just as much to the calls that cannot be replaced.

The calendar contract asserts `LIST_EVENT_FIELDS` still excludes the three fields, so if upstream ever widens it, CI reports that the swap has become possible rather than the idea being lost.

`AGENTS.md` writes down the distinction between an entity platform contract, a cross-integration import and a `hass.data` lookup, plus the check to run before trading a private call for a service. `CLAUDE.md` is a one-line `@AGENTS.md` import, since Claude Code reads only the latter name and the guidance should not be tied to one assistant.
