### PR TITLE
chore: bump version to 1.16.0

### DIFF
--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0", "python-dateutil>=2.9.0"],
-  "version": "1.15.0"
+  "version": "1.16.0"
 }


### PR DESCRIPTION
Bumps the manifest to 1.16.0, which is what the create-release workflow watches: merging this tags v1.16.0 and publishes the HACS zip.

Minor rather than patch because the release adds a new opt-in tool group and a second HTTP path. What has landed on main since v1.15.0:

- Bounded AppDaemon app-file access (#85): eight opt-in tools for listing, reading, saving, deleting, backing up and restoring files under a validated apps root, off by default.
- A second MCP endpoint at `/api/mcp_http` (#88), because core's `mcp_server` claims `/api/mcp` from 2025.11 and aiohttp resolves the duplicate silently. A repair names the conflict when it happens.
- `call_service` now returns service response data (#75).
- Statistics are read through `recorder.get_statistics` and its response envelope (#86), which raises the floor to Home Assistant 2025.6.0. `hacs.json` now declares that minimum and CI tests it.
- `knx_recent_telegrams` supports the DB-backed telegram store (#80).
- Malformed tool calls are rejected as JSON-RPC `-32602` instead of being coerced, and an unexpected handler failure comes back as an error result rather than taking down the response (#87).
- The `openid` scope is advertised in protected resource metadata (#84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3838tvpa983527Zss9awL
