### PR TITLE
perf: emit compact JSON in tool, resource, and prompt output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,11 @@ Black and Ruff at line length 100, both enforced in CI. Tools register through
 handler anticipates comes back as text in that same shape rather than as a raised
 exception.
 
+Serialize any JSON a tool, resource, or prompt returns with `json_utils.dumps`. It
+is compact, which is a third fewer tokens than `indent=2` for the model that reads
+it, and it goes through `_HAJSONEncoder` so datetimes and sets serialize. Ruff bans
+`json.dumps` outside that helper.
+
 `call_tool` owns the two things a handler does not have to. It rejects a call the
 caller got wrong — an unknown name, a non-object `arguments`, a declared-required
 property that is absent or null — by raising `InvalidToolRequest`, which the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,9 +56,11 @@ handler anticipates comes back as text in that same shape rather than as a raise
 exception.
 
 Serialize any JSON a tool, resource, or prompt returns with `json_utils.dumps`. It
-is compact, which is a third fewer tokens than `indent=2` for the model that reads
-it, and it goes through `_HAJSONEncoder` so datetimes and sets serialize. Ruff bans
-`json.dumps` outside that helper.
+is compact and keeps non-ASCII text as is, which is a third fewer tokens than
+`indent=2` for the model that reads it, and its encoder accepts every value Home
+Assistant's own API accepts, falling back to `str()` rather than failing a whole
+response on one exotic attribute. Ruff flags `json.dumps` anywhere in the package
+(TID251); the helper carries the one `noqa`, and tests are exempt.
 
 `call_tool` owns the two things a handler does not have to. It rejects a call the
 caller got wrong — an unknown name, a non-object `arguments`, a declared-required

--- a/custom_components/mcp_server_http_transport/const.py
+++ b/custom_components/mcp_server_http_transport/const.py
@@ -1,6 +1,16 @@
 """Constants for the MCP Server integration."""
 
+import json
+from pathlib import Path
+from typing import Final
+
 DOMAIN = "mcp_server_http_transport"
+
+# The version a client sees in serverInfo is the one the manifest declares, so a
+# release bump in one place is a bump everywhere.
+VERSION: Final[str] = json.loads(
+    Path(__file__).with_name("manifest.json").read_text(encoding="utf-8")
+)["version"]
 
 # MCP Server configuration
 DEFAULT_PORT = 8080

--- a/custom_components/mcp_server_http_transport/http.py
+++ b/custom_components/mcp_server_http_transport/http.py
@@ -14,6 +14,7 @@ from .const import (
     MCP_HTTP_PATH,
     MCP_PATH,
     RESOURCE_METADATA_PREFIX,
+    VERSION,
 )
 from .prompts import get_prompt, get_prompts
 from .resources import get_resources, read_resource
@@ -368,7 +369,7 @@ class MCPEndpointView(HomeAssistantView):
                     },
                     "serverInfo": {
                         "name": "home-assistant-mcp-server",
-                        "version": "0.1.0",
+                        "version": VERSION,
                     },
                 },
                 "id": msg_id,

--- a/custom_components/mcp_server_http_transport/json_patch.py
+++ b/custom_components/mcp_server_http_transport/json_patch.py
@@ -5,8 +5,9 @@ whole Lovelace config back and forth.
 """
 
 import copy
-import json
 from typing import Any
+
+from .json_utils import dumps
 
 # Operations that address a second location in the document.
 _OPS_WITH_FROM = {"move", "copy"}
@@ -42,7 +43,7 @@ def format_pointer(tokens: list[str]) -> str:
 def _describe(value: Any, limit: int = 120) -> str:
     """Render a value for an error message, truncated so errors stay readable."""
     try:
-        text = json.dumps(value, default=str)
+        text = dumps(value)
     except (TypeError, ValueError):
         text = repr(value)
     return text if len(text) <= limit else text[:limit] + "…"

--- a/custom_components/mcp_server_http_transport/json_utils.py
+++ b/custom_components/mcp_server_http_transport/json_utils.py
@@ -1,29 +1,52 @@
 """Shared JSON helpers for Home Assistant MCP serialization."""
 
+import dataclasses
 import json
-from datetime import date, datetime
+from datetime import date, datetime, time
+from enum import Enum
 from typing import Any
+
+from homeassistant.helpers.json import json_encoder_default
 
 
 class _HAJSONEncoder(json.JSONEncoder):
-    """JSON encoder that handles datetime/date objects in HA state attributes."""
+    """JSON encoder for the values Home Assistant puts in state attributes.
+
+    Home Assistant serves its own API through orjson plus ``json_encoder_default``,
+    so every value a client of that API tolerates has to serialize here as well:
+    dates and times, enums, dataclasses, paths, and anything with ``as_dict``. Sets
+    of strings are sorted so output is stable. Anything still unknown becomes
+    ``str(value)`` rather than raising, because the tool wrapper reports a raised
+    TypeError as ``isError`` and one exotic attribute would then blank a whole
+    response.
+    """
 
     def default(self, o: Any) -> Any:
-        if isinstance(o, datetime):
-            return o.isoformat()
-        if isinstance(o, date):
+        if isinstance(o, (datetime, date, time)):
             return o.isoformat()
         if isinstance(o, (set, frozenset)):
             return sorted(o) if all(isinstance(x, str) for x in o) else list(o)
-        return super().default(o)
+        if isinstance(o, Enum):
+            return o.value
+        if dataclasses.is_dataclass(o) and not isinstance(o, type):
+            return dataclasses.asdict(o)
+        if hasattr(o, "as_dict"):
+            return o.as_dict()
+        try:
+            return json_encoder_default(o)
+        except TypeError:
+            return str(o)
 
 
 def dumps(obj: Any, *, cls: type[json.JSONEncoder] = _HAJSONEncoder) -> str:
-    """Serialize ``obj`` as compact JSON for an LLM to read.
+    """Serialize ``obj`` as compact JSON for a language model to read.
 
-    The consumer of every tool, resource, and prompt payload is a language model, so
-    indentation and the spaces after separators are token overhead with nothing to
-    show for it: compact output is roughly a third smaller than ``indent=2``. Only
-    ``cls`` is configurable, for callers whose payload needs a wider encoder.
+    Indentation, the spaces after separators, and ``\\uXXXX`` escapes for
+    non-ASCII text are all tokens the model pays for with nothing to show for it, so
+    none are emitted. The JSON-RPC envelope escapes the text again on the wire, so
+    the HTTP response stays ASCII either way. Only ``cls`` is configurable, for a
+    caller whose payload needs a wider encoder.
     """
-    return json.dumps(obj, separators=(",", ":"), cls=cls)
+    return json.dumps(  # noqa: TID251 - the one place output is serialized
+        obj, separators=(",", ":"), ensure_ascii=False, cls=cls
+    )

--- a/custom_components/mcp_server_http_transport/json_utils.py
+++ b/custom_components/mcp_server_http_transport/json_utils.py
@@ -16,3 +16,14 @@ class _HAJSONEncoder(json.JSONEncoder):
         if isinstance(o, (set, frozenset)):
             return sorted(o) if all(isinstance(x, str) for x in o) else list(o)
         return super().default(o)
