### PR TITLE
fix: return graceful errors for failing tool calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,5 +51,21 @@ when core changes underneath it.
 ## Conventions
 
 Black and Ruff at line length 100, both enforced in CI. Tools register through
-`@register_tool` and return `{"content": [{"type": "text", ...}]}`; errors come back
-as text in that same shape rather than as raised exceptions.
+`@register_tool` and return `{"content": [{"type": "text", ...}]}`; a failure a
+handler anticipates comes back as text in that same shape rather than as a raised
+exception.
+
+`call_tool` owns the two things a handler does not have to. It rejects a call the
+caller got wrong — an unknown name, a non-object `arguments`, a declared-required
+property that is absent or null — by raising `InvalidToolRequest`, which the
+transport reports as JSON-RPC `-32602`; a handler therefore never has to defend
+against a missing required key. Anything a handler raises that it did not expect
+is caught and returned as a result with `isError: true`, so a single failing tool
+cannot take down the JSON-RPC response.
+
+Two consequences worth knowing before you write a tool. Listing a property in
+`required` means the handler is guaranteed it, so any guidance the handler wants
+to give about that property being absent is unreachable — put the reason in the
+property's schema `description`, which the `-32602` message quotes back. And
+`isError` is currently set only by that wrapper, so a handler-caught failure still
+returns a success-shaped result whose text happens to describe an error.

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -12,7 +12,7 @@ from .completions import complete
 from .const import DOMAIN
 from .prompts import get_prompt, get_prompts
 from .resources import get_resources, read_resource
-from .tools import InvalidToolArguments, call_tool, get_tool_schemas
+from .tools import InvalidToolRequest, call_tool, get_tool_schemas
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,6 +38,15 @@ def _service_unavailable() -> web.Response:
         },
         status=503,
     )
+
+
+def _jsonrpc_error(code: int, message: str, msg_id: Any = None) -> dict[str, Any]:
+    """Build a JSON-RPC error response object."""
+    return {
+        "jsonrpc": "2.0",
+        "error": {"code": code, "message": message},
+        "id": msg_id,
+    }
 
 
 def _get_issuer(request: web.Request) -> str | None:
@@ -222,19 +231,14 @@ class MCPEndpointView(HomeAssistantView):
             return self._unauthorized(request)
 
         try:
-            # Parse JSON-RPC message
+            # Parse JSON-RPC message. Only decoding failures belong here —
+            # aiohttp's own exceptions (an oversized body, a client that hung
+            # up mid-read) carry the right status already and must propagate.
             body = await request.json()
-        except Exception as e:
+        except (ValueError, UnicodeDecodeError) as e:
             _LOGGER.error("Could not parse MCP request body: %s", e)
             return web.json_response(
-                {
-                    "jsonrpc": "2.0",
-                    "error": {
-                        "code": -32700,
-                        "message": f"Parse error: {str(e)}",
-                    },
-                    "id": None,
-                },
+                _jsonrpc_error(-32700, f"Parse error: {str(e)}"),
                 status=400,
             )
 
@@ -257,14 +261,11 @@ class MCPEndpointView(HomeAssistantView):
             # Under a non-2xx status intermediary proxies substitute their own
             # error page and the client never sees what actually went wrong.
             return web.json_response(
-                {
-                    "jsonrpc": "2.0",
-                    "error": {
-                        "code": -32603,
-                        "message": f"Internal error: {str(e)}",
-                    },
-                    "id": body.get("id") if isinstance(body, dict) else None,
-                },
+                _jsonrpc_error(
+                    -32603,
+                    f"Internal error: {str(e)}",
+                    body.get("id") if isinstance(body, dict) else None,
+                )
             )
 
     async def _handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
@@ -308,15 +309,8 @@ class MCPEndpointView(HomeAssistantView):
 
             try:
                 result = await self._call_tool(name, arguments)
