### PR TITLE
fix: serve MCP on a path core's mcp_server cannot claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The MCP server uses OAuth 2.0 Dynamic Client Registration (DCR), which allows Cl
    - Click Settings (gear icon)
    - Navigate to "Connectors"
    - Click "Add custom connector"
-   - Enter your MCP server URL: `https://your-home-assistant.com/api/mcp`
+   - Enter your MCP server URL: `https://your-home-assistant.com/api/mcp`, or `https://your-home-assistant.com/api/mcp_http` if Home Assistant's built-in MCP Server integration is also installed (see [Another integration also serves /api/mcp](#another-integration-also-serves-apimcp))
    - Click "Connect"
 
 2. Claude will automatically:
@@ -89,7 +89,27 @@ For local agents or MCP clients that can't run an OAuth browser flow, you can au
 
 1. Enable native authentication: Settings > Devices & Services > MCP Server > Configure > check "Enable native Home Assistant authentication"
 2. Create a token: go to your Home Assistant user profile > Long-Lived Access Tokens > Create Token
-3. Configure your MCP client to send the token as a Bearer header to `http://your-home-assistant:8123/api/mcp`
+3. Configure your MCP client to send the token as a Bearer header to `http://your-home-assistant:8123/api/mcp` (or `/api/mcp_http`, see [Another integration also serves /api/mcp](#another-integration-also-serves-apimcp))
+
+## Troubleshooting
+
+### Another integration also serves /api/mcp
+
+Home Assistant's built-in **Model Context Protocol Server** integration (`mcp_server`) serves its streamable HTTP transport on `/api/mcp`, the same path this integration uses. It has done so since Home Assistant 2025.11.
+
+Home Assistant cannot share a path between two integrations: whichever registered it first at startup answers every request there, and the other is silently unreachable on that path. Nothing is logged, both integrations keep showing as healthy, and an MCP client connects successfully to whichever server won, so the only visible symptom is the client getting the wrong set of tools.
+
+This integration therefore also answers on **`/api/mcp_http`**, which nothing else claims. If `/api/mcp` is already taken when this integration starts, it stays off that path entirely and serves only `/api/mcp_http`. Either way it raises a repair naming the conflict. Point your MCP client at `https://your-home-assistant/api/mcp_http`.
+
+To tell whether the built-in server holds `/api/mcp` on a running instance, probe a path only that server registers:
+
+```bash
+curl -o /dev/null -w '%{http_code}\n' https://your-home-assistant/api/mcp/assist
+```
+
+`405` means the built-in server is live (on Home Assistant 2026.8 and newer, which added these per-API paths); `404` means it is not. The `401` challenge on `/api/mcp` itself tells you nothing, because both servers use the same realm.
+
+Deleting the built-in integration's config entry does not release the path on its own: Home Assistant binds HTTP routes at startup and cannot unbind them, so restart afterwards.
 
 ## MCP Capabilities
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,11 @@ Home Assistant cannot share a path between two integrations: whichever registere
 
 This integration therefore also answers on **`/api/mcp_http`**, which nothing else claims. If `/api/mcp` is already taken when this integration starts, it stays off that path entirely and serves only `/api/mcp_http`. Either way it raises a repair naming the conflict. Point your MCP client at `https://your-home-assistant/api/mcp_http`.
 
-To tell whether the built-in server holds `/api/mcp` on a running instance, probe a path only that server registers:
+The repair is the reliable signal, and it is raised on every version. Failing that, look for **Model Context Protocol Server** under Settings > Devices & Services. A `405` from the probe below confirms it as well, but only from 2026.8 onwards, which is when the built-in server added its per-API paths; on 2025.11 to 2026.7 the probe returns `404` while the conflict is real, so a `404` proves nothing on its own. The `401` challenge on `/api/mcp` is no help either, because both servers use the same realm.
 
 ```bash
 curl -o /dev/null -w '%{http_code}\n' https://your-home-assistant/api/mcp/assist
 ```
-
-`405` means the built-in server is live (on Home Assistant 2026.8 and newer, which added these per-API paths); `404` means it is not. The `401` challenge on `/api/mcp` itself tells you nothing, because both servers use the same realm.
 
 Deleting the built-in integration's config entry does not release the path on its own: Home Assistant binds HTTP routes at startup and cannot unbind them, so restart afterwards.
 

--- a/custom_components/mcp_server_http_transport/__init__.py
+++ b/custom_components/mcp_server_http_transport/__init__.py
@@ -3,8 +3,10 @@
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.start import async_at_started
 from mcp.server import Server
 
 from .const import (
@@ -13,12 +15,11 @@ from .const import (
     CONF_IMAGE_FILE_ACCESS,
     CONF_NATIVE_AUTH,
     DOMAIN,
+    ISSUE_ENDPOINT_CONFLICT,
+    MCP_HTTP_PATH,
+    MCP_PATH,
 )
-from .http import (
-    MCPEndpointView,
-    MCPProtectedResourceMetadataView,
-    MCPSubpathProtectedResourceMetadataView,
-)
+from .http import mcp_path_is_contested, register_mcp_views
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,14 +52,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register HTTP endpoints. The views are gated on hass.data[DOMAIN] so
     # requests stop being served the moment async_unload_entry clears it
     # (HA has no public register_view reverse — see #37).
-    hass.http.register_view(MCPProtectedResourceMetadataView(hass))
-    hass.http.register_view(MCPSubpathProtectedResourceMetadataView(hass))
-    hass.http.register_view(MCPEndpointView(hass, server, native_auth_enabled))
+    contested = register_mcp_views(hass, server, native_auth_enabled)
 
-    _LOGGER.info("MCP Server initialized at /api/mcp (native_auth=%s)", native_auth_enabled)
+    _LOGGER.info(
+        "MCP Server initialized at %s (native_auth=%s)",
+        MCP_HTTP_PATH if contested else f"{MCP_PATH} and {MCP_HTTP_PATH}",
+        native_auth_enabled,
+    )
 
+    # Another integration can claim MCP_PATH after this one has set up, so the
+    # conflict is reported once Home Assistant has started rather than here.
+    entry.async_on_unload(async_at_started(hass, _async_report_endpoint_conflict))
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
+
+
+@callback
+def _async_report_endpoint_conflict(hass: HomeAssistant) -> None:
+    """Raise a repair issue while another integration also serves MCP_PATH."""
+    if not mcp_path_is_contested(hass):
+        ir.async_delete_issue(hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT)
+        return
+
+    _LOGGER.warning(
+        "Another integration also serves POST %s. Home Assistant routes that path to "
+        "whichever integration registered it first, so point MCP clients at %s, which "
+        "only this integration serves",
+        MCP_PATH,
+        MCP_HTTP_PATH,
+    )
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        ISSUE_ENDPOINT_CONFLICT,
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key=ISSUE_ENDPOINT_CONFLICT,
+        translation_placeholders={"path": MCP_PATH, "dedicated_path": MCP_HTTP_PATH},
+        learn_more_url=(
+            "https://github.com/ganhammar/hass-mcp-server" "#another-integration-also-serves-apimcp"
+        ),
+    )
 
 
 async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -69,4 +103,5 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     hass.data[DOMAIN].clear()
+    ir.async_delete_issue(hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT)
     return True

--- a/custom_components/mcp_server_http_transport/__init__.py
+++ b/custom_components/mcp_server_http_transport/__init__.py
@@ -67,7 +67,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         An integration claims its paths from its own async_setup, so one that
         loads after this entry, at boot or when the user adds it, would
-        otherwise take MCP_PATH with nothing said until the next restart.
+        otherwise take MCP_PATH with nothing said until the next restart. The
+        event fires per component rather than per config entry, so a second
+        entry for a domain that is already loaded goes unseen; nothing that
+        registers HTTP views does that today.
         """
         _async_report_endpoint_conflict(hass)
 

--- a/custom_components/mcp_server_http_transport/__init__.py
+++ b/custom_components/mcp_server_http_transport/__init__.py
@@ -3,7 +3,8 @@
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import EVENT_COMPONENT_LOADED
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.start import async_at_started
@@ -19,7 +20,7 @@ from .const import (
     MCP_HTTP_PATH,
     MCP_PATH,
 )
-from .http import mcp_path_is_contested, register_mcp_views
+from .http import mcp_path_is_contested, register_mcp_views, serves_mcp_path
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,35 +53,50 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register HTTP endpoints. The views are gated on hass.data[DOMAIN] so
     # requests stop being served the moment async_unload_entry clears it
     # (HA has no public register_view reverse — see #37).
-    contested = register_mcp_views(hass, server, native_auth_enabled)
+    register_mcp_views(hass, server, native_auth_enabled)
 
     _LOGGER.info(
         "MCP Server initialized at %s (native_auth=%s)",
-        MCP_HTTP_PATH if contested else f"{MCP_PATH} and {MCP_HTTP_PATH}",
+        f"{MCP_PATH} and {MCP_HTTP_PATH}" if serves_mcp_path(hass) else MCP_HTTP_PATH,
         native_auth_enabled,
     )
 
-    # Another integration can claim MCP_PATH after this one has set up, so the
-    # conflict is reported once Home Assistant has started rather than here.
+    @callback
+    def _async_component_loaded(event: Event) -> None:
+        """Re-check after any component loads.
+
+        An integration claims its paths from its own async_setup, so one that
+        loads after this entry, at boot or when the user adds it, would
+        otherwise take MCP_PATH with nothing said until the next restart.
+        """
+        _async_report_endpoint_conflict(hass)
+
     entry.async_on_unload(async_at_started(hass, _async_report_endpoint_conflict))
+    entry.async_on_unload(hass.bus.async_listen(EVENT_COMPONENT_LOADED, _async_component_loaded))
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     return True
 
 
 @callback
 def _async_report_endpoint_conflict(hass: HomeAssistant) -> None:
-    """Raise a repair issue while another integration also serves MCP_PATH."""
+    """Raise a repair issue while another integration also has MCP_PATH bound.
+
+    Safe to call repeatedly: the issue is the state of the conflict, and the
+    warning goes out only when the conflict is newly seen.
+    """
     if not mcp_path_is_contested(hass):
         ir.async_delete_issue(hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT)
         return
 
-    _LOGGER.warning(
-        "Another integration also serves POST %s. Home Assistant routes that path to "
-        "whichever integration registered it first, so point MCP clients at %s, which "
-        "only this integration serves",
-        MCP_PATH,
-        MCP_HTTP_PATH,
-    )
+    if ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_ENDPOINT_CONFLICT) is None:
+        _LOGGER.warning(
+            "Another integration also has POST %s bound. Home Assistant routes that path "
+            "to whichever integration registered it first, so point MCP clients at %s, "
+            "which only this integration serves",
+            MCP_PATH,
+            MCP_HTTP_PATH,
+        )
+
     ir.async_create_issue(
         hass,
         DOMAIN,
@@ -101,7 +117,11 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
+    """Unload a config entry.
+
+    Any conflict issue stays up: the routes registered for this entry keep
+    MCP_PATH bound (answering 503) until Home Assistant restarts, so unloading
+    makes the conflict worse rather than resolving it.
+    """
     hass.data[DOMAIN].clear()
-    ir.async_delete_issue(hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT)
     return True

--- a/custom_components/mcp_server_http_transport/const.py
+++ b/custom_components/mcp_server_http_transport/const.py
@@ -13,3 +13,14 @@ CONF_NATIVE_AUTH = "native_auth_enabled"
 CONF_CONFIG_FILE_ACCESS = "config_file_access_enabled"
 CONF_CAMERA_IMAGE_ACCESS = "camera_image_access_enabled"
 CONF_IMAGE_FILE_ACCESS = "image_file_access_enabled"
+
+# HTTP paths. Home Assistant's built-in mcp_server integration serves its
+# streamable transport on /api/mcp from 2025.11 onwards, and aiohttp resolves a
+# duplicated path to whichever integration registered it first, silently. This
+# integration therefore also answers on a path nothing else claims.
+MCP_PATH = "/api/mcp"
+MCP_HTTP_PATH = "/api/mcp_http"
+RESOURCE_METADATA_PREFIX = "/.well-known/oauth-protected-resource"
+
+# Repairs issue raised while another integration also serves MCP_PATH.
+ISSUE_ENDPOINT_CONFLICT = "endpoint_conflict"

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any
 
-from aiohttp import web
+from aiohttp import hdrs, web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant
 from mcp.server import Server
@@ -21,10 +21,12 @@ from .tools import InvalidToolRequest, call_tool, get_tool_schemas
 
 _LOGGER = logging.getLogger(__name__)
 
-# hass.data key holding the routes this integration registered. It sits outside
-# hass.data[DOMAIN] on purpose: async_unload_entry clears that, while the routes
-# themselves survive until Home Assistant restarts.
+# hass.data keys holding the routes this integration registered and the endpoint
+# view serving them. They sit outside hass.data[DOMAIN] on purpose:
+# async_unload_entry clears that, while routes stay bound until Home Assistant
+# restarts and a reload has to find the view the router already holds.
 REGISTERED_ROUTES = f"{DOMAIN}_routes"
+REGISTERED_ENDPOINT = f"{DOMAIN}_endpoint_view"
 
 
 def _resource_path(request_path: str) -> str:
@@ -38,25 +40,37 @@ def _resource_path(request_path: str) -> str:
 
 
 def _mcp_post_routes(hass: HomeAssistant) -> list[web.AbstractRoute]:
-    """Return every POST route on MCP_PATH, in registration order.
+    """Return every route answering a POST to MCP_PATH, in registration order.
 
     aiohttp walks same-path resources linearly and hands the request to the
     first one that has the method, so the head of this list is what a client
-    POSTing to MCP_PATH actually reaches.
+    POSTing to MCP_PATH actually reaches. A wildcard route carries METH_ANY
+    rather than a method name and answers POST just the same.
     """
     return [
         route
         for route in hass.http.app.router.routes()
-        if route.method == "POST"
+        if route.method in (hdrs.METH_POST, hdrs.METH_ANY)
         and (resource := route.resource) is not None
         and resource.canonical == MCP_PATH
     ]
 
 
 def mcp_path_is_contested(hass: HomeAssistant) -> bool:
-    """Return True when an integration other than this one serves POST MCP_PATH."""
+    """Return True when an integration other than this one has MCP_PATH bound."""
     ours = hass.data.get(REGISTERED_ROUTES, set())
     return any(route not in ours for route in _mcp_post_routes(hass))
+
+
+def serves_mcp_path(hass: HomeAssistant) -> bool:
+    """Return True when a POST to MCP_PATH reaches this integration.
+
+    Only the head of the list matters, and it can be a route from an earlier
+    load: routes cannot be unregistered, so the view that claimed MCP_PATH
+    before a competitor appeared keeps answering there until a restart.
+    """
+    routes = _mcp_post_routes(hass)
+    return bool(routes) and routes[0] in hass.data.get(REGISTERED_ROUTES, set())
 
 
 def _integration_loaded(hass: HomeAssistant) -> bool:
@@ -103,9 +117,7 @@ def _get_issuer(request: web.Request) -> str | None:
         return None
 
 
-def _get_protected_resource_metadata(
-    base_url: str, resource_path: str = MCP_PATH
-) -> dict[str, Any]:
+def _get_protected_resource_metadata(base_url: str, resource_path: str) -> dict[str, Any]:
     """Generate OAuth 2.0 Protected Resource Metadata (RFC 9728)."""
     resource = f"{base_url}{resource_path}"
     return {
@@ -129,13 +141,18 @@ class MCPProtectedResourceMetadataView(HomeAssistantView):
         self.hass = hass
 
     async def get(self, request: web.Request) -> web.Response:
-        """Return protected resource metadata."""
+        """Return protected resource metadata for MCP_PATH.
+
+        The root path carries no endpoint of its own, and Home Assistant's auth
+        component serves its own metadata here on the versions that have one, so
+        this answers only where nothing else does.
+        """
         if not _integration_loaded(self.hass):
             return _service_unavailable()
         base_url = _get_issuer(request)
         if base_url is None:
             return web.json_response({"error": "OIDC provider not available"}, status=404)
-        metadata = _get_protected_resource_metadata(base_url)
+        metadata = _get_protected_resource_metadata(base_url, MCP_PATH)
         return web.json_response(metadata)
 
 
@@ -147,9 +164,11 @@ class MCPSubpathProtectedResourceMetadataView(HomeAssistantView):
     name = "api:mcp:metadata:mcp"
     requires_auth = False
 
-    def __init__(self, hass: HomeAssistant) -> None:
-        """Initialize the metadata view."""
+    def __init__(self, hass: HomeAssistant, paths: list[str] | None = None) -> None:
+        """Initialize the metadata view, optionally narrowing the paths served."""
         self.hass = hass
+        if paths is not None:
+            self.url, self.extra_urls = paths[0], list(paths[1:])
 
     async def get(self, request: web.Request) -> web.Response:
         """Return protected resource metadata for the endpoint the path names."""
@@ -171,12 +190,18 @@ class MCPEndpointView(HomeAssistantView):
     requires_auth = False
 
     def __init__(
-        self, hass: HomeAssistant, server: Server, native_auth_enabled: bool = False
+        self,
+        hass: HomeAssistant,
+        server: Server,
+        native_auth_enabled: bool = False,
+        paths: list[str] | None = None,
     ) -> None:
-        """Initialize the MCP endpoint."""
+        """Initialize the MCP endpoint, optionally narrowing the paths served."""
         self.hass = hass
         self.server = server
         self.native_auth_enabled = native_auth_enabled
+        if paths is not None:
+            self.url, self.extra_urls = paths[0], list(paths[1:])
 
     async def _validate_token(self, request: web.Request) -> dict[str, Any] | None:
         """Validate the bearer token via OIDC (if available) then native HA auth."""
@@ -433,27 +458,36 @@ class MCPEndpointView(HomeAssistantView):
 
 
 def register_mcp_views(hass: HomeAssistant, server: Server, native_auth_enabled: bool) -> bool:
-    """Register the HTTP views and report whether MCP_PATH was already claimed.
+    """Register the HTTP views and report whether MCP_PATH is claimed elsewhere.
 
-    MCP_PATH is skipped when something else already serves POST there.
-    Home Assistant's built-in mcp_server registers no GET on it, so taking the
-    path half-way would answer a client's discovery probe from this integration
-    while its actual traffic went elsewhere. MCP_HTTP_PATH is always served.
+    MCP_PATH is skipped, endpoint and metadata alike, when something else
+    already has it bound. Home Assistant's built-in mcp_server registers no GET
+    on the endpoint and no metadata at all, so serving either half would answer
+    a client's discovery from this integration while its actual traffic went
+    elsewhere, sending it to this integration's authorization server for a token
+    the other one will reject. MCP_HTTP_PATH is always served.
+
+    A reload updates the view the router already holds instead of registering a
+    second one, which would sit behind the first and never be reached.
     """
-    router = hass.http.app.router
     contested = mcp_path_is_contested(hass)
 
-    endpoint = MCPEndpointView(hass, server, native_auth_enabled)
-    if contested:
-        endpoint.url = MCP_HTTP_PATH
-        endpoint.extra_urls = []
+    if (endpoint := hass.data.get(REGISTERED_ENDPOINT)) is not None:
+        endpoint.server = server
+        endpoint.native_auth_enabled = native_auth_enabled
+        return contested
 
+    endpoint_paths = [MCP_HTTP_PATH] if contested else [MCP_PATH, MCP_HTTP_PATH]
+    endpoint = MCPEndpointView(hass, server, native_auth_enabled, paths=endpoint_paths)
+    metadata_paths = [f"{RESOURCE_METADATA_PREFIX}{path}" for path in endpoint_paths]
+
+    router = hass.http.app.router
     before = set(router.routes())
     hass.http.register_view(MCPProtectedResourceMetadataView(hass))
-    hass.http.register_view(MCPSubpathProtectedResourceMetadataView(hass))
+    hass.http.register_view(MCPSubpathProtectedResourceMetadataView(hass, paths=metadata_paths))
     hass.http.register_view(endpoint)
 
-    ours = hass.data.setdefault(REGISTERED_ROUTES, set())
-    ours.update(route for route in router.routes() if route not in before)
+    hass.data[REGISTERED_ROUTES] = {route for route in router.routes() if route not in before}
+    hass.data[REGISTERED_ENDPOINT] = endpoint
 
     return contested

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -141,18 +141,24 @@ class MCPProtectedResourceMetadataView(HomeAssistantView):
         self.hass = hass
 
     async def get(self, request: web.Request) -> web.Response:
-        """Return protected resource metadata for MCP_PATH.
+        """Return protected resource metadata for the endpoint this server holds.
 
-        The root path carries no endpoint of its own, and Home Assistant's auth
-        component serves its own metadata here on the versions that have one, so
-        this answers only where nothing else does.
+        The root path names no endpoint of its own, and a client falls back to it
+        when the path-suffixed form 404s, so it has to describe a path this
+        integration actually answers: naming a contested MCP_PATH would send the
+        client here for a token the integration holding that path rejects.
+
+        Home Assistant's auth component serves its own metadata here on the
+        versions that have a root view, and wins the route by registering first,
+        so this answers only where nothing else does.
         """
         if not _integration_loaded(self.hass):
             return _service_unavailable()
         base_url = _get_issuer(request)
         if base_url is None:
             return web.json_response({"error": "OIDC provider not available"}, status=404)
-        metadata = _get_protected_resource_metadata(base_url, MCP_PATH)
+        resource_path = MCP_PATH if serves_mcp_path(self.hass) else MCP_HTTP_PATH
+        metadata = _get_protected_resource_metadata(base_url, resource_path)
         return web.json_response(metadata)
 
 
@@ -457,8 +463,8 @@ class MCPEndpointView(HomeAssistantView):
         return await call_tool(self.hass, name, arguments)
 
 
-def register_mcp_views(hass: HomeAssistant, server: Server, native_auth_enabled: bool) -> bool:
-    """Register the HTTP views and report whether MCP_PATH is claimed elsewhere.
+def register_mcp_views(hass: HomeAssistant, server: Server, native_auth_enabled: bool) -> None:
+    """Register the HTTP views this integration serves.
 
     MCP_PATH is skipped, endpoint and metadata alike, when something else
     already has it bound. Home Assistant's built-in mcp_server registers no GET
@@ -470,13 +476,12 @@ def register_mcp_views(hass: HomeAssistant, server: Server, native_auth_enabled:
     A reload updates the view the router already holds instead of registering a
     second one, which would sit behind the first and never be reached.
     """
-    contested = mcp_path_is_contested(hass)
-
     if (endpoint := hass.data.get(REGISTERED_ENDPOINT)) is not None:
         endpoint.server = server
         endpoint.native_auth_enabled = native_auth_enabled
-        return contested
+        return
 
+    contested = mcp_path_is_contested(hass)
     endpoint_paths = [MCP_HTTP_PATH] if contested else [MCP_PATH, MCP_HTTP_PATH]
     endpoint = MCPEndpointView(hass, server, native_auth_enabled, paths=endpoint_paths)
     metadata_paths = [f"{RESOURCE_METADATA_PREFIX}{path}" for path in endpoint_paths]
@@ -489,5 +494,3 @@ def register_mcp_views(hass: HomeAssistant, server: Server, native_auth_enabled:
 
     hass.data[REGISTERED_ROUTES] = {route for route in router.routes() if route not in before}
     hass.data[REGISTERED_ENDPOINT] = endpoint
-
-    return contested

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -9,12 +9,54 @@ from homeassistant.core import HomeAssistant
 from mcp.server import Server
 
 from .completions import complete
-from .const import DOMAIN
+from .const import (
+    DOMAIN,
+    MCP_HTTP_PATH,
+    MCP_PATH,
+    RESOURCE_METADATA_PREFIX,
+)
 from .prompts import get_prompt, get_prompts
 from .resources import get_resources, read_resource
 from .tools import InvalidToolRequest, call_tool, get_tool_schemas
 
 _LOGGER = logging.getLogger(__name__)
+
+# hass.data key holding the routes this integration registered. It sits outside
+# hass.data[DOMAIN] on purpose: async_unload_entry clears that, while the routes
+# themselves survive until Home Assistant restarts.
+REGISTERED_ROUTES = f"{DOMAIN}_routes"
+
+
+def _resource_path(request_path: str) -> str:
+    """Return which MCP endpoint a request is about.
+
+    The RFC 9728 metadata path is the endpoint path suffixed onto the well-known
+    prefix, so one suffix test covers both /api/mcp_http and
+    /.well-known/oauth-protected-resource/api/mcp_http.
+    """
+    return MCP_HTTP_PATH if request_path.endswith(MCP_HTTP_PATH) else MCP_PATH
+
+
+def _mcp_post_routes(hass: HomeAssistant) -> list[web.AbstractRoute]:
+    """Return every POST route on MCP_PATH, in registration order.
+
+    aiohttp walks same-path resources linearly and hands the request to the
+    first one that has the method, so the head of this list is what a client
+    POSTing to MCP_PATH actually reaches.
+    """
+    return [
+        route
+        for route in hass.http.app.router.routes()
+        if route.method == "POST"
+        and (resource := route.resource) is not None
+        and resource.canonical == MCP_PATH
+    ]
+
+
+def mcp_path_is_contested(hass: HomeAssistant) -> bool:
+    """Return True when an integration other than this one serves POST MCP_PATH."""
+    ours = hass.data.get(REGISTERED_ROUTES, set())
+    return any(route not in ours for route in _mcp_post_routes(hass))
 
 
 def _integration_loaded(hass: HomeAssistant) -> bool:
@@ -61,14 +103,17 @@ def _get_issuer(request: web.Request) -> str | None:
         return None
 
 
-def _get_protected_resource_metadata(base_url: str) -> dict[str, Any]:
+def _get_protected_resource_metadata(
+    base_url: str, resource_path: str = MCP_PATH
+) -> dict[str, Any]:
     """Generate OAuth 2.0 Protected Resource Metadata (RFC 9728)."""
+    resource = f"{base_url}{resource_path}"
     return {
-        "resource": f"{base_url}/api/mcp",
+        "resource": resource,
         "authorization_servers": [f"{base_url}/oidc"],
         "bearer_methods_supported": ["header"],
         "resource_signing_alg_values_supported": ["RS256"],
-        "resource_documentation": f"{base_url}/api/mcp",
+        "resource_documentation": resource,
     }
 
 
@@ -95,9 +140,10 @@ class MCPProtectedResourceMetadataView(HomeAssistantView):
 
 
 class MCPSubpathProtectedResourceMetadataView(HomeAssistantView):
-    """OAuth 2.0 Protected Resource Metadata endpoint (RFC 9728) with /mcp suffix."""
+    """OAuth 2.0 Protected Resource Metadata (RFC 9728) for each endpoint path."""
 
-    url = "/.well-known/oauth-protected-resource/api/mcp"
+    url = f"{RESOURCE_METADATA_PREFIX}{MCP_PATH}"
+    extra_urls = [f"{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}"]
     name = "api:mcp:metadata:mcp"
     requires_auth = False
 
@@ -106,20 +152,21 @@ class MCPSubpathProtectedResourceMetadataView(HomeAssistantView):
         self.hass = hass
 
     async def get(self, request: web.Request) -> web.Response:
-        """Return protected resource metadata with /mcp suffix."""
+        """Return protected resource metadata for the endpoint the path names."""
         if not _integration_loaded(self.hass):
             return _service_unavailable()
         base_url = _get_issuer(request)
         if base_url is None:
             return web.json_response({"error": "OIDC provider not available"}, status=404)
-        metadata = _get_protected_resource_metadata(base_url)
+        metadata = _get_protected_resource_metadata(base_url, _resource_path(request.path))
         return web.json_response(metadata)
 
 
 class MCPEndpointView(HomeAssistantView):
     """MCP HTTP endpoint view."""
 
-    url = "/api/mcp"
+    url = MCP_PATH
+    extra_urls = [MCP_HTTP_PATH]
     name = "api:mcp"
     requires_auth = False
 
@@ -150,7 +197,7 @@ class MCPEndpointView(HomeAssistantView):
             # This MCP server is the protected resource (RFC 8707); its canonical
             # URI is the resource a compliant client (e.g. Claude) binds the token
             # to. Require the token's aud to match it.
-            expected_audience = f"{expected_issuer}/api/mcp"
+            expected_audience = f"{expected_issuer}{_resource_path(request.path)}"
             try:
                 result = validate_access_token(
                     self.hass, token, expected_issuer, expected_audience=expected_audience
@@ -182,7 +229,9 @@ class MCPEndpointView(HomeAssistantView):
         """
         base_url = _get_issuer(request)
         if base_url is not None:
-            resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource/api/mcp"
+            resource_metadata_url = (
+                f"{base_url}{RESOURCE_METADATA_PREFIX}{_resource_path(request.path)}"
+            )
             www_authenticate = (
                 f'Bearer realm="MCP Server",' f' resource_metadata="{resource_metadata_url}"'
             )
@@ -381,3 +430,30 @@ class MCPEndpointView(HomeAssistantView):
     async def _call_tool(self, name: str, arguments: dict[str, Any]) -> dict[str, Any]:
         """Call a tool by name."""
         return await call_tool(self.hass, name, arguments)
+
+
+def register_mcp_views(hass: HomeAssistant, server: Server, native_auth_enabled: bool) -> bool:
+    """Register the HTTP views and report whether MCP_PATH was already claimed.
+
+    MCP_PATH is skipped when something else already serves POST there.
+    Home Assistant's built-in mcp_server registers no GET on it, so taking the
+    path half-way would answer a client's discovery probe from this integration
+    while its actual traffic went elsewhere. MCP_HTTP_PATH is always served.
+    """
+    router = hass.http.app.router
+    contested = mcp_path_is_contested(hass)
+
+    endpoint = MCPEndpointView(hass, server, native_auth_enabled)
+    if contested:
+        endpoint.url = MCP_HTTP_PATH
+        endpoint.extra_urls = []
+
+    before = set(router.routes())
+    hass.http.register_view(MCPProtectedResourceMetadataView(hass))
+    hass.http.register_view(MCPSubpathProtectedResourceMetadataView(hass))
+    hass.http.register_view(endpoint)
+
+    ours = hass.data.setdefault(REGISTERED_ROUTES, set())
+    ours.update(route for route in router.routes() if route not in before)
+
+    return contested

--- a/custom_components/mcp_server_http_transport/strings.json
+++ b/custom_components/mcp_server_http_transport/strings.json
@@ -45,5 +45,11 @@
     "error": {
       "oidc_provider_required": "The OIDC Provider integration is required when native authentication is disabled. Install it or keep native authentication enabled."
     }
+  },
+  "issues": {
+    "endpoint_conflict": {
+      "title": "Another integration also serves {path}",
+      "description": "Home Assistant's built-in **Model Context Protocol Server** integration registers the same `{path}` endpoint as this integration. Only one of them can serve it: whichever registered first when Home Assistant started answers every request there, and the other is silently unreachable on that path.\n\nThis integration always answers on `{dedicated_path}`, which nothing else claims. Point your MCP client at `{dedicated_path}` (for example `https://your-home-assistant:8123{dedicated_path}`).\n\nTo free up `{path}` instead, remove one of the two integrations and restart Home Assistant. Deleting the config entry on its own is not enough, because Home Assistant keeps HTTP routes until it restarts."
+    }
   }
 }

--- a/custom_components/mcp_server_http_transport/translations/en.json
+++ b/custom_components/mcp_server_http_transport/translations/en.json
@@ -45,5 +45,11 @@
     "error": {
       "oidc_provider_required": "The OIDC Provider integration is required when native authentication is disabled. Install it or keep native authentication enabled."
     }
+  },
+  "issues": {
+    "endpoint_conflict": {
+      "title": "Another integration also serves {path}",
+      "description": "Home Assistant's built-in **Model Context Protocol Server** integration registers the same `{path}` endpoint as this integration. Only one of them can serve it: whichever registered first when Home Assistant started answers every request there, and the other is silently unreachable on that path.\n\nThis integration always answers on `{dedicated_path}`, which nothing else claims. Point your MCP client at `{dedicated_path}` (for example `https://your-home-assistant:8123{dedicated_path}`).\n\nTo free up `{path}` instead, remove one of the two integrations and restart Home Assistant. Deleting the config entry on its own is not enough, because Home Assistant keeps HTTP routes until it restarts."
+    }
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,6 +48,9 @@ def mock_hass():
     hass.config.entries.async_domains = Mock(return_value=["oidc_provider"])
     hass.http = Mock()
     hass.http.register_view = Mock()
+    # register_mcp_views reads the router to see who else serves /api/mcp; an
+    # empty router stands for an instance where nothing else does.
+    hass.http.app.router.routes = Mock(return_value=[])
     return hass
 
 

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -153,17 +153,15 @@ class TestAsyncUnloadEntry:
         assert len(mock_hass.data[DOMAIN]) == 0
 
     @patch("custom_components.mcp_server_http_transport.ir")
-    async def test_async_unload_entry_drops_the_conflict_issue(
+    async def test_async_unload_entry_keeps_the_conflict_issue(
         self, mock_ir, mock_hass, mock_config_entry
     ):
-        """An unloaded integration no longer conflicts with anything."""
+        """Unloading binds nothing back: the routes hold the path until a restart."""
         mock_hass.data[DOMAIN] = {"server": Mock()}
 
         await async_unload_entry(mock_hass, mock_config_entry)
 
-        mock_ir.async_delete_issue.assert_called_once_with(
-            mock_hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT
-        )
+        mock_ir.async_delete_issue.assert_not_called()
 
 
 class TestEndpointConflictIssue:
@@ -173,6 +171,8 @@ class TestEndpointConflictIssue:
     @patch("custom_components.mcp_server_http_transport.mcp_path_is_contested", return_value=True)
     def test_conflict_raises_issue(self, mock_contested, mock_ir, mock_hass):
         """A contested path raises a repair naming both paths."""
+        mock_ir.async_get.return_value.async_get_issue.return_value = None
+
         _async_report_endpoint_conflict(mock_hass)
 
         mock_ir.async_create_issue.assert_called_once()
@@ -189,10 +189,24 @@ class TestEndpointConflictIssue:
     @patch("custom_components.mcp_server_http_transport.ir")
     @patch("custom_components.mcp_server_http_transport.mcp_path_is_contested", return_value=False)
     def test_no_conflict_clears_issue(self, mock_contested, mock_ir, mock_hass):
-        """An uncontested path clears any issue left from an earlier run."""
+        """An uncontested path clears any issue left from an earlier check."""
         _async_report_endpoint_conflict(mock_hass)
 
         mock_ir.async_create_issue.assert_not_called()
         mock_ir.async_delete_issue.assert_called_once_with(
             mock_hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT
         )
+
+    @patch("custom_components.mcp_server_http_transport.ir")
+    @patch("custom_components.mcp_server_http_transport.mcp_path_is_contested", return_value=True)
+    def test_repeated_checks_warn_once(self, mock_contested, mock_ir, mock_hass, caplog):
+        """The check runs on every component load, so only a new conflict warns."""
+        mock_ir.async_get.return_value.async_get_issue.return_value = None
+        _async_report_endpoint_conflict(mock_hass)
+
+        mock_ir.async_get.return_value.async_get_issue.return_value = Mock()
+        caplog.clear()
+        _async_report_endpoint_conflict(mock_hass)
+
+        assert not caplog.records
+        assert mock_ir.async_create_issue.call_count == 2

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -4,9 +4,15 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from custom_components.mcp_server_http_transport import (
     DOMAIN,
+    _async_report_endpoint_conflict,
     async_setup,
     async_setup_entry,
     async_unload_entry,
+)
+from custom_components.mcp_server_http_transport.const import (
+    ISSUE_ENDPOINT_CONFLICT,
+    MCP_HTTP_PATH,
+    MCP_PATH,
 )
 
 
@@ -26,14 +32,10 @@ class TestAsyncSetupEntry:
     """Test async_setup_entry function."""
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
-    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
-    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
     async def test_async_setup_entry_initializes_server(
         self,
-        mock_subpath_view,
-        mock_metadata_view,
-        mock_endpoint_view,
+        mock_register_views,
         mock_server_class,
         mock_hass,
         mock_config_entry,
@@ -51,104 +53,46 @@ class TestAsyncSetupEntry:
         mock_server_class.assert_called_once_with("home-assistant-mcp-server")
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
-    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
-    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
     async def test_async_setup_entry_registers_views(
         self,
-        mock_subpath_view,
-        mock_metadata_view,
-        mock_endpoint_view,
+        mock_register_views,
         mock_server_class,
         mock_hass,
         mock_config_entry,
     ):
-        """Test async_setup_entry registers HTTP views."""
-        result = await async_setup_entry(mock_hass, mock_config_entry)
-
-        assert result is True
-        assert mock_hass.http.register_view.call_count == 3
-
-    @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
-    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
-    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
-    async def test_async_setup_entry_registers_protected_resource_views(
-        self,
-        mock_subpath_view_class,
-        mock_metadata_view_class,
-        mock_endpoint_view,
-        mock_server_class,
-        mock_hass,
-        mock_config_entry,
-    ):
-        """Test async_setup_entry registers protected resource metadata views."""
-        mock_metadata_view = Mock()
-        mock_subpath_view = Mock()
-        mock_metadata_view_class.return_value = mock_metadata_view
-        mock_subpath_view_class.return_value = mock_subpath_view
-
-        result = await async_setup_entry(mock_hass, mock_config_entry)
-
-        assert result is True
-        mock_metadata_view_class.assert_called_once()
-        mock_subpath_view_class.assert_called_once()
-
-    @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
-    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
-    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
-    async def test_async_setup_entry_registers_endpoint_view(
-        self,
-        mock_subpath_view,
-        mock_metadata_view,
-        mock_endpoint_view_class,
-        mock_server_class,
-        mock_hass,
-        mock_config_entry,
-    ):
-        """Test async_setup_entry registers endpoint view with hass and server."""
+        """Test async_setup_entry registers the HTTP views."""
         mock_server = Mock()
         mock_server_class.return_value = mock_server
-        mock_endpoint_view = Mock()
-        mock_endpoint_view_class.return_value = mock_endpoint_view
 
         result = await async_setup_entry(mock_hass, mock_config_entry)
 
         assert result is True
-        mock_endpoint_view_class.assert_called_once_with(mock_hass, mock_server, False)
+        mock_register_views.assert_called_once_with(mock_hass, mock_server, False)
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
-    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
-    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
     async def test_async_setup_entry_passes_native_auth_enabled(
         self,
-        mock_subpath_view,
-        mock_metadata_view,
-        mock_endpoint_view_class,
+        mock_register_views,
         mock_server_class,
         mock_hass,
         mock_config_entry,
     ):
-        """Test async_setup_entry passes native_auth_enabled to endpoint view."""
+        """Test async_setup_entry passes native_auth_enabled on to registration."""
         mock_config_entry.data = {"native_auth_enabled": True}
         mock_server = Mock()
         mock_server_class.return_value = mock_server
 
         await async_setup_entry(mock_hass, mock_config_entry)
 
-        mock_endpoint_view_class.assert_called_once_with(mock_hass, mock_server, True)
+        mock_register_views.assert_called_once_with(mock_hass, mock_server, True)
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
-    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
-    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
     async def test_async_setup_entry_image_access_defaults_off(
         self,
-        mock_subpath_view,
-        mock_metadata_view,
-        mock_endpoint_view,
+        mock_register_views,
         mock_server_class,
         mock_hass,
         mock_config_entry,
@@ -160,14 +104,10 @@ class TestAsyncSetupEntry:
         assert mock_hass.data[DOMAIN]["image_file_access"] is False
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.MCPEndpointView")
-    @patch("custom_components.mcp_server_http_transport.MCPProtectedResourceMetadataView")
-    @patch("custom_components.mcp_server_http_transport.MCPSubpathProtectedResourceMetadataView")
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
     async def test_async_setup_entry_wires_image_access_flags(
         self,
-        mock_subpath_view,
-        mock_metadata_view,
-        mock_endpoint_view,
+        mock_register_views,
         mock_server_class,
         mock_hass,
         mock_config_entry,
@@ -202,7 +142,8 @@ class TestUpdateListener:
 class TestAsyncUnloadEntry:
     """Test async_unload_entry function."""
 
-    async def test_async_unload_entry_clears_data(self, mock_hass, mock_config_entry):
+    @patch("custom_components.mcp_server_http_transport.ir")
+    async def test_async_unload_entry_clears_data(self, mock_ir, mock_hass, mock_config_entry):
         """Test async_unload_entry clears domain data."""
         mock_hass.data[DOMAIN] = {"server": Mock()}
 
@@ -210,3 +151,48 @@ class TestAsyncUnloadEntry:
 
         assert result is True
         assert len(mock_hass.data[DOMAIN]) == 0
+
+    @patch("custom_components.mcp_server_http_transport.ir")
+    async def test_async_unload_entry_drops_the_conflict_issue(
+        self, mock_ir, mock_hass, mock_config_entry
+    ):
+        """An unloaded integration no longer conflicts with anything."""
+        mock_hass.data[DOMAIN] = {"server": Mock()}
+
+        await async_unload_entry(mock_hass, mock_config_entry)
+
+        mock_ir.async_delete_issue.assert_called_once_with(
+            mock_hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT
+        )
+
+
+class TestEndpointConflictIssue:
+    """Test the repair raised when another integration also serves /api/mcp."""
+
+    @patch("custom_components.mcp_server_http_transport.ir")
+    @patch("custom_components.mcp_server_http_transport.mcp_path_is_contested", return_value=True)
+    def test_conflict_raises_issue(self, mock_contested, mock_ir, mock_hass):
+        """A contested path raises a repair naming both paths."""
+        _async_report_endpoint_conflict(mock_hass)
+
+        mock_ir.async_create_issue.assert_called_once()
+        args, kwargs = mock_ir.async_create_issue.call_args
+        assert args == (mock_hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT)
+        assert kwargs["translation_key"] == ISSUE_ENDPOINT_CONFLICT
+        assert kwargs["translation_placeholders"] == {
+            "path": MCP_PATH,
+            "dedicated_path": MCP_HTTP_PATH,
+        }
+        assert kwargs["severity"] is mock_ir.IssueSeverity.WARNING
+        assert kwargs["is_fixable"] is False
+
+    @patch("custom_components.mcp_server_http_transport.ir")
+    @patch("custom_components.mcp_server_http_transport.mcp_path_is_contested", return_value=False)
+    def test_no_conflict_clears_issue(self, mock_contested, mock_ir, mock_hass):
+        """An uncontested path clears any issue left from an earlier run."""
+        _async_report_endpoint_conflict(mock_hass)
+
+        mock_ir.async_create_issue.assert_not_called()
+        mock_ir.async_delete_issue.assert_called_once_with(
+            mock_hass, DOMAIN, ISSUE_ENDPOINT_CONFLICT
+        )

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -32,7 +32,7 @@ class TestAsyncSetupEntry:
     """Test async_setup_entry function."""
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views")
     async def test_async_setup_entry_initializes_server(
         self,
         mock_register_views,
@@ -53,7 +53,7 @@ class TestAsyncSetupEntry:
         mock_server_class.assert_called_once_with("home-assistant-mcp-server")
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views")
     async def test_async_setup_entry_registers_views(
         self,
         mock_register_views,
@@ -71,7 +71,7 @@ class TestAsyncSetupEntry:
         mock_register_views.assert_called_once_with(mock_hass, mock_server, False)
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views")
     async def test_async_setup_entry_passes_native_auth_enabled(
         self,
         mock_register_views,
@@ -89,7 +89,7 @@ class TestAsyncSetupEntry:
         mock_register_views.assert_called_once_with(mock_hass, mock_server, True)
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views")
     async def test_async_setup_entry_image_access_defaults_off(
         self,
         mock_register_views,
@@ -104,7 +104,7 @@ class TestAsyncSetupEntry:
         assert mock_hass.data[DOMAIN]["image_file_access"] is False
 
     @patch("custom_components.mcp_server_http_transport.Server")
-    @patch("custom_components.mcp_server_http_transport.register_mcp_views", return_value=False)
+    @patch("custom_components.mcp_server_http_transport.register_mcp_views")
     async def test_async_setup_entry_wires_image_access_flags(
         self,
         mock_register_views,

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -22,9 +22,10 @@ import pytest
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import EVENT_COMPONENT_LOADED
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.setup import async_setup_component
+from homeassistant.setup import ATTR_COMPONENT, async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
 
@@ -34,6 +35,7 @@ from custom_components.mcp_server_http_transport.const import (
     ISSUE_ENDPOINT_CONFLICT,
     MCP_HTTP_PATH,
     MCP_PATH,
+    RESOURCE_METADATA_PREFIX,
 )
 
 
@@ -258,3 +260,87 @@ async def test_contested_path_raises_a_repair(
         "path": MCP_PATH,
         "dedicated_path": MCP_HTTP_PATH,
     }
+
+
+async def test_contested_path_metadata_is_not_served_either(
+    contested_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """Nothing else serves this metadata, so answering would misdirect a client.
+
+    A client that gets a 401 from the integration holding /api/mcp builds the
+    RFC 9728 path-suffixed URL. Answering it here would name this integration's
+    authorization server for a token that integration will reject.
+    """
+    client = await hass_client_no_auth()
+
+    resp = await client.get(f"{RESOURCE_METADATA_PREFIX}{MCP_PATH}")
+
+    assert resp.status == 404
+
+
+async def test_dedicated_path_metadata_is_still_served(
+    contested_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """Discovery for the path this integration does serve keeps working."""
+    client = await hass_client_no_auth()
+
+    resp = await client.get(f"{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}")
+
+    assert resp.status == 200
+    assert (await resp.json())["resource"].endswith(MCP_HTTP_PATH)
+
+
+async def test_a_competitor_arriving_after_setup_raises_the_repair(
+    loaded_entry: MockConfigEntry,
+    hass: HomeAssistant,
+) -> None:
+    """The user adding the built-in integration later is the likely path here."""
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_ENDPOINT_CONFLICT) is None
+
+    hass.http.register_view(_CompetingMCPView())
+    # The check re-runs on any component load, so the event names one that is
+    # actually loaded here rather than the integration being stood in for.
+    hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: "http"})
+    await hass.async_block_till_done()
+
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_ENDPOINT_CONFLICT) is not None
+
+
+async def test_a_competitor_arriving_after_setup_does_not_take_the_path(
+    loaded_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Routes registered first keep answering, so this integration still serves."""
+    hass.http.register_view(_CompetingMCPView())
+    client = await hass_client()
+
+    resp = await client.post(
+        MCP_PATH,
+        json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+    )
+
+    assert resp.status == 200
+    assert (await resp.json())["result"]["protocolVersion"] == "2024-11-05"
+
+
+async def test_a_reload_keeps_serving_both_paths(
+    loaded_entry: MockConfigEntry,
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """A reload updates the registered view rather than queueing another one."""
+    assert await hass.config_entries.async_reload(loaded_entry.entry_id)
+    await hass.async_block_till_done()
+
+    client = await hass_client()
+    for path in (MCP_PATH, MCP_HTTP_PATH):
+        resp = await client.post(
+            path,
+            json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+        )
+
+        assert resp.status == 200, path
+        assert (await resp.json())["result"]["protocolVersion"] == "2024-11-05"

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -19,13 +19,22 @@ path under test.
 """
 
 import pytest
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
 
-from custom_components.mcp_server_http_transport.const import CONF_NATIVE_AUTH, DOMAIN
+from custom_components.mcp_server_http_transport.const import (
+    CONF_NATIVE_AUTH,
+    DOMAIN,
+    ISSUE_ENDPOINT_CONFLICT,
+    MCP_HTTP_PATH,
+    MCP_PATH,
+)
 
 
 @pytest.fixture
@@ -122,3 +131,130 @@ async def test_unauthenticated_get_carries_the_challenge(
     assert resp.status == 401
     assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")
     assert (await resp.json())["error"] == "invalid_token"
+
+
+async def test_dedicated_path_is_served(
+    loaded_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """The path only this integration claims routes to it."""
+    client = await hass_client()
+
+    resp = await client.post(
+        MCP_HTTP_PATH,
+        json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+    )
+
+    assert resp.status == 200
+    assert (await resp.json())["result"]["protocolVersion"] == "2024-11-05"
+
+
+async def test_dedicated_path_challenges_an_unauthenticated_probe(
+    loaded_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """A GET probe on the dedicated path gets the same challenge as /api/mcp."""
+    client = await hass_client_no_auth()
+
+    resp = await client.get(MCP_HTTP_PATH)
+
+    assert resp.status == 401
+    assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+async def test_no_repair_when_nothing_else_serves_api_mcp(
+    loaded_entry: MockConfigEntry,
+    hass: HomeAssistant,
+) -> None:
+    """An uncontested endpoint raises no repair."""
+    assert ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_ENDPOINT_CONFLICT) is None
+
+
+class _CompetingMCPView(HomeAssistantView):
+    """Stand-in for Home Assistant's built-in mcp_server streamable endpoint.
+
+    Core registers POST /api/mcp (and no GET) from its own async_setup, which
+    runs before this integration's config entry on a normal startup.
+    """
+
+    url = MCP_PATH
+    name = "test:competing_mcp"
+    requires_auth = False
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Answer the way the other integration would."""
+        return web.json_response({"served_by": "built-in"})
+
+
+@pytest.fixture
+async def contested_entry(enable_custom_integrations: None, hass: HomeAssistant) -> MockConfigEntry:
+    """Set the integration up with /api/mcp already taken by something else."""
+    assert await async_setup_component(hass, "http", {})
+    hass.http.register_view(_CompetingMCPView())
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_NATIVE_AUTH: True})
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    return entry
+
+
+async def test_contested_path_is_left_to_the_integration_that_claimed_it(
+    contested_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """aiohttp keeps sending /api/mcp to whichever view registered first."""
+    client = await hass_client()
+
+    resp = await client.post(
+        MCP_PATH,
+        json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+    )
+
+    assert resp.status == 200
+    assert (await resp.json()) == {"served_by": "built-in"}
+
+
+async def test_contested_path_is_not_half_claimed(
+    contested_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """This integration registers no method at all on a path it does not own."""
+    client = await hass_client_no_auth()
+
+    resp = await client.get(MCP_PATH)
+
+    assert resp.status == 405
+
+
+async def test_dedicated_path_serves_while_api_mcp_is_contested(
+    contested_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """The dedicated path reaches this integration no matter who holds /api/mcp."""
+    client = await hass_client()
+
+    resp = await client.post(
+        MCP_HTTP_PATH,
+        json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
+    )
+
+    assert resp.status == 200
+    assert (await resp.json())["result"]["protocolVersion"] == "2024-11-05"
+
+
+async def test_contested_path_raises_a_repair(
+    contested_entry: MockConfigEntry,
+    hass: HomeAssistant,
+) -> None:
+    """The silent shadowing surfaces as a repair naming the dedicated path."""
+    issue = ir.async_get(hass).async_get_issue(DOMAIN, ISSUE_ENDPOINT_CONFLICT)
+
+    assert issue is not None
+    assert issue.translation_placeholders == {
+        "path": MCP_PATH,
+        "dedicated_path": MCP_HTTP_PATH,
+    }

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -292,6 +292,41 @@ async def test_dedicated_path_metadata_is_still_served(
     assert (await resp.json())["resource"].endswith(MCP_HTTP_PATH)
 
 
+async def test_root_metadata_names_a_path_this_integration_answers(
+    contested_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """The bare well-known path is where a client falls back when the suffixed one 404s.
+
+    Home Assistant's auth component claims this path on the versions that have a
+    root view of its own; where it does not, this integration answers and must
+    not name the endpoint another integration is holding.
+    """
+    client = await hass_client_no_auth()
+
+    resp = await client.get(RESOURCE_METADATA_PREFIX)
+
+    if resp.status == 404:
+        pytest.skip("Home Assistant's auth component serves this path on this version")
+    assert resp.status == 200
+    assert (await resp.json())["resource"].endswith(MCP_HTTP_PATH)
+
+
+async def test_root_metadata_names_api_mcp_while_this_integration_holds_it(
+    loaded_entry: MockConfigEntry,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """An uncontested instance keeps advertising /api/mcp as the resource."""
+    client = await hass_client_no_auth()
+
+    resp = await client.get(RESOURCE_METADATA_PREFIX)
+
+    if resp.status == 404:
+        pytest.skip("Home Assistant's auth component serves this path on this version")
+    assert resp.status == 200
+    assert (await resp.json())["resource"].endswith(MCP_PATH)
+
+
 async def test_a_competitor_arriving_after_setup_raises_the_repair(
     loaded_entry: MockConfigEntry,
     hass: HomeAssistant,

--- a/tests/test_e2e_oidc.py
+++ b/tests/test_e2e_oidc.py
@@ -31,7 +31,11 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
 
-from custom_components.mcp_server_http_transport.const import DOMAIN
+from custom_components.mcp_server_http_transport.const import (
+    DOMAIN,
+    MCP_HTTP_PATH,
+    MCP_PATH,
+)
 
 # Skip unless the real paired provider is vendored. When conftest.py installs the
 # stub instead, the imported module is a Mock and there is nothing real to pin.
@@ -55,7 +59,8 @@ OIDC_DOMAIN = "oidc_provider"
 FORWARDED = {"X-Forwarded-Proto": "https", "X-Forwarded-Host": "mcp.example.com"}
 ISSUER_BASE = "https://mcp.example.com"
 TOKEN_ISSUER = f"{ISSUER_BASE}/oidc"
-RESOURCE = f"{ISSUER_BASE}/api/mcp"
+RESOURCE = f"{ISSUER_BASE}{MCP_PATH}"
+RESOURCE_HTTP = f"{ISSUER_BASE}{MCP_HTTP_PATH}"
 
 
 @pytest.fixture
@@ -101,9 +106,9 @@ def _sign(
     return jwt.encode(payload, pem, algorithm="RS256")
 
 
-async def _post_initialize(client: ClientSessionGenerator, token: str):
+async def _post_initialize(client: ClientSessionGenerator, token: str, path: str = MCP_PATH):
     return await client.post(
-        "/api/mcp",
+        path,
         json={"jsonrpc": "2.0", "method": "initialize", "id": 1},
         headers={**FORWARDED, "Authorization": f"Bearer {token}"},
     )
@@ -178,3 +183,61 @@ async def test_unauthenticated_get_advertises_resource_metadata(
         'Bearer realm="MCP Server",'
         f' resource_metadata="{ISSUER_BASE}/.well-known/oauth-protected-resource/api/mcp"'
     )
+
+
+async def test_dedicated_path_accepts_a_token_bound_to_it(
+    oidc_ready: rsa.RSAPrivateKey, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """The path this integration serves alone is a resource in its own right."""
+    client = await hass_client_no_auth()
+    token = _sign(oidc_ready, aud=RESOURCE_HTTP)
+
+    resp = await _post_initialize(client, token, MCP_HTTP_PATH)
+
+    assert resp.status == 200
+    assert (await resp.json())["result"]["protocolVersion"] == "2024-11-05"
+
+
+async def test_dedicated_path_rejects_a_token_bound_to_the_other_endpoint(
+    oidc_ready: rsa.RSAPrivateKey, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """The two endpoints are separate resources, so their tokens do not cross.
+
+    A client that moves to the dedicated path re-runs discovery, is handed that
+    path's metadata by the 401, and asks for a token bound to it.
+    """
+    client = await hass_client_no_auth()
+    token = _sign(oidc_ready, aud=RESOURCE)
+
+    resp = await _post_initialize(client, token, MCP_HTTP_PATH)
+
+    assert resp.status == 401
+
+
+async def test_dedicated_path_advertises_its_own_resource_metadata(
+    oidc_ready: rsa.RSAPrivateKey, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """The challenge points at the metadata for the path the client called."""
+    client = await hass_client_no_auth()
+
+    resp = await client.get(MCP_HTTP_PATH, headers=FORWARDED)
+
+    assert resp.status == 401
+    assert resp.headers["WWW-Authenticate"] == (
+        'Bearer realm="MCP Server",'
+        f' resource_metadata="{ISSUER_BASE}/.well-known/oauth-protected-resource{MCP_HTTP_PATH}"'
+    )
+
+
+async def test_dedicated_path_metadata_names_itself_as_the_resource(
+    oidc_ready: rsa.RSAPrivateKey, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """Following that pointer yields metadata for the dedicated path."""
+    client = await hass_client_no_auth()
+
+    resp = await client.get(
+        f"/.well-known/oauth-protected-resource{MCP_HTTP_PATH}", headers=FORWARDED
+    )
+
+    assert resp.status == 200
+    assert (await resp.json())["resource"] == RESOURCE_HTTP

--- a/tests/test_e2e_oidc.py
+++ b/tests/test_e2e_oidc.py
@@ -3,10 +3,11 @@
 The MCP server is an OAuth protected resource (RFC 8707). For the OIDC path it
 delegates signature/issuer checking to the paired provider's
 ``validate_access_token``, but it owns one piece of the contract itself: it
-derives ``expected_audience = {issuer}/api/mcp`` from the request and rejects any
-token whose ``aud`` is not bound to that resource. That seam breaks silently if
-either repo changes how the resource URI is derived or how ``aud`` is shaped,
-because each repo's own suite stays green.
+derives ``expected_audience`` from the endpoint the request came in on, and
+rejects any token whose ``aud`` is not bound to that resource. The two endpoints
+are separate resources, so a token minted for one is not accepted on the other.
+That seam breaks silently if either repo changes how the resource URI is derived
+or how ``aud`` is shaped, because each repo's own suite stays green.
 
 This pins the seam by exercising the *real* ``validate_access_token`` (the
 function ``http.py`` imports), which lives in the paired ``oidc_provider``
@@ -15,7 +16,7 @@ file; when it isn't present (a normal local checkout) ``conftest.py`` stubs the
 module instead and these tests skip.
 
 No browser and no issuance flow: a token is signed directly with a provider
-keypair seeded into ``hass.data`` and POSTed to ``/api/mcp``.
+keypair seeded into ``hass.data`` and POSTed to the endpoint under test.
 """
 
 import time

--- a/tests/test_ha_api_contracts.py
+++ b/tests/test_ha_api_contracts.py
@@ -34,6 +34,15 @@ from homeassistant.helpers.recorder import DATA_INSTANCE
 
 from custom_components.mcp_server_http_transport.const import MCP_PATH
 
+# Core's built-in MCP server is what claims /api/mcp (#81). Importing it needs
+# aiohttp_sse, which only its own manifest pulls in, and the streamable endpoint
+# it collides on only exists from Home Assistant 2025.11; both absences raise
+# ImportError here and skip the contract rather than failing it.
+try:
+    from homeassistant.components.mcp_server.http import STREAMABLE_API
+except ImportError:
+    STREAMABLE_API = None
+
 # The KNX contracts below need the integration and its telegram store importable,
 # which takes KNX's own requirements (xknx, knx-frontend, knx-telegram-store) on
 # top of Home Assistant. They are installed on the KNX leg in CI and skipped
@@ -331,11 +340,14 @@ class TestViewRegistrationContracts:
 
         assert len(list(app.router.routes())) == 4
 
-    def test_core_mcp_server_url_is_the_path_this_integration_serves(self):
-        """Core's built-in MCP server registers the path this one has used.
+    @pytest.mark.skipif(
+        STREAMABLE_API is None,
+        reason="core's streamable MCP endpoint is not importable on this install",
+    )
+    def test_core_streamable_endpoint_is_the_path_this_integration_serves(self):
+        """The conflict this integration works around is core serving MCP_PATH.
 
-        Importing it would need the integration installed, so the path is
-        asserted as a constant: if a future release moves core's streamable
-        endpoint, MCP_PATH is free again and the repair can be retired.
+        If a release moves core's streamable endpoint, MCP_PATH stops being
+        contested and the repair, and the second path it points at, can go.
         """
-        assert MCP_PATH == "/api/mcp"
+        assert MCP_PATH == STREAMABLE_API

--- a/tests/test_ha_api_contracts.py
+++ b/tests/test_ha_api_contracts.py
@@ -16,8 +16,10 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from aiohttp import web
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.components.calendar.const import DATA_COMPONENT, LIST_EVENT_FIELDS
+from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.services import (
     SERVICE_GET_STATISTICS,
@@ -29,6 +31,8 @@ from homeassistant.components.recorder.statistics import (
 )
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.recorder import DATA_INSTANCE
+
+from custom_components.mcp_server_http_transport.const import MCP_PATH
 
 # The KNX contracts below need the integration and its telegram store importable,
 # which takes KNX's own requirements (xknx, knx-frontend, knx-telegram-store) on
@@ -264,3 +268,74 @@ class TestKnxTelegramStoreContracts:
         """The window the tool reads off the config entry, and its fallback."""
         assert CONF_KNX_TELEGRAM_DB_LOAD_HOURS == "telegram_db_load_hours"
         assert KNX_TELEGRAM_LOAD_HOURS_DEFAULT == 24
+
+
+class _ContractView(HomeAssistantView):
+    """A view registered on two paths, standing in for the MCP endpoint."""
+
+    url = "/api/contract_test"
+    extra_urls = ["/api/contract_test_alt"]
+    name = "test:contract"
+    requires_auth = False
+
+    async def post(self, request: web.Request) -> web.Response:
+        """Serve nothing; only the registration is under test."""
+        return web.Response()
+
+
+def _register(view: HomeAssistantView, app: web.Application) -> None:
+    view.register(Mock(), app, app.router)
+
+
+class TestViewRegistrationContracts:
+    """Contracts for http.py, which reads the router to detect a path conflict.
+
+    Home Assistant exposes no way to ask who serves a path, or to unregister a
+    view, so register_mcp_views inspects hass.http.app.router directly. Nothing
+    promises that stays readable, and the conflict with core's mcp_server on
+    /api/mcp (#81) is invisible without it.
+    """
+
+    def test_register_serves_url_and_extra_urls(self):
+        """The endpoint reaches its second path through extra_urls."""
+        app = web.Application()
+
+        _register(_ContractView(), app)
+
+        assert [route.resource.canonical for route in app.router.routes()] == [
+            "/api/contract_test",
+            "/api/contract_test_alt",
+        ]
+
+    def test_routes_expose_method_and_canonical_path(self):
+        """The conflict check reads exactly these two attributes off a route."""
+        app = web.Application()
+
+        _register(_ContractView(), app)
+
+        route = next(iter(app.router.routes()))
+        assert route.method == "POST"
+        assert route.resource.canonical == "/api/contract_test"
+
+    def test_a_second_view_on_one_path_registers_rather_than_raising(self):
+        """Two integrations can hold one path, which is why #81 is silent.
+
+        HomeAssistantView.register adds routes without a name, so aiohttp raises
+        nothing on the duplicate. Were this to start raising, registering
+        MCP_PATH while core's mcp_server holds it would fail setup instead.
+        """
+        app = web.Application()
+
+        _register(_ContractView(), app)
+        _register(_ContractView(), app)
+
+        assert len(list(app.router.routes())) == 4
+
+    def test_core_mcp_server_url_is_the_path_this_integration_serves(self):
+        """Core's built-in MCP server registers the path this one has used.
+
+        Importing it would need the integration installed, so the path is
+        asserted as a constant: if a future release moves core's streamable
+        endpoint, MCP_PATH is free again and the repair can be retired.
+        """
+        assert MCP_PATH == "/api/mcp"

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,18 +1,27 @@
 """Tests for HTTP transport, auth, and JSON-RPC routing."""
 
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from custom_components.oidc_provider.token_validator import get_issuer_from_request
 
-from custom_components.mcp_server_http_transport.const import DOMAIN
+from custom_components.mcp_server_http_transport.const import (
+    DOMAIN,
+    MCP_HTTP_PATH,
+    MCP_PATH,
+    RESOURCE_METADATA_PREFIX,
+)
 from custom_components.mcp_server_http_transport.http import (
+    REGISTERED_ROUTES,
     MCPEndpointView,
     MCPProtectedResourceMetadataView,
     MCPSubpathProtectedResourceMetadataView,
     _get_issuer,
     _get_protected_resource_metadata,
+    mcp_path_is_contested,
+    register_mcp_views,
 )
 from custom_components.mcp_server_http_transport.tools import TOOLS
 
@@ -143,6 +152,7 @@ class TestMCPSubpathProtectedResourceMetadataView:
         """Test GET returns protected resource metadata."""
         request = Mock()
         request.headers = {}
+        request.path = f"{RESOURCE_METADATA_PREFIX}{MCP_PATH}"
         request.url.origin.return_value = "https://homeassistant.local"
 
         view = MCPSubpathProtectedResourceMetadataView(Mock())
@@ -151,6 +161,21 @@ class TestMCPSubpathProtectedResourceMetadataView:
         assert response.status == 200
         body = json.loads(response.body)
         assert body["resource"] == "https://homeassistant.local/api/mcp"
+
+    async def test_get_describes_the_endpoint_the_path_names(self):
+        """Metadata for the dedicated path describes that path as the resource."""
+        request = Mock()
+        request.headers = {}
+        request.path = f"{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}"
+        request.url.origin.return_value = "https://homeassistant.local"
+
+        view = MCPSubpathProtectedResourceMetadataView(Mock())
+        response = await view.get(request)
+
+        assert response.status == 200
+        body = json.loads(response.body)
+        assert body["resource"] == f"https://homeassistant.local{MCP_HTTP_PATH}"
+        assert body["resource_documentation"] == f"https://homeassistant.local{MCP_HTTP_PATH}"
 
     async def test_get_returns_404_when_oidc_unavailable(self):
         """Test GET returns 404 when OIDC provider is not installed."""
@@ -315,6 +340,7 @@ class TestMCPEndpointView:
         """Test GET without a token returns 401 carrying the metadata pointer."""
         request = Mock()
         request.headers = {}
+        request.path = MCP_PATH
         request.url.origin.return_value = "https://homeassistant.local"
 
         with patch(
@@ -329,6 +355,25 @@ class TestMCPEndpointView:
         assert (
             'resource_metadata="https://homeassistant.local:8123'
             '/.well-known/oauth-protected-resource/api/mcp"' in response.headers["WWW-Authenticate"]
+        )
+
+    async def test_challenge_points_at_the_metadata_for_the_path_used(self, view):
+        """A probe on the dedicated path is pointed at that path's metadata."""
+        request = Mock()
+        request.headers = {}
+        request.path = MCP_HTTP_PATH
+        request.url.origin.return_value = "https://homeassistant.local"
+
+        with patch(
+            "custom_components.mcp_server_http_transport.http._get_issuer",
+            return_value="https://homeassistant.local:8123",
+        ):
+            response = await view.get(request)
+
+        assert response.status == 401
+        assert (
+            f'resource_metadata="https://homeassistant.local:8123'
+            f'{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}"' in response.headers["WWW-Authenticate"]
         )
 
     async def test_get_with_valid_token_returns_405(self, view):
@@ -759,6 +804,7 @@ class TestOidcAudienceBinding:
         import sys
 
         request = Mock()
+        request.path = MCP_PATH
         request.headers = {
             "Authorization": "Bearer t",
             "X-Forwarded-Proto": "https",
@@ -776,6 +822,29 @@ class TestOidcAudienceBinding:
         assert result == {"sub": "u"}
         _, kwargs = mv.validate_access_token.call_args
         assert kwargs.get("expected_audience") == "https://ha.example.com/api/mcp"
+
+    async def test_audience_follows_the_endpoint_the_client_called(self, view):
+        """A token for the dedicated path is bound to that path, not /api/mcp."""
+        import sys
+
+        request = Mock()
+        request.path = MCP_HTTP_PATH
+        request.headers = {
+            "Authorization": "Bearer t",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "ha.example.com",
+        }
+
+        mv = sys.modules["custom_components.oidc_provider.token_validator"]
+        mv.validate_access_token.reset_mock()
+        mv.validate_access_token.return_value = {"sub": "u"}
+        try:
+            await view._validate_token(request)
+        finally:
+            mv.validate_access_token.return_value = None
+
+        _, kwargs = mv.validate_access_token.call_args
+        assert kwargs.get("expected_audience") == f"https://ha.example.com{MCP_HTTP_PATH}"
 
     async def test_falls_back_to_legacy_signature_on_type_error(self, view):
         """An older OIDC provider without expected_audience still works."""
@@ -803,3 +872,110 @@ class TestOidcAudienceBinding:
             mv.validate_access_token.return_value = None
 
         assert result == {"sub": "legacy"}
+
+
+class _FakeRoute:
+    """A registered route, carrying only what the conflict check reads."""
+
+    def __init__(self, method: str, path: str) -> None:
+        self.method = method
+        self.resource = SimpleNamespace(canonical=path)
+
+
+class _FakeRouter:
+    """A router that records routes the way HomeAssistantView.register adds them."""
+
+    def __init__(self) -> None:
+        self._routes: list[_FakeRoute] = []
+
+    def routes(self) -> list[_FakeRoute]:
+        return list(self._routes)
+
+    def add_view(self, view) -> None:
+        for method in ("get", "post", "delete", "put", "patch", "head", "options"):
+            if not getattr(view, method, None):
+                continue
+            for url in [view.url, *view.extra_urls]:
+                self._routes.append(_FakeRoute(method.upper(), url))
+
+
+@pytest.fixture
+def routing_hass():
+    """A hass whose HTTP router records what gets registered on it."""
+    hass = Mock()
+    hass.data = {DOMAIN: {}}
+    router = _FakeRouter()
+    hass.http.app.router = router
+    hass.http.register_view = router.add_view
+    return hass
+
+
+def _paths(router: _FakeRouter, method: str = "POST") -> list[str]:
+    """Return the paths serving a method, in registration order."""
+    return [route.resource.canonical for route in router.routes() if route.method == method]
+
+
+class TestRegisterMCPViews:
+    """Test which paths the integration claims, and how it spots a conflict."""
+
+    def test_claims_both_paths_when_api_mcp_is_free(self, routing_hass, mock_server):
+        """With nothing else on /api/mcp, the endpoint serves both paths."""
+        contested = register_mcp_views(routing_hass, mock_server, False)
+
+        assert contested is False
+        assert _paths(routing_hass.http.app.router) == [MCP_PATH, MCP_HTTP_PATH]
+
+    def test_registers_the_metadata_views(self, routing_hass, mock_server):
+        """Both RFC 9728 metadata paths are served alongside the endpoint."""
+        register_mcp_views(routing_hass, mock_server, False)
+
+        assert _paths(routing_hass.http.app.router, "GET") == [
+            RESOURCE_METADATA_PREFIX,
+            f"{RESOURCE_METADATA_PREFIX}{MCP_PATH}",
+            f"{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}",
+            MCP_PATH,
+            MCP_HTTP_PATH,
+        ]
+
+    def test_stays_off_api_mcp_when_another_integration_serves_it(self, routing_hass, mock_server):
+        """A path already answering POST elsewhere is left alone entirely.
+
+        Home Assistant's built-in mcp_server registers no GET on /api/mcp, so
+        taking half the path would answer a client's discovery probe here while
+        its actual traffic went to the other integration.
+        """
+        router = routing_hass.http.app.router
+        router._routes.append(_FakeRoute("POST", MCP_PATH))
+
+        contested = register_mcp_views(routing_hass, mock_server, False)
+
+        assert contested is True
+        assert _paths(router) == [MCP_PATH, MCP_HTTP_PATH]  # the foreign one, then ours
+        assert MCP_PATH not in _paths(router, "GET")
+
+    def test_own_routes_are_not_mistaken_for_a_conflict(self, routing_hass, mock_server):
+        """A reload re-registers the views; that is not another integration."""
+        register_mcp_views(routing_hass, mock_server, False)
+
+        assert mcp_path_is_contested(routing_hass) is False
+
+        contested = register_mcp_views(routing_hass, mock_server, False)
+
+        assert contested is False
+
+    def test_conflict_is_seen_when_the_other_integration_arrives_later(
+        self, routing_hass, mock_server
+    ):
+        """A path claimed after setup still reports as contested."""
+        register_mcp_views(routing_hass, mock_server, False)
+        routing_hass.http.app.router._routes.append(_FakeRoute("POST", MCP_PATH))
+
+        assert mcp_path_is_contested(routing_hass) is True
+
+    def test_registered_routes_survive_an_unload(self, routing_hass, mock_server):
+        """The tracked routes live outside hass.data[DOMAIN], which unload clears."""
+        register_mcp_views(routing_hass, mock_server, False)
+        routing_hass.data[DOMAIN].clear()
+
+        assert routing_hass.data[REGISTERED_ROUTES]
+        assert mcp_path_is_contested(routing_hass) is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -103,13 +103,14 @@ def test_get_protected_resource_metadata():
 class TestMCPProtectedResourceMetadataView:
     """Test the MCP protected resource metadata view at root."""
 
-    async def test_get_returns_metadata(self):
+    async def test_get_returns_metadata(self, routing_hass, mock_server):
         """Test GET returns protected resource metadata."""
+        register_mcp_views(routing_hass, mock_server, False)
         request = Mock(path=MCP_PATH)
         request.headers = {}
         request.url.origin.return_value = "https://homeassistant.local"
 
-        view = MCPProtectedResourceMetadataView(Mock())
+        view = MCPProtectedResourceMetadataView(routing_hass)
         response = await view.get(request)
 
         assert response.status == 200
@@ -119,19 +120,42 @@ class TestMCPProtectedResourceMetadataView:
         assert body["resource"] == "https://homeassistant.local/api/mcp"
         assert body["authorization_servers"] == ["https://homeassistant.local/oidc"]
 
-    async def test_get_with_forwarded_headers(self):
+    async def test_get_with_forwarded_headers(self, routing_hass, mock_server):
         """Test GET with X-Forwarded headers."""
+        register_mcp_views(routing_hass, mock_server, False)
         request = Mock(path=MCP_PATH)
         request.headers = {
             "X-Forwarded-Proto": "https",
             "X-Forwarded-Host": "example.com",
         }
 
-        view = MCPProtectedResourceMetadataView(Mock())
+        view = MCPProtectedResourceMetadataView(routing_hass)
         response = await view.get(request)
 
         body = json.loads(response.body)
         assert body["resource"] == "https://example.com/api/mcp"
+
+    async def test_get_names_the_dedicated_path_when_api_mcp_is_contested(
+        self, routing_hass, mock_server
+    ):
+        """The root path describes an endpoint this integration actually answers.
+
+        A client falls back here when the path-suffixed metadata 404s, so naming
+        a contested /api/mcp would send it to this authorization server for a
+        token the integration holding that path rejects.
+        """
+        routing_hass.http.app.router._routes.append(_FakeRoute("POST", MCP_PATH))
+        register_mcp_views(routing_hass, mock_server, False)
+        request = Mock(path=RESOURCE_METADATA_PREFIX)
+        request.headers = {}
+        request.url.origin.return_value = "https://homeassistant.local"
+
+        view = MCPProtectedResourceMetadataView(routing_hass)
+        response = await view.get(request)
+
+        assert json.loads(response.body)["resource"] == (
+            f"https://homeassistant.local{MCP_HTTP_PATH}"
+        )
 
     async def test_get_returns_404_when_oidc_unavailable(self):
         """Test GET returns 404 when OIDC provider is not installed."""
@@ -899,7 +923,7 @@ class _FakeRouter:
 def routing_hass():
     """A hass whose HTTP router records what gets registered on it."""
     hass = Mock()
-    hass.data = {DOMAIN: {}}
+    hass.data = {DOMAIN: {"entry_id": Mock()}}
     router = _FakeRouter()
     hass.http.app.router = router
     hass.http.register_view = router.add_view
@@ -916,9 +940,8 @@ class TestRegisterMCPViews:
 
     def test_claims_both_paths_when_api_mcp_is_free(self, routing_hass, mock_server):
         """With nothing else on /api/mcp, the endpoint serves both paths."""
-        contested = register_mcp_views(routing_hass, mock_server, False)
+        register_mcp_views(routing_hass, mock_server, False)
 
-        assert contested is False
         assert _paths(routing_hass.http.app.router) == [MCP_PATH, MCP_HTTP_PATH]
 
     def test_registers_the_metadata_views(self, routing_hass, mock_server):
@@ -943,9 +966,8 @@ class TestRegisterMCPViews:
         router = routing_hass.http.app.router
         router._routes.append(_FakeRoute("POST", MCP_PATH))
 
-        contested = register_mcp_views(routing_hass, mock_server, False)
+        register_mcp_views(routing_hass, mock_server, False)
 
-        assert contested is True
         assert _paths(router) == [MCP_PATH, MCP_HTTP_PATH]  # the foreign one, then ours
         assert MCP_PATH not in _paths(router, "GET")
 
@@ -968,20 +990,17 @@ class TestRegisterMCPViews:
         """A route registered for every method answers POST as well."""
         routing_hass.http.app.router._routes.append(_FakeRoute("*", MCP_PATH))
 
-        contested = register_mcp_views(routing_hass, mock_server, False)
+        register_mcp_views(routing_hass, mock_server, False)
 
-        assert contested is True
+        assert mcp_path_is_contested(routing_hass) is True
         assert MCP_PATH not in _paths(routing_hass.http.app.router, "GET")
 
     def test_own_routes_are_not_mistaken_for_a_conflict(self, routing_hass, mock_server):
         """A reload does not make this integration its own competitor."""
         register_mcp_views(routing_hass, mock_server, False)
+        register_mcp_views(routing_hass, mock_server, False)
 
         assert mcp_path_is_contested(routing_hass) is False
-
-        contested = register_mcp_views(routing_hass, mock_server, False)
-
-        assert contested is False
 
     def test_a_reload_updates_the_view_the_router_holds(self, routing_hass, mock_server):
         """Registering again would sit behind the first view and never be reached."""

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -14,6 +14,7 @@ from custom_components.mcp_server_http_transport.const import (
     RESOURCE_METADATA_PREFIX,
 )
 from custom_components.mcp_server_http_transport.http import (
+    REGISTERED_ENDPOINT,
     REGISTERED_ROUTES,
     MCPEndpointView,
     MCPProtectedResourceMetadataView,
@@ -22,13 +23,14 @@ from custom_components.mcp_server_http_transport.http import (
     _get_protected_resource_metadata,
     mcp_path_is_contested,
     register_mcp_views,
+    serves_mcp_path,
 )
 from custom_components.mcp_server_http_transport.tools import TOOLS
 
 
 def test_get_base_url_with_forwarded_headers():
     """Test get_issuer_from_request with X-Forwarded headers (proxy setup)."""
-    request = Mock()
+    request = Mock(path=MCP_PATH)
     request.headers = {
         "X-Forwarded-Proto": "https",
         "X-Forwarded-Host": "example.com",
@@ -43,7 +45,7 @@ def test_get_base_url_with_forwarded_headers():
 
 def test_get_base_url_without_forwarded_headers():
     """Test get_issuer_from_request without X-Forwarded headers (direct connection)."""
-    request = Mock()
+    request = Mock(path=MCP_PATH)
     request.headers = {}
     request.url.origin.return_value = "http://192.168.1.100:8123"
 
@@ -55,7 +57,7 @@ def test_get_base_url_without_forwarded_headers():
 
 def test_get_base_url_with_partial_forwarded_headers():
     """Test get_issuer_from_request with only one X-Forwarded header (should use fallback)."""
-    request = Mock()
+    request = Mock(path=MCP_PATH)
     request.headers = {
         "X-Forwarded-Proto": "https",
     }
@@ -71,7 +73,7 @@ def test_get_issuer_returns_none_when_oidc_unavailable():
     """Test _get_issuer returns None when oidc_provider import fails."""
     import sys
 
-    request = Mock()
+    request = Mock(path=MCP_PATH)
     # Temporarily remove the mocked oidc module so the import raises ImportError
     saved = sys.modules.pop("custom_components.oidc_provider.token_validator", None)
     saved_parent = sys.modules.pop("custom_components.oidc_provider", None)
@@ -89,7 +91,7 @@ def test_get_protected_resource_metadata():
     """Test _get_protected_resource_metadata returns correct structure."""
     base_url = "https://homeassistant.local"
 
-    metadata = _get_protected_resource_metadata(base_url)
+    metadata = _get_protected_resource_metadata(base_url, MCP_PATH)
 
     assert metadata["resource"] == f"{base_url}/api/mcp"
     assert metadata["authorization_servers"] == [f"{base_url}/oidc"]
@@ -103,7 +105,7 @@ class TestMCPProtectedResourceMetadataView:
 
     async def test_get_returns_metadata(self):
         """Test GET returns protected resource metadata."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {}
         request.url.origin.return_value = "https://homeassistant.local"
 
@@ -119,7 +121,7 @@ class TestMCPProtectedResourceMetadataView:
 
     async def test_get_with_forwarded_headers(self):
         """Test GET with X-Forwarded headers."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {
             "X-Forwarded-Proto": "https",
             "X-Forwarded-Host": "example.com",
@@ -133,7 +135,7 @@ class TestMCPProtectedResourceMetadataView:
 
     async def test_get_returns_404_when_oidc_unavailable(self):
         """Test GET returns 404 when OIDC provider is not installed."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
 
         view = MCPProtectedResourceMetadataView(Mock())
         with patch(
@@ -150,9 +152,8 @@ class TestMCPSubpathProtectedResourceMetadataView:
 
     async def test_get_returns_metadata(self):
         """Test GET returns protected resource metadata."""
-        request = Mock()
+        request = Mock(path=f"{RESOURCE_METADATA_PREFIX}{MCP_PATH}")
         request.headers = {}
-        request.path = f"{RESOURCE_METADATA_PREFIX}{MCP_PATH}"
         request.url.origin.return_value = "https://homeassistant.local"
 
         view = MCPSubpathProtectedResourceMetadataView(Mock())
@@ -164,9 +165,8 @@ class TestMCPSubpathProtectedResourceMetadataView:
 
     async def test_get_describes_the_endpoint_the_path_names(self):
         """Metadata for the dedicated path describes that path as the resource."""
-        request = Mock()
+        request = Mock(path=f"{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}")
         request.headers = {}
-        request.path = f"{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}"
         request.url.origin.return_value = "https://homeassistant.local"
 
         view = MCPSubpathProtectedResourceMetadataView(Mock())
@@ -179,7 +179,7 @@ class TestMCPSubpathProtectedResourceMetadataView:
 
     async def test_get_returns_404_when_oidc_unavailable(self):
         """Test GET returns 404 when OIDC provider is not installed."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
 
         view = MCPSubpathProtectedResourceMetadataView(Mock())
         with patch(
@@ -218,7 +218,7 @@ class TestMCPEndpointView:
 
     async def test_post_without_token_returns_401(self, view):
         """Test POST without Authorization header returns 401."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {}
         request.url.origin.return_value = "https://homeassistant.local"
 
@@ -231,7 +231,7 @@ class TestMCPEndpointView:
 
     async def test_post_with_invalid_token_returns_401(self, view):
         """Test POST with invalid token returns 401."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer invalid_token"}
         request.url.origin.return_value = "https://homeassistant.local"
 
@@ -244,7 +244,7 @@ class TestMCPEndpointView:
 
     async def test_post_initialize_request(self, view):
         """Test POST with initialize request."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(return_value={"jsonrpc": "2.0", "method": "initialize", "id": 1})
 
@@ -260,7 +260,7 @@ class TestMCPEndpointView:
 
     async def test_post_initialize_advertises_capabilities(self, view):
         """Test POST initialize advertises resources and prompts capabilities."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(return_value={"jsonrpc": "2.0", "method": "initialize", "id": 21})
 
@@ -275,7 +275,7 @@ class TestMCPEndpointView:
 
     async def test_post_tools_list_request(self, view):
         """Test POST with tools/list request."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(return_value={"jsonrpc": "2.0", "method": "tools/list", "id": 2})
 
@@ -310,7 +310,7 @@ class TestMCPEndpointView:
 
     async def test_post_unknown_method_returns_error(self, view):
         """Test POST with unknown method returns error."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(
             return_value={"jsonrpc": "2.0", "method": "unknown_method", "id": 9}
@@ -327,7 +327,7 @@ class TestMCPEndpointView:
 
     async def test_post_notification_returns_202(self, view):
         """Test POST with notification (no id) returns 202."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(return_value={"jsonrpc": "2.0", "method": "some_notification"})
 
@@ -338,9 +338,8 @@ class TestMCPEndpointView:
 
     async def test_get_without_token_returns_401_with_challenge(self, view):
         """Test GET without a token returns 401 carrying the metadata pointer."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {}
-        request.path = MCP_PATH
         request.url.origin.return_value = "https://homeassistant.local"
 
         with patch(
@@ -359,9 +358,8 @@ class TestMCPEndpointView:
 
     async def test_challenge_points_at_the_metadata_for_the_path_used(self, view):
         """A probe on the dedicated path is pointed at that path's metadata."""
-        request = Mock()
+        request = Mock(path=MCP_HTTP_PATH)
         request.headers = {}
-        request.path = MCP_HTTP_PATH
         request.url.origin.return_value = "https://homeassistant.local"
 
         with patch(
@@ -378,7 +376,7 @@ class TestMCPEndpointView:
 
     async def test_get_with_valid_token_returns_405(self, view):
         """Test GET with a valid token is Method Not Allowed; there is no SSE stream."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
 
         with patch.object(view, "_validate_token", return_value={"sub": "user123"}):
@@ -394,7 +392,7 @@ class TestMCPEndpointView:
         hass.data = {}
         view = MCPEndpointView(hass, mock_server)
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {}
 
         response = await view.get(request)
@@ -404,7 +402,7 @@ class TestMCPEndpointView:
 
     async def test_validate_token_without_bearer_prefix(self, view):
         """Test _validate_token without Bearer prefix returns None."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "invalid_format"}
 
         result = await view._validate_token(request)
@@ -413,7 +411,7 @@ class TestMCPEndpointView:
 
     async def test_post_tools_call_unknown_tool(self, view):
         """Test POST with tools/call for unknown tool."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(
             return_value={
@@ -445,7 +443,7 @@ class TestToolErrorHandling:
     """
 
     async def _call(self, view, name, arguments, msg_id=1):
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(
             return_value={
@@ -565,7 +563,7 @@ class TestToolErrorHandling:
         assert body["id"] == 1
 
     async def test_unparseable_body_returns_parse_error(self, view):
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
         request.json = AsyncMock(side_effect=ValueError("not json"))
         request.url.origin.return_value = "https://homeassistant.local"
@@ -590,7 +588,7 @@ class TestIntegrationDisabledGate:
         hass.data = {}
         view = MCPEndpointView(hass, Mock())
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
 
         response = await view.post(request)
@@ -604,7 +602,7 @@ class TestIntegrationDisabledGate:
         hass.data = {"mcp_server_http_transport": {}}  # matches async_unload_entry.clear()
         view = MCPEndpointView(hass, Mock())
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_token"}
 
         response = await view.post(request)
@@ -634,7 +632,7 @@ class TestIntegrationDisabledGate:
         hass.data = {"mcp_server_http_transport": {"server": Mock()}}
         view = MCPEndpointView(hass, Mock())
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {}  # no token → 401, not 503
 
         response = await view.post(request)
@@ -671,7 +669,7 @@ class TestNativeAuth:
         mock_refresh_token.user.id = "user_abc"
         mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer valid_llat"}
 
         result = await view._validate_token(request)
@@ -681,7 +679,7 @@ class TestNativeAuth:
 
     async def test_llat_rejected_when_disabled(self, view_disabled, mock_hass):
         """Test that LLAT is not tried when native auth is disabled."""
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer some_token"}
 
         result = await view_disabled._validate_token(request)
@@ -693,7 +691,7 @@ class TestNativeAuth:
         """Test that an invalid LLAT returns None."""
         mock_hass.auth.async_validate_access_token.return_value = None
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer bad_token"}
 
         result = await view._validate_token(request)
@@ -704,7 +702,7 @@ class TestNativeAuth:
         """Test that OIDC validation is attempted before LLAT."""
         import sys
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer oidc_token"}
 
         mock_validator = sys.modules["custom_components.oidc_provider.token_validator"]
@@ -724,7 +722,7 @@ class TestNativeAuth:
         mock_refresh_token.user.id = "ha_user"
         mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer llat_token"}
 
         # OIDC will fail (ImportError from conftest mock returning None)
@@ -740,7 +738,7 @@ class TestNativeAuth:
         mock_refresh_token.user.id = "fallback_user"
         mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer some_token"}
 
         saved = sys.modules.pop("custom_components.oidc_provider.token_validator", None)
@@ -759,7 +757,7 @@ class TestNativeAuth:
         """Test 401 response uses plain Bearer when OIDC is not available."""
         mock_hass.auth.async_validate_access_token.return_value = None
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer bad_token"}
         request.url.origin.return_value = "http://localhost:8123"
 
@@ -779,7 +777,7 @@ class TestNativeAuth:
         mock_refresh_token.user.id = "user_xyz"
         mock_hass.auth.async_validate_access_token.return_value = mock_refresh_token
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {"Authorization": "Bearer my_llat"}
         request.json = AsyncMock(return_value={"jsonrpc": "2.0", "method": "initialize", "id": 1})
 
@@ -803,8 +801,7 @@ class TestOidcAudienceBinding:
         """_validate_token derives the resource URI and passes it as audience."""
         import sys
 
-        request = Mock()
-        request.path = MCP_PATH
+        request = Mock(path=MCP_PATH)
         request.headers = {
             "Authorization": "Bearer t",
             "X-Forwarded-Proto": "https",
@@ -827,8 +824,7 @@ class TestOidcAudienceBinding:
         """A token for the dedicated path is bound to that path, not /api/mcp."""
         import sys
 
-        request = Mock()
-        request.path = MCP_HTTP_PATH
+        request = Mock(path=MCP_HTTP_PATH)
         request.headers = {
             "Authorization": "Bearer t",
             "X-Forwarded-Proto": "https",
@@ -850,7 +846,7 @@ class TestOidcAudienceBinding:
         """An older OIDC provider without expected_audience still works."""
         import sys
 
-        request = Mock()
+        request = Mock(path=MCP_PATH)
         request.headers = {
             "Authorization": "Bearer t",
             "X-Forwarded-Proto": "https",
@@ -953,8 +949,32 @@ class TestRegisterMCPViews:
         assert _paths(router) == [MCP_PATH, MCP_HTTP_PATH]  # the foreign one, then ours
         assert MCP_PATH not in _paths(router, "GET")
 
+    def test_metadata_for_a_contested_path_is_left_alone_too(self, routing_hass, mock_server):
+        """The RFC 9728 metadata follows the endpoint off a contested path.
+
+        Nothing else serves that metadata, so answering there would hand a
+        client this integration's authorization server for a token the
+        integration actually holding /api/mcp will reject.
+        """
+        router = routing_hass.http.app.router
+        router._routes.append(_FakeRoute("POST", MCP_PATH))
+
+        register_mcp_views(routing_hass, mock_server, False)
+
+        assert f"{RESOURCE_METADATA_PREFIX}{MCP_PATH}" not in _paths(router, "GET")
+        assert f"{RESOURCE_METADATA_PREFIX}{MCP_HTTP_PATH}" in _paths(router, "GET")
+
+    def test_a_wildcard_route_counts_as_a_competitor(self, routing_hass, mock_server):
+        """A route registered for every method answers POST as well."""
+        routing_hass.http.app.router._routes.append(_FakeRoute("*", MCP_PATH))
+
+        contested = register_mcp_views(routing_hass, mock_server, False)
+
+        assert contested is True
+        assert MCP_PATH not in _paths(routing_hass.http.app.router, "GET")
+
     def test_own_routes_are_not_mistaken_for_a_conflict(self, routing_hass, mock_server):
-        """A reload re-registers the views; that is not another integration."""
+        """A reload does not make this integration its own competitor."""
         register_mcp_views(routing_hass, mock_server, False)
 
         assert mcp_path_is_contested(routing_hass) is False
@@ -962,6 +982,41 @@ class TestRegisterMCPViews:
         contested = register_mcp_views(routing_hass, mock_server, False)
 
         assert contested is False
+
+    def test_a_reload_updates_the_view_the_router_holds(self, routing_hass, mock_server):
+        """Registering again would sit behind the first view and never be reached."""
+        register_mcp_views(routing_hass, mock_server, False)
+        routes_after_first_load = routing_hass.http.app.router.routes()
+        endpoint = routing_hass.data[REGISTERED_ENDPOINT]
+
+        reloaded_server = Mock()
+        register_mcp_views(routing_hass, reloaded_server, True)
+
+        assert routing_hass.http.app.router.routes() == routes_after_first_load
+        assert endpoint.native_auth_enabled is True
+        assert endpoint.server is reloaded_server
+
+    def test_serves_mcp_path_reports_who_answers(self, routing_hass, mock_server):
+        """Only the first route on the path answers, whoever registered it."""
+        register_mcp_views(routing_hass, mock_server, False)
+
+        assert serves_mcp_path(routing_hass) is True
+
+        # A competitor arriving later queues behind the route already bound.
+        routing_hass.http.app.router._routes.append(_FakeRoute("POST", MCP_PATH))
+
+        assert mcp_path_is_contested(routing_hass) is True
+        assert serves_mcp_path(routing_hass) is True
+
+    def test_serves_mcp_path_is_false_when_another_integration_got_there_first(
+        self, routing_hass, mock_server
+    ):
+        """A path claimed before setup is answered by its holder, not this one."""
+        routing_hass.http.app.router._routes.append(_FakeRoute("POST", MCP_PATH))
+
+        register_mcp_views(routing_hass, mock_server, False)
+
+        assert serves_mcp_path(routing_hass) is False
 
     def test_conflict_is_seen_when_the_other_integration_arrives_later(
         self, routing_hass, mock_server


### PR DESCRIPTION
Fixes #81.

Home Assistant's built-in `mcp_server` integration registers its streamable HTTP transport on `/api/mcp`, the path this integration has always used. That has been true since **2025.11.0**, not 2026.8 as the issue reports: 2025.10.4 has no `/api/mcp`, and 2026.8 only added the `/api/mcp/{api_id}` views the reporter probed with. Anyone on 2025.11+ with both integrations installed is exposed.

`HomeAssistantView.register` adds routes without a name, so aiohttp raises nothing on the duplicate, and `UrlDispatcher.resolve` walks same-path resources linearly and explicitly respects registration order. Core registers its views from `async_setup`, so on a normal startup it gets there first. Nothing is logged and both integrations keep showing as healthy, so the only symptom is a client getting the wrong tool set.

Core's streamable view defines only `post`, which is why the reported symptom is confusing: `POST /api/mcp` goes to core while `GET /api/mcp` falls through to this integration, so the 401 challenge the reporter saw on GET was ours all along.

The endpoint now also answers on `/api/mcp_http`, and stays off `/api/mcp` entirely when something already serves POST there. Taking the path half-way would answer a client's discovery probe here while its actual traffic went to core. A conflict that shows up anyway, including the reverse case where this integration registered first and core is the unreachable one, raises a repair naming both paths once Home Assistant has started.

Worth looking at closely:

- **Conflict detection** reads `hass.http.app.router` directly, because Home Assistant offers no way to ask who serves a path. Routes registered here are tracked in a `hass.data` key that sits outside `hass.data[DOMAIN]`, so a reload (which re-registers the views but clears domain data) is not mistaken for another integration. The reach is pinned in `tests/test_ha_api_contracts.py`.
- **Each path is its own protected resource.** The RFC 9728 metadata, the token audience (RFC 8707) and the 401 `resource_metadata` pointer now follow the path the client called, so a client on either path discovers and binds to that path. `/api/mcp` behaves exactly as before; a token bound to one path is not accepted on the other, which is what the spec asks for and what a client re-running discovery will do anyway.
- **The repair, not just docs.** The failure is invisible from every surface a user would check, so a `_LOGGER.warning` alone would not reach anyone.

`tests/test_e2e.py` registers a competing view before the config entry and drives the result through real aiohttp: `/api/mcp` reaches the competitor, `/api/mcp_http` reaches this integration, `GET /api/mcp` is a 405 (nothing of ours on that path), and the repair is raised. `tests/test_e2e_oidc.py` pins the audience seam for the new path against the real paired provider.