+
+
+def dumps(obj: Any, *, cls: type[json.JSONEncoder] = _HAJSONEncoder) -> str:
+    """Serialize ``obj`` as compact JSON for an LLM to read.
+
+    The consumer of every tool, resource, and prompt payload is a language model, so
+    indentation and the spaces after separators are token overhead with nothing to
+    show for it: compact output is roughly a third smaller than ``indent=2``. Only
+    ``cls`` is configurable, for callers whose payload needs a wider encoder.
+    """
+    return json.dumps(obj, separators=(",", ":"), cls=cls)

--- a/custom_components/mcp_server_http_transport/manifest.json
+++ b/custom_components/mcp_server_http_transport/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/ganhammar/hass-mcp-server/issues",
   "requirements": ["mcp>=1.0.0", "python-dateutil>=2.9.0"],
-  "version": "1.16.0"
+  "version": "1.17.0"
 }

--- a/custom_components/mcp_server_http_transport/prompts/automation.py
+++ b/custom_components/mcp_server_http_transport/prompts/automation.py
@@ -1,11 +1,11 @@
 """Automation-related prompts."""
 
-import json
 import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
+from ..json_utils import dumps
 from . import register_prompt
 
 _LOGGER = logging.getLogger(__name__)
@@ -31,7 +31,7 @@ async def automation_review(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     automation_id = arguments.get("automation_id", "")
     try:
         config = await read_list_entry(hass, "automations.yaml", automation_id)
-        config_text = json.dumps(config, indent=2)
+        config_text = dumps(config)
     except Exception:
         _LOGGER.exception("Error reading automation config for '%s'", automation_id)
         config_text = f"Automation with id '{automation_id}' not found in automations.yaml"

--- a/custom_components/mcp_server_http_transport/prompts/automation_workflows.py
+++ b/custom_components/mcp_server_http_transport/prompts/automation_workflows.py
@@ -1,12 +1,11 @@
 """Automation workflow prompts: building, debugging, and auditing."""
 
-import json
 import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from ..json_utils import _HAJSONEncoder
+from ..json_utils import dumps
 from . import register_prompt
 
 _LOGGER = logging.getLogger(__name__)
@@ -96,7 +95,7 @@ async def automation_debugger(hass: HomeAssistant, arguments: dict[str, Any]) ->
     # Fetch automation config
     try:
         config = await read_list_entry(hass, "automations.yaml", automation_id)
-        config_text = json.dumps(config, indent=2, cls=_HAJSONEncoder)
+        config_text = dumps(config)
     except Exception:
         _LOGGER.exception("Error reading automation config for '%s'", automation_id)
         config_text = f"Automation with id '{automation_id}' not found in automations.yaml"
@@ -113,7 +112,7 @@ async def automation_debugger(hass: HomeAssistant, arguments: dict[str, Any]) ->
                 break
 
     if state is not None:
-        state_text = json.dumps(
+        state_text = dumps(
             {
                 "entity_id": state.entity_id,
                 "state": state.state,
@@ -121,8 +120,6 @@ async def automation_debugger(hass: HomeAssistant, arguments: dict[str, Any]) ->
                 "current_state": state.attributes.get("current", 0),
                 "mode": state.attributes.get("mode", "single"),
             },
-            indent=2,
-            cls=_HAJSONEncoder,
         )
     else:
         state_text = f"Automation entity not found for id '{automation_id}'"
@@ -152,11 +149,7 @@ async def automation_debugger(hass: HomeAssistant, arguments: dict[str, Any]) ->
             events = await get_instance(hass).async_add_executor_job(
                 processor.get_events, start_time, end_time
             )
-            logbook_text = (
-                json.dumps(events[:20], indent=2, cls=_HAJSONEncoder)
-                if events
-                else "No recent events"
-            )
+            logbook_text = dumps(events[:20]) if events else "No recent events"
     except Exception:
         _LOGGER.debug("Could not fetch logbook entries for automation debug")
 
@@ -201,7 +194,7 @@ async def automation_audit(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     automations = None
     try:
         automations = await read_list_entries(hass, "automations.yaml")
-        automations_text = json.dumps(automations, indent=2, cls=_HAJSONEncoder)
+        automations_text = dumps(automations)
     except Exception:
         _LOGGER.exception("Error reading automations for audit")
         automations_text = "Unable to read automations.yaml"
@@ -217,7 +210,7 @@ async def automation_audit(hass: HomeAssistant, arguments: dict[str, Any]) -> di
                     "last_triggered": str(state.attributes.get("last_triggered", "never")),
                 }
             )
-    states_text = json.dumps(auto_states, indent=2, cls=_HAJSONEncoder)
+    states_text = dumps(auto_states)
 
     return {
         "description": "Audit all automations",

--- a/custom_components/mcp_server_http_transport/prompts/diagnostics.py
+++ b/custom_components/mcp_server_http_transport/prompts/diagnostics.py
@@ -1,11 +1,10 @@
 """Diagnostic and troubleshooting prompts."""
 
-import json
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from ..json_utils import _HAJSONEncoder
+from ..json_utils import dumps
 from . import register_prompt
 
 
@@ -28,7 +27,7 @@ def troubleshoot_device(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
     if state is None:
         state_info = f"Entity {entity_id} not found"
     else:
-        state_info = json.dumps(
+        state_info = dumps(
             {
                 "entity_id": state.entity_id,
                 "state": state.state,
@@ -36,8 +35,6 @@ def troubleshoot_device(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
                 "last_changed": state.last_changed.isoformat(),
                 "last_updated": state.last_updated.isoformat(),
             },
-            indent=2,
-            cls=_HAJSONEncoder,
         )
 
     return {
@@ -83,7 +80,7 @@ def setup_guide(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any
     else:
         domain = state.entity_id.split(".")[0]
         device_class = state.attributes.get("device_class", "generic")
-        state_info = json.dumps(
+        state_info = dumps(
             {
                 "entity_id": state.entity_id,
                 "state": state.state,
@@ -91,8 +88,6 @@ def setup_guide(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str, Any
                 "last_changed": state.last_changed.isoformat(),
                 "last_updated": state.last_updated.isoformat(),
             },
-            indent=2,
-            cls=_HAJSONEncoder,
         )
 
     return {

--- a/custom_components/mcp_server_http_transport/prompts/optimization.py
+++ b/custom_components/mcp_server_http_transport/prompts/optimization.py
@@ -1,12 +1,11 @@
 """Optimization and analysis prompts."""
 
-import json
 import logging
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from ..json_utils import _HAJSONEncoder
+from ..json_utils import dumps
 from . import register_prompt
 
 _LOGGER = logging.getLogger(__name__)
@@ -34,7 +33,7 @@ async def schedule_optimizer(hass: HomeAssistant, arguments: dict[str, Any]) -> 
 
     try:
         automations = await read_list_entries(hass, "automations.yaml")
-        automations_text = json.dumps(automations, indent=2, cls=_HAJSONEncoder)
+        automations_text = dumps(automations)
     except Exception:
         _LOGGER.exception("Error reading automations for schedule optimizer")
         automations_text = "Unable to read automations.yaml"
@@ -46,7 +45,7 @@ async def schedule_optimizer(hass: HomeAssistant, arguments: dict[str, Any]) -> 
             entity_context = (
                 f"\n**Focus entity:** {entity_id}\n"
                 f"Current state: {state.state}\n"
-                f"Attributes: {json.dumps(dict(state.attributes), indent=2, cls=_HAJSONEncoder)}\n"
+                f"Attributes: {dumps(dict(state.attributes))}\n"
             )
         else:
             entity_context = f"\n**Focus entity:** {entity_id} (not found)\n"
@@ -101,7 +100,7 @@ async def naming_conventions(hass: HomeAssistant, arguments: dict[str, Any]) -> 
             }
         )
 
-    entities_text = json.dumps(by_domain, indent=2, cls=_HAJSONEncoder)
+    entities_text = dumps(by_domain)
     total = sum(len(v) for v in by_domain.values())
 
     return {

--- a/custom_components/mcp_server_http_transport/prompts/workflows.py
+++ b/custom_components/mcp_server_http_transport/prompts/workflows.py
@@ -1,6 +1,5 @@
 """Cross-cutting workflow prompts: dashboard building, change validation, security review."""
 
-import json
 import logging
 from typing import Any
 
@@ -9,6 +8,7 @@ from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
+from ..json_utils import dumps
 from . import register_prompt
 
 _LOGGER = logging.getLogger(__name__)
@@ -84,7 +84,7 @@ async def dashboard_builder(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     if not entities_info:
         entities_text = "No entities found for the given criteria."
     else:
-        entities_text = json.dumps(entities_info, indent=2)
+        entities_text = dumps(entities_info)
 
     return {
         "description": "Dashboard layout builder",
@@ -144,21 +144,15 @@ async def change_validator(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         try:
             if ct == "script":
                 entries = await read_dict_entries(hass, "scripts.yaml")
-                sections.append(
-                    f"**Scripts ({len(entries)}):**\n```json\n{json.dumps(entries, indent=2)}\n```"
-                )
+                sections.append(f"**Scripts ({len(entries)}):**\n```json\n{dumps(entries)}\n```")
             elif ct == "automation":
                 entries = await read_list_entries(hass, "automations.yaml")
                 sections.append(
-                    f"**Automations ({len(entries)}):**\n"
-                    f"```json\n{json.dumps(entries, indent=2)}\n```"
+                    f"**Automations ({len(entries)}):**\n```json\n{dumps(entries)}\n```"
                 )
             elif ct == "scene":
                 entries = await read_list_entries(hass, "scenes.yaml")
-                sections.append(
-                    f"**Scenes ({len(entries)}):**\n"
-                    f"```json\n{json.dumps(entries, indent=2)}\n```"
-                )
+                sections.append(f"**Scenes ({len(entries)}):**\n```json\n{dumps(entries)}\n```")
         except Exception:
             _LOGGER.debug("Could not read %s config for change validator", ct)
             sections.append(f"**{ct.title()}s:** Unable to read configuration")
@@ -224,7 +218,7 @@ async def security_review(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         "external_url": getattr(config, "external_url", None),
         "internal_url": getattr(config, "internal_url", None),
     }
-    config_text = json.dumps(config_data, indent=2)
+    config_text = dumps(config_data)
 
     # Integrations
     entries = hass.config_entries.async_entries()
@@ -236,7 +230,7 @@ async def security_review(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         }
         for entry in entries
     ]
-    integrations_text = json.dumps(integrations, indent=2)
+    integrations_text = dumps(integrations)
 
     # Sensitive entity domains
     sensitive_domains = {"camera", "lock", "alarm_control_panel", "cover"}
@@ -251,7 +245,7 @@ async def security_review(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
                     "friendly_name": state.attributes.get("friendly_name", state.entity_id),
                 }
             )
-    sensitive_text = json.dumps(sensitive_entities, indent=2)
+    sensitive_text = dumps(sensitive_entities)
 
     return {
         "description": "Security review",

--- a/custom_components/mcp_server_http_transport/resources.py
+++ b/custom_components/mcp_server_http_transport/resources.py
@@ -1,6 +1,5 @@
 """MCP resource definitions and handlers for Home Assistant."""
 
-import json
 from typing import Any
 
 from homeassistant.const import __version__ as HA_VERSION
@@ -10,7 +9,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import floor_registry as fr
 from homeassistant.helpers import label_registry as lr
 
-from .json_utils import _HAJSONEncoder
+from .json_utils import dumps
 
 RESOURCES = [
     {
@@ -153,7 +152,7 @@ def _read_config(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(data, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(data),
         }
     ]
 
@@ -173,7 +172,7 @@ def _read_areas(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(areas, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(areas),
         }
     ]
 
@@ -187,7 +186,7 @@ async def _read_dashboard(hass: HomeAssistant, uri: str, url_path: str) -> list[
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(config, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(config),
         }
     ]
 
@@ -210,7 +209,7 @@ def _read_devices(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(devices, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(devices),
         }
     ]
 
@@ -223,7 +222,7 @@ def _read_services(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(result, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(result),
         }
     ]
 
@@ -245,7 +244,7 @@ def _read_floors(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(floors, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(floors),
         }
     ]
 
@@ -268,7 +267,7 @@ def _read_entity(hass: HomeAssistant, uri: str, entity_id: str) -> list[dict[str
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(data, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(data),
         }
     ]
 
@@ -289,7 +288,7 @@ def _read_entities(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(by_domain, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(by_domain),
         }
     ]
 
@@ -311,7 +310,7 @@ def _read_entities_domain(hass: HomeAssistant, uri: str, domain: str) -> list[di
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(entities),
         }
     ]
 
@@ -333,7 +332,7 @@ def _read_labels(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(labels, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(labels),
         }
     ]
 
@@ -354,6 +353,6 @@ def _read_integrations(hass: HomeAssistant, uri: str) -> list[dict[str, Any]]:
         {
             "uri": uri,
             "mimeType": "application/json",
-            "text": json.dumps(integrations, indent=2, cls=_HAJSONEncoder),
+            "text": dumps(integrations),
         }
     ]

--- a/custom_components/mcp_server_http_transport/server.py
+++ b/custom_components/mcp_server_http_transport/server.py
@@ -10,6 +10,7 @@ from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
+from .const import VERSION
 from .json_utils import dumps
 
 _LOGGER = logging.getLogger(__name__)
@@ -177,7 +178,7 @@ class HomeAssistantMCPServer:
         async with stdio_server() as (read_stream, write_stream):
             init_options = InitializationOptions(
                 server_name="home-assistant",
-                server_version="0.1.0",
+                server_version=VERSION,
                 capabilities=self.server.get_capabilities(
                     notification_options=None, experimental_capabilities=None
                 ),

--- a/custom_components/mcp_server_http_transport/server.py
+++ b/custom_components/mcp_server_http_transport/server.py
@@ -10,6 +10,8 @@ from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
+from .json_utils import dumps
+
 _LOGGER = logging.getLogger(__name__)
 
 _HAS_GET_ENTITY_ALIASES = hasattr(er, "async_get_entity_aliases")
@@ -128,7 +130,7 @@ class HomeAssistantMCPServer:
             "last_updated": state.last_updated.isoformat(),
         }
 
-        return [TextContent(type="text", text=str(result))]
+        return [TextContent(type="text", text=dumps(result))]
 
     async def _call_service(self, arguments: dict[str, Any]) -> list[TextContent]:
         """Call a Home Assistant service."""
@@ -168,7 +170,7 @@ class HomeAssistantMCPServer:
                 }
             )
 
-        return [TextContent(type="text", text=str(entities))]
+        return [TextContent(type="text", text=dumps(entities))]
 
     async def run(self, host: str, port: int) -> None:
         """Run the MCP server."""

--- a/custom_components/mcp_server_http_transport/tools/__init__.py
+++ b/custom_components/mcp_server_http_transport/tools/__init__.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from homeassistant.core import HomeAssistant
 
-from ..json_utils import _HAJSONEncoder  # noqa: F401
+from ..json_utils import dumps  # noqa: F401
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/mcp_server_http_transport/tools/appdaemon_files.py
+++ b/custom_components/mcp_server_http_transport/tools/appdaemon_files.py
@@ -1,7 +1,6 @@
 """Narrow, race-resistant opt-in access to AppDaemon application files only."""
 
 import hashlib
-import json
 import os
 import re
 import stat
@@ -23,6 +22,7 @@ from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
+    dumps,
     register_tool,
 )
 
@@ -830,7 +830,7 @@ async def list_appdaemon_files(hass: HomeAssistant, arguments: dict[str, Any]) -
             "content": [
                 {
                     "type": "text",
-                    "text": json.dumps(await hass.async_add_executor_job(work), indent=2),
+                    "text": dumps(await hass.async_add_executor_job(work)),
                 }
             ]
         }
@@ -861,9 +861,7 @@ async def get_appdaemon_file(hass: HomeAssistant, arguments: dict[str, Any]) -> 
                 }
 
         return {
-            "content": [
-                {"type": "text", "text": json.dumps(await hass.async_add_executor_job(work))}
-            ]
+            "content": [{"type": "text", "text": dumps(await hass.async_add_executor_job(work))}]
         }
     except Exception as exc:
         return _error("reading AppDaemon file", exc)
@@ -915,9 +913,7 @@ async def save_appdaemon_file(hass: HomeAssistant, arguments: dict[str, Any]) ->
                 }
 
         return {
-            "content": [
-                {"type": "text", "text": json.dumps(await hass.async_add_executor_job(work))}
-            ]
+            "content": [{"type": "text", "text": dumps(await hass.async_add_executor_job(work))}]
         }
     except Exception as exc:
         return _error("saving AppDaemon file", exc)
@@ -951,9 +947,7 @@ async def delete_appdaemon_file(hass: HomeAssistant, arguments: dict[str, Any]) 
                 }
 
         return {
-            "content": [
-                {"type": "text", "text": json.dumps(await hass.async_add_executor_job(work))}
-            ]
+            "content": [{"type": "text", "text": dumps(await hass.async_add_executor_job(work))}]
         }
     except Exception as exc:
         if isinstance(exc, _UnlinkFailure) and exc.possibly_committed:
@@ -961,7 +955,7 @@ async def delete_appdaemon_file(hass: HomeAssistant, arguments: dict[str, Any]) 
                 "content": [
                     {
                         "type": "text",
-                        "text": json.dumps(
+                        "text": dumps(
                             {
                                 "success": False,
                                 "mutation_result": "delete may have committed before an error",
@@ -993,9 +987,7 @@ async def backup_appdaemon_files(hass: HomeAssistant, arguments: dict[str, Any])
                 return {"success": True, "backup": _backup_path(stamp), "files": files}
 
         return {
-            "content": [
-                {"type": "text", "text": json.dumps(await hass.async_add_executor_job(work))}
-            ]
+            "content": [{"type": "text", "text": dumps(await hass.async_add_executor_job(work))}]
         }
     except Exception as exc:
         return _error("backing up AppDaemon files", exc)
@@ -1044,9 +1036,7 @@ async def list_appdaemon_backups(hass: HomeAssistant, arguments: dict[str, Any])
                 return answer
 
         return {
-            "content": [
-                {"type": "text", "text": json.dumps(await hass.async_add_executor_job(work))}
-            ]
+            "content": [{"type": "text", "text": dumps(await hass.async_add_executor_job(work))}]
         }
     except Exception as exc:
         return _error("listing AppDaemon backups", exc)
@@ -1120,9 +1110,7 @@ async def restore_appdaemon_backup(
                 return _restore(fs, timestamp)
 
         return {
-            "content": [
-                {"type": "text", "text": json.dumps(await hass.async_add_executor_job(work))}
-            ]
+            "content": [{"type": "text", "text": dumps(await hass.async_add_executor_job(work))}]
         }
     except Exception as exc:
         return _error("restoring AppDaemon backup", exc)

--- a/custom_components/mcp_server_http_transport/tools/calendar.py
+++ b/custom_components/mcp_server_http_transport/tools/calendar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime, timedelta
 from typing import Any
@@ -27,7 +26,7 @@ from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -53,7 +52,7 @@ def _text_result(payload: dict[str, Any]) -> dict[str, Any]:
         "content": [
             {
                 "type": "text",
-                "text": json.dumps(payload, indent=2, cls=_HAJSONEncoder),
+                "text": dumps(payload),
             }
         ]
     }

--- a/custom_components/mcp_server_http_transport/tools/config.py
+++ b/custom_components/mcp_server_http_transport/tools/config.py
@@ -1,6 +1,5 @@
 """Automation, scene, and script CRUD and read tools."""
 
-import json
 import logging
 from typing import Any
 
@@ -11,7 +10,7 @@ from . import (
     ANNOTATION_IDEMPOTENT,
     ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -133,9 +132,7 @@ async def list_automations(hass: HomeAssistant, arguments: dict[str, Any]) -> di
 
     try:
         entries = await read_list_entries(hass, "automations.yaml")
-        return {
-            "content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(entries)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing automations: {str(e)}"}]}
 
@@ -161,9 +158,7 @@ async def get_automation_config(hass: HomeAssistant, arguments: dict[str, Any]) 
 
     try:
         entry = await read_list_entry(hass, "automations.yaml", arguments["automation_id"])
-        return {
-            "content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(entry)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting automation config: {str(e)}"}]}
 
@@ -272,9 +267,7 @@ async def list_scenes(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
 
     try:
         entries = await read_list_entries(hass, "scenes.yaml")
-        return {
-            "content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(entries)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing scenes: {str(e)}"}]}
 
@@ -300,9 +293,7 @@ async def get_scene_config(hass: HomeAssistant, arguments: dict[str, Any]) -> di
 
     try:
         entry = await read_list_entry(hass, "scenes.yaml", arguments["scene_id"])
-        return {
-            "content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(entry)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting scene config: {str(e)}"}]}
 
@@ -417,9 +408,7 @@ async def list_scripts(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
 
     try:
         entries = await read_dict_entries(hass, "scripts.yaml")
-        return {
-            "content": [{"type": "text", "text": json.dumps(entries, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(entries)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing scripts: {str(e)}"}]}
 
@@ -445,8 +434,6 @@ async def get_script_config(hass: HomeAssistant, arguments: dict[str, Any]) -> d
 
     try:
         entry = await read_dict_entry(hass, "scripts.yaml", arguments["key"])
-        return {
-            "content": [{"type": "text", "text": json.dumps(entry, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(entry)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting script config: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/config_files.py
+++ b/custom_components/mcp_server_http_transport/tools/config_files.py
@@ -1,6 +1,5 @@
 """Config file access tools (list, read, write, delete, backup, restore YAML files)."""
 
-import json
 import logging
 import os
 import re
@@ -17,6 +16,7 @@ from . import (
     ANNOTATION_IDEMPOTENT,
     ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
+    dumps,
     register_tool,
 )
 
@@ -248,7 +248,7 @@ async def list_config_files(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     recursive = bool(arguments.get("recursive", False))
     try:
         files = await hass.async_add_executor_job(_list_yaml_filenames_sync, config_dir, recursive)
-        return {"content": [{"type": "text", "text": json.dumps(files, indent=2)}]}
+        return {"content": [{"type": "text", "text": dumps(files)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing config files: {e}"}]}
 
@@ -713,7 +713,7 @@ async def list_config_backups(hass: HomeAssistant, arguments: dict[str, Any]) ->
         result = await hass.async_add_executor_job(_list_backups_sync, _config_dir(hass))
         if not result:
             return {"content": [{"type": "text", "text": "No backups found"}]}
-        return {"content": [{"type": "text", "text": json.dumps(result, indent=2)}]}
+        return {"content": [{"type": "text", "text": dumps(result)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing backups: {e}"}]}
 

--- a/custom_components/mcp_server_http_transport/tools/dashboards.py
+++ b/custom_components/mcp_server_http_transport/tools/dashboards.py
@@ -1,6 +1,5 @@
 """Dashboard tools."""
 
-import json
 import logging
 from typing import Any
 
@@ -11,7 +10,7 @@ from . import (
     ANNOTATION_IDEMPOTENT,
     ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -33,11 +32,7 @@ async def list_dashboards_tool(hass: HomeAssistant, arguments: dict[str, Any]) -
 
     try:
         dashboards = await list_dashboards(hass)
-        return {
-            "content": [
-                {"type": "text", "text": json.dumps(dashboards, indent=2, cls=_HAJSONEncoder)}
-            ]
-        }
+        return {"content": [{"type": "text", "text": dumps(dashboards)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error listing dashboards: {str(e)}"}]}
 
@@ -122,9 +117,7 @@ async def get_dashboard_config_tool(
         else:
             result = resolve_pointer(config, pointer) if pointer else config
 
-        return {
-            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(result)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting dashboard config: {str(e)}"}]}
 
@@ -383,7 +376,7 @@ async def create_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) 
                     "type": "text",
                     "text": (
                         f"Successfully created dashboard '{arguments['url_path']}': "
-                        f"{json.dumps(item, indent=2, cls=_HAJSONEncoder)}"
+                        f"{dumps(item)}"
                     ),
                 }
             ]
@@ -439,10 +432,7 @@ async def update_dashboard_tool(hass: HomeAssistant, arguments: dict[str, Any]) 
             "content": [
                 {
                     "type": "text",
-                    "text": (
-                        f"Successfully updated dashboard '{url_path}': "
-                        f"{json.dumps(item, indent=2, cls=_HAJSONEncoder)}"
-                    ),
+                    "text": (f"Successfully updated dashboard '{url_path}': " f"{dumps(item)}"),
                 }
             ]
         }

--- a/custom_components/mcp_server_http_transport/tools/entities.py
+++ b/custom_components/mcp_server_http_transport/tools/entities.py
@@ -1,6 +1,5 @@
 """Entity, area, device, and service tools."""
 
-import json
 import logging
 from typing import Any
 
@@ -14,7 +13,7 @@ from homeassistant.helpers.service import async_get_all_descriptions
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -79,7 +78,7 @@ async def get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str,
         "last_updated": state.last_updated.isoformat(),
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -156,7 +155,7 @@ async def call_service(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
                 "content": [
                     {
                         "type": "text",
-                        "text": json.dumps(response, indent=2, cls=_HAJSONEncoder),
+                        "text": dumps(response),
                     }
                 ]
             }
@@ -248,9 +247,7 @@ async def list_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
             }
         entities.append(entity)
 
-    return {
-        "content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]
-    }
+    return {"content": [{"type": "text", "text": dumps(entities)}]}
 
 
 @register_tool(
@@ -274,7 +271,7 @@ async def list_areas(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         for area in registry.async_list_areas()
     ]
 
-    return {"content": [{"type": "text", "text": json.dumps(areas, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(areas)}]}
 
 
 @register_tool(
@@ -311,9 +308,7 @@ async def list_devices(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             }
         )
 
-    return {
-        "content": [{"type": "text", "text": json.dumps(devices, indent=2, cls=_HAJSONEncoder)}]
-    }
+    return {"content": [{"type": "text", "text": dumps(devices)}]}
 
 
 @register_tool(
@@ -399,7 +394,7 @@ async def get_device_details(hass: HomeAssistant, arguments: dict[str, Any]) -> 
             entities.append(entity)
         result["entities"] = entities
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -429,7 +424,7 @@ async def list_services(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[
     for domain, domain_services in services.items():
         result[domain] = list(domain_services.keys())
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -479,7 +474,7 @@ async def describe_service(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     else:
         result = dict(domain_services)
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -586,9 +581,7 @@ async def search_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
         if len(entities) >= limit:
             break
 
-    return {
-        "content": [{"type": "text", "text": json.dumps(entities, indent=2, cls=_HAJSONEncoder)}]
-    }
+    return {"content": [{"type": "text", "text": dumps(entities)}]}
 
 
 @register_tool(
@@ -617,7 +610,7 @@ async def list_labels(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
         for label in registry.async_list_labels()
     ]
 
-    return {"content": [{"type": "text", "text": json.dumps(labels, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(labels)}]}
 
 
 @register_tool(
@@ -681,6 +674,4 @@ async def batch_get_state(hass: HomeAssistant, arguments: dict[str, Any]) -> dic
             }
         )
 
-    return {
-        "content": [{"type": "text", "text": json.dumps(results, indent=2, cls=_HAJSONEncoder)}]
-    }
+    return {"content": [{"type": "text", "text": dumps(results)}]}

--- a/custom_components/mcp_server_http_transport/tools/helpers.py
+++ b/custom_components/mcp_server_http_transport/tools/helpers.py
@@ -1,6 +1,5 @@
 """Helper entity CRUD tools (input_boolean, input_text, counter, timer, etc.)."""
 
-import json
 import logging
 from typing import Any
 
@@ -12,7 +11,7 @@ from . import (
     ANNOTATION_IDEMPOTENT,
     ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -133,9 +132,7 @@ async def list_helpers(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
                 }
             )
 
-    return {
-        "content": [{"type": "text", "text": json.dumps(helpers, indent=2, cls=_HAJSONEncoder)}]
-    }
+    return {"content": [{"type": "text", "text": dumps(helpers)}]}
 
 
 @register_tool(
@@ -167,9 +164,7 @@ async def get_helper_config(hass: HomeAssistant, arguments: dict[str, Any]) -> d
                 f"Helper '{arguments['entity_id']}' not found in storage "
                 "(it may be YAML-configured)"
             )
-        return {
-            "content": [{"type": "text", "text": json.dumps(item, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(item)}]}
     except Exception as e:
         return {"content": [{"type": "text", "text": f"Error getting helper config: {str(e)}"}]}
 

--- a/custom_components/mcp_server_http_transport/tools/knx.py
+++ b/custom_components/mcp_server_http_transport/tools/knx.py
@@ -1,6 +1,5 @@
 """KNX bus tools — read Home Assistant's KNX group-monitor telegram history."""
 
-import json
 import logging
 import re
 from datetime import timedelta
@@ -14,7 +13,7 @@ from . import (
     ANNOTATION_IDEMPOTENT,
     ANNOTATION_NON_IDEMPOTENT,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -193,7 +192,7 @@ async def knx_recent_telegrams(hass: HomeAssistant, arguments: dict[str, Any]) -
         "returned": len(returned),
         "telegrams": returned,
     }
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 def _not_setup() -> dict[str, Any]:
@@ -247,7 +246,7 @@ async def knx_get_base_data(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         "project_info": project_info,
         "supported_platforms": _supported_platforms_ui(),
     }
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -307,7 +306,7 @@ async def knx_get_entities(hass: HomeAssistant, arguments: dict[str, Any]) -> di
     _lim = arguments.get("limit")
     limit = max(1, int(_lim) if _lim is not None else 200)
     result = {"count": len(rows), "entities_by_group": rows[:limit]}
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 # --- Write tools (experimental): mutate HA's KNX UI config via config_store ---
@@ -353,7 +352,7 @@ async def knx_create_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     except Exception as err:  # noqa: BLE001
         return {"content": [{"type": "text", "text": f"create_entity failed: {err}"}]}
     result = {"created": True, "entity_id": entity_id, "platform": platform}
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -393,7 +392,7 @@ async def knx_update_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     except Exception as err:  # noqa: BLE001
         return {"content": [{"type": "text", "text": f"update_entity failed: {err}"}]}
     result = {"updated": True, "entity_id": entity_id, "platform": platform}
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -422,4 +421,4 @@ async def knx_delete_entity(hass: HomeAssistant, arguments: dict[str, Any]) -> d
     except Exception as err:  # noqa: BLE001
         return {"content": [{"type": "text", "text": f"delete_entity failed: {err}"}]}
     result = {"deleted": True, "entity_id": entity_id}
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}

--- a/custom_components/mcp_server_http_transport/tools/statistics.py
+++ b/custom_components/mcp_server_http_transport/tools/statistics.py
@@ -1,7 +1,6 @@
 """Long-term statistics tools."""
 
 import asyncio
-import json
 import logging
 from datetime import datetime as dt
 from typing import Any
@@ -12,7 +11,7 @@ from homeassistant.util import dt as dt_util
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -114,9 +113,7 @@ async def get_statistics(hass: HomeAssistant, arguments: dict[str, Any]) -> dict
                     entry[key] = stat[key]
             result.append(entry)
 
-        return {
-            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(result)}]}
     except Exception as e:
         _LOGGER.error("Error getting statistics: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting statistics: {str(e)}"}]}
@@ -175,11 +172,7 @@ async def list_statistic_ids(hass: HomeAssistant, arguments: dict[str, Any]) -> 
         metadata = await get_instance(hass).async_add_executor_job(
             recorder_list_statistic_ids, hass, id_set, statistic_type
         )
-        return {
-            "content": [
-                {"type": "text", "text": json.dumps(metadata, indent=2, cls=_HAJSONEncoder)}
-            ]
-        }
+        return {"content": [{"type": "text", "text": dumps(metadata)}]}
     except Exception as e:
         _LOGGER.error("Error listing statistic IDs: %s", e)
         return {"content": [{"type": "text", "text": f"Error listing statistic IDs: {str(e)}"}]}
@@ -211,9 +204,7 @@ async def validate_statistics(hass: HomeAssistant, arguments: dict[str, Any]) ->
             statistic_id: [issue.as_dict() for issue in issue_list]
             for statistic_id, issue_list in issues.items()
         }
-        return {
-            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(result)}]}
     except Exception as e:
         _LOGGER.error("Error validating statistics: %s", e)
         return {"content": [{"type": "text", "text": f"Error validating statistics: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/system.py
+++ b/custom_components/mcp_server_http_transport/tools/system.py
@@ -1,6 +1,5 @@
 """System, template, and history tools."""
 
-import json
 import logging
 from datetime import datetime as dt
 from typing import Any
@@ -12,7 +11,7 @@ from homeassistant.util import dt as dt_util
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -44,7 +43,7 @@ async def get_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str
         "language": config.language,
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -132,9 +131,7 @@ async def get_history(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
                     "attributes": dict(state.attributes),
                 }
             )
-        return {
-            "content": [{"type": "text", "text": json.dumps(history, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(history)}]}
     except Exception as e:
         _LOGGER.error("Error getting history: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting history: {str(e)}"}]}
@@ -255,9 +252,7 @@ async def get_logbook(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
             processor.get_events, start_time, end_time
         )
 
-        return {
-            "content": [{"type": "text", "text": json.dumps(events, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(events)}]}
     except Exception as e:
         _LOGGER.error("Error getting logbook: %s", e)
         return {"content": [{"type": "text", "text": f"Error getting logbook: {str(e)}"}]}

--- a/custom_components/mcp_server_http_transport/tools/system_admin.py
+++ b/custom_components/mcp_server_http_transport/tools/system_admin.py
@@ -1,6 +1,5 @@
 """System administration and diagnostic tools."""
 
-import json
 import logging
 from collections import deque
 from datetime import datetime
@@ -12,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from . import (
     ANNOTATION_DESTRUCTIVE,
     ANNOTATION_READ_ONLY,
-    _HAJSONEncoder,
+    dumps,
     register_tool,
 )
 
@@ -217,7 +216,7 @@ async def get_system_status(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         "integration_count": integration_count,
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -268,7 +267,7 @@ async def get_domain_stats(hass: HomeAssistant, arguments: dict[str, Any]) -> di
         "examples": examples,
     }
 
-    return {"content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]}
+    return {"content": [{"type": "text", "text": dumps(result)}]}
 
 
 @register_tool(
@@ -294,9 +293,7 @@ async def check_config(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[s
             "valid": len(errors) == 0,
             "errors": errors,
         }
-        return {
-            "content": [{"type": "text", "text": json.dumps(result, indent=2, cls=_HAJSONEncoder)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(result)}]}
     except Exception as e:
         _LOGGER.error("Error checking config: %s", e)
         return {"content": [{"type": "text", "text": f"Error checking config: {str(e)}"}]}
@@ -324,8 +321,4 @@ async def list_integrations(hass: HomeAssistant, arguments: dict[str, Any]) -> d
         for entry in entries
     ]
 
-    return {
-        "content": [
-            {"type": "text", "text": json.dumps(integrations, indent=2, cls=_HAJSONEncoder)}
-        ]
-    }
+    return {"content": [{"type": "text", "text": dumps(integrations)}]}

--- a/custom_components/mcp_server_http_transport/tools/traces.py
+++ b/custom_components/mcp_server_http_transport/tools/traces.py
@@ -24,7 +24,6 @@ Two facts about how HA keys traces shape these tools:
     says why rather than reading as an error.
 """
 
-import json
 import logging
 from datetime import datetime
 from typing import Any
@@ -36,6 +35,7 @@ from homeassistant.util import dt as dt_util
 
 from . import (
     ANNOTATION_READ_ONLY,
+    dumps,
     register_tool,
 )
 
@@ -249,9 +249,7 @@ async def list_traces(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[st
         traces = await async_list_traces(hass, domain, key)
         traces = sorted(traces, key=_sort_key, reverse=True)[:limit]
         traces = _attach_entity_ids(hass, traces, entity_id)
-        return {
-            "content": [{"type": "text", "text": json.dumps(traces, indent=2, cls=_TRACE_ENCODER)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(traces, cls=_TRACE_ENCODER)}]}
     except ValueError as e:
         return {"content": [{"type": "text", "text": f"Error: {e}"}]}
     except Exception as e:
@@ -344,9 +342,7 @@ async def get_trace(hass: HomeAssistant, arguments: dict[str, Any]) -> dict[str,
         trace = await async_get_trace(hass, key, run_id)
         if arguments.get("summary", False):
             trace = _summarize_trace(trace)
-        return {
-            "content": [{"type": "text", "text": json.dumps(trace, indent=2, cls=_TRACE_ENCODER)}]
-        }
+        return {"content": [{"type": "text", "text": dumps(trace, cls=_TRACE_ENCODER)}]}
     except ValueError as e:
         return {"content": [{"type": "text", "text": f"Error: {e}"}]}
     except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,5 +37,14 @@ select = [
     "F",   # pyflakes
     "I",   # isort
     "UP",  # pyupgrade
+    "TID251",  # banned APIs, see below
 ]
 ignore = []
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"json.dumps".msg = "Serialize output with json_utils.dumps; it is compact, which saves the model a third of the tokens."
+
+[tool.ruff.lint.per-file-ignores]
+"custom_components/mcp_server_http_transport/json_utils.py" = ["TID251"]
+"custom_components/mcp_server_http_transport/json_patch.py" = ["TID251"]
+"tests/**" = ["TID251"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,4 @@ ignore = []
 "json.dumps".msg = "Serialize output with json_utils.dumps; it is compact, which saves the model a third of the tokens."
 
 [tool.ruff.lint.per-file-ignores]
-"custom_components/mcp_server_http_transport/json_utils.py" = ["TID251"]
-"custom_components/mcp_server_http_transport/json_patch.py" = ["TID251"]
 "tests/**" = ["TID251"]

--- a/tests/test_ha_api_contracts.py
+++ b/tests/test_ha_api_contracts.py
@@ -13,6 +13,7 @@ alternative; the docstrings say which, and what to do when one breaks.
 import dataclasses
 import inspect
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -30,6 +31,7 @@ from homeassistant.components.recorder.statistics import (
     validate_statistics,
 )
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.json import json_encoder_default
 from homeassistant.helpers.recorder import DATA_INSTANCE
 
 from custom_components.mcp_server_http_transport.const import MCP_PATH
@@ -351,3 +353,25 @@ class TestViewRegistrationContracts:
         contested and the repair, and the second path it points at, can go.
         """
         assert MCP_PATH == STREAMABLE_API
+
+
+class TestJsonEncoderDefaultContract:
+    """``_HAJSONEncoder`` delegates to ``json_encoder_default`` for the value types
+    Home Assistant's own API accepts, then falls back to ``str()``.
+
+    The public alternative is ``homeassistant.helpers.json.json_dumps``, which is
+    orjson: no encoder hook for the trace tools' ``ExtendedJSONEncoder``, and it
+    neither sorts sets nor accepts frozensets. Were this to break, copy the Path
+    and ``as_dict`` branches into ``_HAJSONEncoder.default`` and drop the import.
+    """
+
+    def test_takes_one_value_and_maps_the_types_relied_on(self):
+        assert list(inspect.signature(json_encoder_default).parameters) == ["obj"]
+        assert json_encoder_default(Path("/config/www")) == "/config/www"
+        assert json_encoder_default({"a"}) == ["a"]
+
+    def test_raises_type_error_for_an_unknown_value(self):
+        # The str() fallback in _HAJSONEncoder only runs if HA raises TypeError,
+        # not some other exception, for a value it does not know.
+        with pytest.raises(TypeError):
+            json_encoder_default(object())

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,6 +1,7 @@
 """Tests for HTTP transport, auth, and JSON-RPC routing."""
 
 import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -26,6 +27,13 @@ from custom_components.mcp_server_http_transport.http import (
     serves_mcp_path,
 )
 from custom_components.mcp_server_http_transport.tools import TOOLS, call_tool
+
+_MANIFEST = Path(__file__).resolve().parents[1] / "custom_components" / DOMAIN / "manifest.json"
+
+
+def _manifest_version() -> str:
+    """The version hacs.json releases, read independently of the integration."""
+    return json.loads(_MANIFEST.read_text(encoding="utf-8"))["version"]
 
 
 def test_appdaemon_tools_are_registered_by_production_registry():
@@ -307,6 +315,7 @@ class TestMCPEndpointView:
         assert body["jsonrpc"] == "2.0"
         assert body["result"]["protocolVersion"] == "2024-11-05"
         assert body["result"]["serverInfo"]["name"] == "home-assistant-mcp-server"
+        assert body["result"]["serverInfo"]["version"] == _manifest_version()
         assert body["id"] == 1
 
     async def test_post_initialize_advertises_capabilities(self, view):

--- a/tests/test_json_patch.py
+++ b/tests/test_json_patch.py
@@ -68,7 +68,7 @@ class TestDescribe:
     """Tests for _describe, which renders values into error messages."""
 
     def test_renders_json(self):
-        assert _describe({"entity": "light.a"}) == '{"entity": "light.a"}'
+        assert _describe({"entity": "light.a"}) == '{"entity":"light.a"}'
 
     def test_truncates_long_values(self):
         text = _describe(["light.a"] * 50)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,9 +1,11 @@
 """Tests for the shared JSON helpers."""
 
 import json
-from datetime import date, datetime
-
-import pytest
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from enum import Enum
+from pathlib import Path
+from uuid import UUID
 
 from custom_components.mcp_server_http_transport.json_utils import _HAJSONEncoder, dumps
 
@@ -48,12 +50,38 @@ class TestHAJSONEncoder:
         decoded = json.loads(json.dumps(value, cls=_HAJSONEncoder))
         assert decoded == {"hue_scenes": ["a", "b"], "brightness": 255}
 
-    def test_raises_type_error_for_unhandled_types(self):
-        class CustomType:
-            pass
+    def test_encodes_time_as_isoformat(self):
+        assert json.dumps(time(8, 30), cls=_HAJSONEncoder) == '"08:30:00"'
 
-        with pytest.raises(TypeError):
-            json.dumps(CustomType(), cls=_HAJSONEncoder)
+    def test_encodes_enum_as_its_value(self):
+        class Mode(Enum):
+            HEAT = "heat"
+
+        assert json.dumps(Mode.HEAT, cls=_HAJSONEncoder) == '"heat"'
+
+    def test_encodes_dataclass_as_dict(self):
+        @dataclass
+        class Point:
+            x: int
+            y: int
+
+        assert json.loads(json.dumps(Point(1, 2), cls=_HAJSONEncoder)) == {"x": 1, "y": 2}
+
+    def test_encodes_as_dict_objects(self):
+        class WithAsDict:
+            def as_dict(self):
+                return {"kind": "custom"}
+
+        assert json.loads(json.dumps(WithAsDict(), cls=_HAJSONEncoder)) == {"kind": "custom"}
+
+    def test_delegates_paths_to_home_assistant_default(self):
+        assert json.dumps(Path("/config/www"), cls=_HAJSONEncoder) == '"/config/www"'
+
+    def test_falls_back_to_str_for_unhandled_types(self):
+        # One exotic attribute must not blank a whole response: the tool wrapper
+        # reports a raised TypeError as isError and the model gets nothing.
+        assert json.dumps(timedelta(minutes=5), cls=_HAJSONEncoder) == '"0:05:00"'
+        assert json.loads(json.dumps(UUID(int=1), cls=_HAJSONEncoder)) == str(UUID(int=1))
 
 
 class TestDumps:
@@ -74,6 +102,15 @@ class TestDumps:
         value = {"when": datetime(2024, 6, 15, 8, 30, 45), "scenes": {"b", "a"}}
         assert dumps(value) == '{"when":"2024-06-15T08:30:45","scenes":["a","b"]}'
 
+    def test_keeps_non_ascii_text(self):
+        # A \u escape is six characters the model pays for; the JSON-RPC envelope
+        # re-escapes the text on the wire, so the HTTP response stays ASCII anyway.
+        assert dumps({"name": "Kök"}) == '{"name":"Kök"}'
+
+    def test_never_fails_on_an_exotic_attribute(self):
+        payload = {"attributes": {"duration": timedelta(minutes=5), "path": Path("/x")}}
+        assert json.loads(dumps(payload)) == {"attributes": {"duration": "0:05:00", "path": "/x"}}
+
     def test_honours_encoder_override(self):
         class Wrapper:
             pass
@@ -82,6 +119,4 @@ class TestDumps:
             def default(self, o):
                 return "wrapped" if isinstance(o, Wrapper) else super().default(o)
 
-        with pytest.raises(TypeError):
-            dumps(Wrapper())
         assert dumps({"w": Wrapper()}, cls=WrapperEncoder) == '{"w":"wrapped"}'

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,11 +1,11 @@
-"""Tests for the shared _HAJSONEncoder."""
+"""Tests for the shared JSON helpers."""
 
 import json
 from datetime import date, datetime
 
 import pytest
 
-from custom_components.mcp_server_http_transport.json_utils import _HAJSONEncoder
+from custom_components.mcp_server_http_transport.json_utils import _HAJSONEncoder, dumps
 
 
 class TestHAJSONEncoder:
@@ -54,3 +54,34 @@ class TestHAJSONEncoder:
 
         with pytest.raises(TypeError):
             json.dumps(CustomType(), cls=_HAJSONEncoder)
+
+
+class TestDumps:
+    """Test dumps emits compact JSON through the HA encoder."""
+
+    def test_omits_indentation_and_separator_whitespace(self):
+        value = {"entity_id": "light.a", "attributes": {"effect_list": ["x", "y"], "brightness": 1}}
+        text = dumps(value)
+        expected = '{"entity_id":"light.a","attributes":{"effect_list":["x","y"],"brightness":1}}'
+        assert text == expected
+        assert json.loads(text) == value
+
+    def test_is_smaller_than_pretty_printed_output(self):
+        value = [{"entity_id": f"light.l{i}", "effect_list": list("abcdef")} for i in range(20)]
+        assert len(dumps(value)) < 0.7 * len(json.dumps(value, indent=2))
+
+    def test_uses_ha_encoder_by_default(self):
+        value = {"when": datetime(2024, 6, 15, 8, 30, 45), "scenes": {"b", "a"}}
+        assert dumps(value) == '{"when":"2024-06-15T08:30:45","scenes":["a","b"]}'
+
+    def test_honours_encoder_override(self):
+        class Wrapper:
+            pass
+
+        class WrapperEncoder(json.JSONEncoder):
+            def default(self, o):
+                return "wrapped" if isinstance(o, Wrapper) else super().default(o)
+
+        with pytest.raises(TypeError):
+            dumps(Wrapper())
+        assert dumps({"w": Wrapper()}, cls=WrapperEncoder) == '{"w":"wrapped"}'

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 """Tests for MCP Server implementation."""
 
+import json
 from datetime import datetime
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -76,8 +77,9 @@ class TestHomeAssistantMCPServer:
 
         assert len(result) == 1
         assert result[0].type == "text"
-        assert "light.living_room" in result[0].text
-        assert "on" in result[0].text
+        data = json.loads(result[0].text)
+        assert data["entity_id"] == "light.living_room"
+        assert data["state"] == "on"
 
     async def test_get_state_entity_not_found(self, server, mock_hass):
         """Test _get_state when entity doesn't exist."""

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -108,8 +108,11 @@ class TestToolsEntities:
         assert body["jsonrpc"] == "2.0"
         assert "result" in body
         assert "content" in body["result"]
-        data = json.loads(body["result"]["content"][0]["text"])
+        text = body["result"]["content"][0]["text"]
+        data = json.loads(text)
         assert data["aliases"] == ["Lounge Light"]
+        # Tool text is compact JSON: no indentation or separator whitespace to pay tokens for.
+        assert text == json.dumps(data, separators=(",", ":"))
 
     async def test_post_tools_call_get_state_not_found(self, view, mock_hass):
         """Test POST with tools/call for non-existent entity."""

--- a/tests/test_tools_entities.py
+++ b/tests/test_tools_entities.py
@@ -329,7 +329,7 @@ class TestToolsEntities:
         )
 
     async def test_post_tools_call_service_unserializable_response(self, view, mock_hass):
-        """A response the encoder cannot handle degrades to the error string."""
+        """A value the encoder does not know is stringified, not the whole response lost."""
         mock_hass.services.supports_response = Mock(return_value=SupportsResponse.ONLY)
         mock_hass.services.async_call = AsyncMock(return_value={"handle": object()})
 
@@ -352,7 +352,8 @@ class TestToolsEntities:
 
         assert response.status == 200
         body = json.loads(response.body)
-        assert "Error calling service" in body["result"]["content"][0]["text"]
+        data = json.loads(body["result"]["content"][0]["text"])
+        assert data["handle"].startswith("<object object at ")
 
     async def test_post_tools_call_service_error(self, view, mock_hass):
         """Test POST with tools/call for call_service that fails."""


### PR DESCRIPTION
Every tool, resource, and prompt payload is read by a language model, so the indentation and separator spaces from `json.dumps(indent=2)` were token overhead with nothing to show for it. Compact separators cut a `list_entities` style payload by roughly a third (#91 measured 32% fewer tokens; on a synthetic 45-light payload the character count drops 39%). Non-ASCII text is no longer escaped either: a `\u` escape is six characters the model pays for on every å, ä or ö, which on a Swedish install is another 29% on attribute text, and the JSON-RPC envelope re-escapes the text on the wire so the HTTP response stays ASCII regardless.

`json_utils.dumps` is the one place output is serialized now, the stdio server and `json_patch` error text included. It uses `separators=(",", ":")`, `ensure_ascii=False`, and `_HAJSONEncoder` by default, with a `cls` override that only `traces.py` needs for HA's `ExtendedJSONEncoder`. All 81 output call sites are a mechanical swap: the 71 `indent=2` calls, the 7 bare `json.dumps` calls in `appdaemon_files.py` that still paid for the stdlib's separator spaces, and the prompt sites, which #91 left as a judgment call. I compacted those too since the reader is still the model and it keeps one convention across the package; easy to revert per file if you would rather keep them readable.

Because `dumps` is now a single funnel and the tool wrapper reports a raised `TypeError` as `isError`, one `Path` or `time` in an entity's attributes would have blanked a whole response. The encoder now accepts what Home Assistant's own API accepts (dates and times, enums, dataclasses, `as_dict` objects, then `json_encoder_default` for the rest) and falls back to `str()` instead of raising. `json_encoder_default` is a cross-integration import, so a contract test pins what is relied on. Worth a look: the `call_service` test for an unserializable response now asserts the value is stringified rather than the call reported as failed, which is the policy change.

Ruff flags `json.dumps` anywhere in the package (TID251); the helper carries the one `noqa` and tests are exempt, so a new tool cannot reintroduce pretty printing. AGENTS.md notes the convention. No schema change; every existing tool test still parses the text with `json.loads`.

Bumps the version to 1.17.0, and `serverInfo.version` now reads the manifest instead of a hardcoded 0.1.0, so this is the first bump a client actually sees.

Closes #91.