-            except InvalidToolArguments as err:
-                return {
-                    "jsonrpc": "2.0",
-                    "error": {
-                        "code": -32602,
-                        "message": str(err),
-                    },
-                    "id": msg_id,
-                }
+            except InvalidToolRequest as err:
+                return _jsonrpc_error(-32602, str(err), msg_id)
 
             return {
                 "jsonrpc": "2.0",
@@ -376,14 +370,7 @@ class MCPEndpointView(HomeAssistantView):
 
         # Unknown method
         if msg_id is not None:
-            return {
-                "jsonrpc": "2.0",
-                "error": {
-                    "code": -32601,
-                    "message": f"Method not found: {method}",
-                },
-                "id": msg_id,
-            }
+            return _jsonrpc_error(-32601, f"Method not found: {method}", msg_id)
 
         return None
 

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -12,7 +12,7 @@ from .completions import complete
 from .const import DOMAIN
 from .prompts import get_prompt, get_prompts
 from .resources import get_resources, read_resource
-from .tools import call_tool, get_tool_schemas
+from .tools import InvalidToolArguments, call_tool, get_tool_schemas
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -221,12 +221,26 @@ class MCPEndpointView(HomeAssistantView):
         if not token_payload:
             return self._unauthorized(request)
 
-        body = None
         try:
             # Parse JSON-RPC message
             body = await request.json()
-            _LOGGER.debug("Received MCP request: %s", body)
+        except Exception as e:
+            _LOGGER.error("Could not parse MCP request body: %s", e)
+            return web.json_response(
+                {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32700,
+                        "message": f"Parse error: {str(e)}",
+                    },
+                    "id": None,
+                },
+                status=400,
+            )
 
+        _LOGGER.debug("Received MCP request: %s", body)
+
+        try:
             # Process the message directly
             response_data = await self._handle_message(body)
 
@@ -239,6 +253,9 @@ class MCPEndpointView(HomeAssistantView):
 
         except Exception as e:
             _LOGGER.error("Error handling MCP request: %s", e, exc_info=True)
+            # A JSON-RPC error is a complete response, so it ships with 200.
+            # Under a non-2xx status intermediary proxies substitute their own
+            # error page and the client never sees what actually went wrong.
             return web.json_response(
                 {
                     "jsonrpc": "2.0",
@@ -248,7 +265,6 @@ class MCPEndpointView(HomeAssistantView):
                     },
                     "id": body.get("id") if isinstance(body, dict) else None,
                 },
-                status=500,
             )
 
     async def _handle_message(self, message: dict[str, Any]) -> dict[str, Any] | None:
@@ -290,7 +306,18 @@ class MCPEndpointView(HomeAssistantView):
             name = params.get("name")
             arguments = params.get("arguments", {})
 
-            result = await self._call_tool(name, arguments)
+            try:
+                result = await self._call_tool(name, arguments)
+            except InvalidToolArguments as err:
+                return {
+                    "jsonrpc": "2.0",
+                    "error": {
+                        "code": -32602,
+                        "message": str(err),
+                    },
+                    "id": msg_id,
+                }
+
             return {
                 "jsonrpc": "2.0",
                 "result": result,

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -1,13 +1,21 @@
 """MCP tool definitions and handlers for Home Assistant."""
 
+import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
 from ..json_utils import _HAJSONEncoder  # noqa: F401
 
+_LOGGER = logging.getLogger(__name__)
+
 # Tool registry: name -> {"schema": {...}, "handler": callable}
 TOOLS: dict[str, dict[str, Any]] = {}
+
+
+class InvalidToolArguments(Exception):
+    """Arguments do not satisfy the tool's declared input schema."""
+
 
 # Reusable MCP ToolAnnotations (see spec §ToolAnnotations).
 ANNOTATION_READ_ONLY: dict[str, Any] = {
@@ -67,12 +75,48 @@ def get_tool_schemas() -> list[dict[str, Any]]:
     return [tool["schema"] for tool in TOOLS.values()]
 
 
+def _missing_required(schema: dict[str, Any], arguments: dict[str, Any]) -> list[str]:
+    """Return the required properties the arguments do not supply."""
+    required = schema.get("inputSchema", {}).get("required", [])
+    return [key for key in required if key not in arguments]
+
+
 async def call_tool(hass: HomeAssistant, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
-    """Call a tool by name."""
+    """Call a tool by name.
+
+    Arguments are checked against the tool's declared required properties before
+    dispatch, so a client working from a stale copy of the tool list gets a named
+    invalid-params error. A handler that raises anything else becomes an isError
+    tool result, which keeps one failing call from turning the whole JSON-RPC
+    response into a transport-level failure.
+    """
     tool = TOOLS.get(name)
     if tool is None:
         raise ValueError(f"Unknown tool: {name}")
-    return await tool["handler"](hass, arguments)
+
+    if not isinstance(arguments, dict):
+        arguments = {}
+
+    missing = _missing_required(tool["schema"], arguments)
+    if missing:
+        noun = "properties" if len(missing) > 1 else "property"
+        raise InvalidToolArguments(
+            f"Missing required {noun} for tool '{name}': {', '.join(missing)}"
+        )
+
+    try:
+        return await tool["handler"](hass, arguments)
+    except Exception as err:  # noqa: BLE001 - surfaced to the client as isError
+        _LOGGER.exception("Tool %s raised an unhandled exception", name)
+        return {
+            "content": [
+                {
+                    "type": "text",
+                    "text": f"Tool '{name}' failed: {type(err).__name__}: {err}",
+                }
+            ],
+            "isError": True,
+        }
 
 
 # Import submodules so tools auto-register via @register_tool

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -13,7 +13,15 @@ _LOGGER = logging.getLogger(__name__)
 TOOLS: dict[str, dict[str, Any]] = {}
 
 
-class InvalidToolArguments(Exception):
+class InvalidToolRequest(Exception):
+    """The call cannot be dispatched as made, and the caller is the one to fix it."""
+
+
+class UnknownTool(InvalidToolRequest):
+    """No tool is registered under the requested name."""
+
+
+class InvalidToolArguments(InvalidToolRequest):
     """Arguments do not satisfy the tool's declared input schema."""
 
 
@@ -76,9 +84,29 @@ def get_tool_schemas() -> list[dict[str, Any]]:
 
 
 def _missing_required(schema: dict[str, Any], arguments: dict[str, Any]) -> list[str]:
-    """Return the required properties the arguments do not supply."""
+    """Return the required properties the arguments do not supply.
+
+    An explicit null counts as absent. A client drifting from the advertised
+    schema sends one as readily as it omits the key, and either way the handler
+    has no value to work with.
+    """
     required = schema.get("inputSchema", {}).get("required", [])
-    return [key for key in required if key not in arguments]
+    return [key for key in required if arguments.get(key) is None]
+
+
+def _describe_missing(schema: dict[str, Any], missing: list[str]) -> str:
+    """Name each missing property alongside its description from the schema.
+
+    The description is what carries the reason a property exists — that confirm
+    gates an irreversible delete, say — so a caller that never read the schema
+    still gets told why the call was rejected.
+    """
+    properties = schema.get("inputSchema", {}).get("properties", {})
+    parts = []
+    for key in missing:
+        description = properties.get(key, {}).get("description")
+        parts.append(f"{key} ({description})" if description else key)
+    return ", ".join(parts)
 
 
 async def call_tool(hass: HomeAssistant, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -89,19 +117,25 @@ async def call_tool(hass: HomeAssistant, name: str, arguments: dict[str, Any]) -
     invalid-params error. A handler that raises anything else becomes an isError
     tool result, which keeps one failing call from turning the whole JSON-RPC
     response into a transport-level failure.
+
+    Anything the caller got wrong — an unknown name, a non-object arguments, a
+    missing required property — raises InvalidToolRequest rather than reaching a
+    handler, so a malformed call can never run a tool's default behavior.
     """
     tool = TOOLS.get(name)
     if tool is None:
-        raise ValueError(f"Unknown tool: {name}")
+        raise UnknownTool(f"Unknown tool: {name}")
 
     if not isinstance(arguments, dict):
-        arguments = {}
+        got = type(arguments).__name__
+        raise InvalidToolArguments(f"Arguments for tool '{name}' must be a JSON object, got {got}")
 
     missing = _missing_required(tool["schema"], arguments)
     if missing:
         noun = "properties" if len(missing) > 1 else "property"
         raise InvalidToolArguments(
-            f"Missing required {noun} for tool '{name}': {', '.join(missing)}"
+            f"Missing required {noun} for tool '{name}': "
+            f"{_describe_missing(tool['schema'], missing)}"
         )
 
     try:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from custom_components.oidc_provider.token_validator import get_issuer_from_request
 
+from custom_components.mcp_server_http_transport.const import DOMAIN
 from custom_components.mcp_server_http_transport.http import (
     MCPEndpointView,
     MCPProtectedResourceMetadataView,
@@ -165,26 +166,30 @@ class TestMCPSubpathProtectedResourceMetadataView:
         assert response.status == 404
 
 
+@pytest.fixture
+def mock_server():
+    """Create a mock MCP server."""
+    return Mock()
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance with the integration loaded."""
+    hass = Mock()
+    hass.states = Mock()
+    hass.services = Mock()
+    hass.data = {DOMAIN: {"entry_id": Mock()}}
+    return hass
+
+
+@pytest.fixture
+def view(mock_hass, mock_server):
+    """Create an MCPEndpointView instance."""
+    return MCPEndpointView(mock_hass, mock_server)
+
+
 class TestMCPEndpointView:
     """Test the MCP endpoint view: auth, routing, and error handling."""
-
-    @pytest.fixture
-    def mock_server(self):
-        """Create a mock MCP server."""
-        return Mock()
-
-    @pytest.fixture
-    def mock_hass(self):
-        """Create a mock Home Assistant instance."""
-        hass = Mock()
-        hass.states = Mock()
-        hass.services = Mock()
-        return hass
-
-    @pytest.fixture
-    def view(self, mock_hass, mock_server):
-        """Create an MCPEndpointView instance."""
-        return MCPEndpointView(mock_hass, mock_server)
 
     async def test_post_without_token_returns_401(self, view):
         """Test POST without Authorization header returns 401."""
@@ -380,25 +385,19 @@ class TestMCPEndpointView:
 
         assert response.status == 200
         body = json.loads(response.body)
-        assert "error" in body
+        assert body["error"]["code"] == -32602
         assert "Unknown tool" in body["error"]["message"]
 
 
 class TestToolErrorHandling:
-    """Regression for #82: a failing tool must not break the HTTP response.
+    """Regression for #82: a failing tool call still answers with a usable body.
 
     A client working from a cached copy of an older tool list keeps sending the
-    argument shape it last saw. That used to reach the handler unchecked, raise,
-    and leave the transport answering with a non-2xx status that proxies replace
-    with their own error page.
+    argument shape it last saw, so the transport has to name what is wrong. A
+    JSON-RPC error is a complete response and ships at 200, because under a
+    non-2xx an intermediary proxy substitutes its own error page and the client
+    never sees the body.
     """
-
-    @pytest.fixture
-    def view(self):
-        hass = Mock()
-        hass.states = Mock()
-        hass.services = Mock()
-        return MCPEndpointView(hass, Mock())
 
     async def _call(self, view, name, arguments, msg_id=1):
         request = Mock()
@@ -442,11 +441,61 @@ class TestToolErrorHandling:
         assert "entity_id" in body["error"]["message"]
         assert "start_time" in body["error"]["message"]
 
-    async def test_null_arguments_are_treated_as_empty(self, view):
-        response, body = await self._call(view, "get_statistics", None)
+    async def test_explicit_null_counts_as_a_missing_property(self, view):
+        """Drift sends a null as readily as it drops the key; both are invalid."""
+        response, body = await self._call(
+            view,
+            "get_statistics",
+            {"entity_id": None, "start_time": None},
+        )
 
         assert response.status == 200
         assert body["error"]["code"] == -32602
+        assert "entity_id" in body["error"]["message"]
+        assert "start_time" in body["error"]["message"]
+
+    async def test_non_dict_arguments_are_rejected(self, view):
+        response, body = await self._call(view, "get_statistics", ["sensor.example"])
+
+        assert response.status == 200
+        assert body["error"]["code"] == -32602
+        assert "must be a JSON object" in body["error"]["message"]
+
+    async def test_non_dict_arguments_never_reach_a_tool_with_no_required_properties(self, view):
+        """restore_config_backup requires nothing, so a coerced {} would restore a backup."""
+        called = False
+
+        async def handler(hass, arguments):
+            nonlocal called
+            called = True
+            return {"content": []}
+
+        entry = TOOLS["restore_config_backup"]
+        with patch.dict(
+            TOOLS,
+            {"restore_config_backup": {"schema": entry["schema"], "handler": handler}},
+        ):
+            response, body = await self._call(view, "restore_config_backup", "2026-01-01")
+
+        assert called is False
+        assert body["error"]["code"] == -32602
+        assert "must be a JSON object" in body["error"]["message"]
+
+    async def test_missing_confirm_reports_why_it_is_required(self, view):
+        """The -32602 carries the schema description, so the safety reason survives."""
+        response, body = await self._call(
+            view, "clear_statistics", {"statistic_ids": ["sensor.energy"]}
+        )
+
+        assert body["error"]["code"] == -32602
+        assert "confirm" in body["error"]["message"]
+        assert "irreversible" in body["error"]["message"]
+
+    async def test_unknown_tool_is_a_caller_error(self, view):
+        response, body = await self._call(view, "get_statistcs", {})
+
+        assert body["error"]["code"] == -32602
+        assert "Unknown tool" in body["error"]["message"]
 
     async def test_unhandled_handler_exception_becomes_is_error_result(self, view):
         """An exception the handler does not catch is reported inside the result."""

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -13,6 +13,7 @@ from custom_components.mcp_server_http_transport.http import (
     _get_issuer,
     _get_protected_resource_metadata,
 )
+from custom_components.mcp_server_http_transport.tools import TOOLS
 
 
 def test_get_base_url_with_forwarded_headers():
@@ -377,10 +378,110 @@ class TestMCPEndpointView:
         with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
             response = await view.post(request)
 
-        assert response.status == 500
+        assert response.status == 200
         body = json.loads(response.body)
         assert "error" in body
         assert "Unknown tool" in body["error"]["message"]
+
+
+class TestToolErrorHandling:
+    """Regression for #82: a failing tool must not break the HTTP response.
+
+    A client working from a cached copy of an older tool list keeps sending the
+    argument shape it last saw. That used to reach the handler unchecked, raise,
+    and leave the transport answering with a non-2xx status that proxies replace
+    with their own error page.
+    """
+
+    @pytest.fixture
+    def view(self):
+        hass = Mock()
+        hass.states = Mock()
+        hass.services = Mock()
+        return MCPEndpointView(hass, Mock())
+
+    async def _call(self, view, name, arguments, msg_id=1):
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(
+            return_value={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+                "id": msg_id,
+            }
+        )
+        request.url.origin.return_value = "https://homeassistant.local"
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        return response, json.loads(response.body)
+
+    async def test_missing_required_argument_returns_invalid_params(self, view):
+        """A stale-schema call names the property it left out."""
+        response, body = await self._call(
+            view,
+            "get_statistics",
+            {
+                "statistic_ids": ["sensor.example"],
+                "start_time": "2026-08-17T00:00:00",
+                "period": "hour",
+            },
+        )
+
+        assert response.status == 200
+        assert body["error"]["code"] == -32602
+        assert "entity_id" in body["error"]["message"]
+        assert body["id"] == 1
+
+    async def test_missing_arguments_lists_every_required_property(self, view):
+        response, body = await self._call(view, "get_statistics", {})
+
+        assert body["error"]["code"] == -32602
+        assert "entity_id" in body["error"]["message"]
+        assert "start_time" in body["error"]["message"]
+
+    async def test_null_arguments_are_treated_as_empty(self, view):
+        response, body = await self._call(view, "get_statistics", None)
+
+        assert response.status == 200
+        assert body["error"]["code"] == -32602
+
+    async def test_unhandled_handler_exception_becomes_is_error_result(self, view):
+        """An exception the handler does not catch is reported inside the result."""
+
+        async def boom(hass, arguments):
+            raise RuntimeError("recorder exploded")
+
+        with patch.dict(
+            TOOLS,
+            {"get_statistics": {"schema": TOOLS["get_statistics"]["schema"], "handler": boom}},
+        ):
+            response, body = await self._call(
+                view,
+                "get_statistics",
+                {"entity_id": "sensor.example", "start_time": "2026-08-17T00:00:00"},
+            )
+
+        assert response.status == 200
+        assert "error" not in body
+        assert body["result"]["isError"] is True
+        assert "recorder exploded" in body["result"]["content"][0]["text"]
+        assert body["id"] == 1
+
+    async def test_unparseable_body_returns_parse_error(self, view):
+        request = Mock()
+        request.headers = {"Authorization": "Bearer valid_token"}
+        request.json = AsyncMock(side_effect=ValueError("not json"))
+        request.url.origin.return_value = "https://homeassistant.local"
+
+        with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
+            response = await view.post(request)
+
+        assert response.status == 400
+        body = json.loads(response.body)
+        assert body["error"]["code"] == -32700
 
 
 class TestIntegrationDisabledGate:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -772,7 +772,7 @@ class TestMCPClientSession:
 
         assert response.status == 200
         body = json.loads(response.body)
-        assert body["error"]["code"] == -32603
+        assert body["error"]["code"] == -32602
         assert "Unknown tool" in body["error"]["message"]
 
     async def test_unknown_method_returns_proper_jsonrpc_error(self, view):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -770,7 +770,7 @@ class TestMCPClientSession:
         with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
             response = await view.post(request)
 
-        assert response.status == 500
+        assert response.status == 200
         body = json.loads(response.body)
         assert body["error"]["code"] == -32603
         assert "Unknown tool" in body["error"]["message"]

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -206,7 +206,7 @@ class TestPrompts:
         with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
             response = await view.post(request)
 
-        assert response.status == 500
+        assert response.status == 200
         body = json.loads(response.body)
         assert "Unknown prompt" in body["error"]["message"]
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -180,7 +180,7 @@ class TestResources:
         with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
             response = await view.post(request)
 
-        assert response.status == 500
+        assert response.status == 200
         body = json.loads(response.body)
         assert "error" in body
         assert "not found" in body["error"]["message"]
@@ -202,7 +202,7 @@ class TestResources:
         with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
             response = await view.post(request)
 
-        assert response.status == 500
+        assert response.status == 200
         body = json.loads(response.body)
         assert "error" in body
         assert "Unknown resource" in body["error"]["message"]

--- a/tests/test_tools_system_admin.py
+++ b/tests/test_tools_system_admin.py
@@ -161,7 +161,7 @@ class TestToolsSystemAdmin:
         assert "confirm=true" in text
 
     async def test_post_tools_call_restart_ha_missing_confirm(self, view, mock_hass):
-        """Test POST with tools/call for restart_ha without confirm argument."""
+        """restart_ha declares confirm required, so omitting it is invalid params."""
         request = Mock()
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(
@@ -181,8 +181,8 @@ class TestToolsSystemAdmin:
 
         assert response.status == 200
         body = json.loads(response.body)
-        text = body["result"]["content"][0]["text"]
-        assert "confirm=true" in text
+        assert body["error"]["code"] == -32602
+        assert "confirm" in body["error"]["message"]
 
     async def test_post_tools_call_get_system_status(self, view, mock_hass):
         """Test POST with tools/call for get_system_status."""


### PR DESCRIPTION
Fixes #82.

A tool handler that raised an unhandled exception took the whole JSON-RPC response with it. The only catch sat in the aiohttp view, which turned any failure into a `-32603` internal error at HTTP 500. Intermediary proxies treat an origin 5xx as a transport failure and substitute their own error page, so the reporter saw a generic Cloudflare 502 and the real cause was only visible in the server log. The response body was well-formed, so the status code is the part that actually broke the client.

`call_tool` now owns the two things a handler shouldn't have to. A call the caller got wrong — an unknown name, a non-object `arguments`, a declared-required property that is absent or explicitly null — raises `InvalidToolRequest` before any handler runs, and the transport reports it as JSON-RPC `-32602`. Anything a handler raises that it did not expect is caught and returned as a result with `isError: true`. That covers the class of bug rather than one handler: there are 81 direct `arguments["..."]` accesses across 12 tool modules, and any of them could previously reach the client as a 502.

Rejecting a non-object `arguments` rather than coercing it to `{}` is the load-bearing part. `restore_config_backup`, `cleanup_config_backups` and `batch_edit_config_files` declare no required properties, so a list or string `arguments` would have passed validation and run the handler's default action — restoring the newest backup over the live config directory, or deleting every snapshot older than 30 days.

The `-32602` message quotes each missing property's schema `description`. Listing a property in `required` makes any handler guidance about its absence unreachable, which matters for the confirm gates: `clear_statistics` explains that the deletion cannot be undone, and that warning is the whole reason the gate exists, so it now travels with the error instead of being lost.

JSON-RPC errors for a well-formed message ship at HTTP 200, since the error object is itself a complete response and only survives the trip to the client under a 2xx. An unparseable body is a genuinely bad request and stays non-2xx, as `-32700` at 400 — and that handler is narrowed to decoding failures, so aiohttp's own exceptions (an oversized body, a client that hung up mid-read) keep their correct status instead of being relabelled as parse errors.

Known gap, called out in AGENTS.md rather than fixed here: `isError` is set only by the new wrapper. The ~58 failures that handlers catch themselves still return success-shaped results whose text happens to describe an error. Flagging those properly touches every tool module and belongs in its own change.
